### PR TITLE
add/metadata_resources > metadata added for resources

### DIFF
--- a/src/api/errors/metadata.json
+++ b/src/api/errors/metadata.json
@@ -1,4 +1,4 @@
 {
   "title": "Errors",
-  "order": 40
+  "order": 2
 }

--- a/src/api/resources/metadata.json
+++ b/src/api/resources/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 0,
+  "order": 1,
   "title": "Resources"
 }

--- a/src/api/resources/metadata.json
+++ b/src/api/resources/metadata.json
@@ -1,0 +1,4 @@
+{
+  "order": 0,
+  "title": "Resources"
+}


### PR DESCRIPTION
`Resources` wasn't appearing because it didn't have `metadata.json`