### PR TITLE
feature/api_ref_new_structure > new structure for API Ref navigation to remove redundancy

### DIFF
--- a/src/components/SideNav/SideNav.js
+++ b/src/components/SideNav/SideNav.js
@@ -66,7 +66,7 @@ export const SideNavBody = ({
   depth = -1,
 }) => (
   <NestedUl isOpen={isOpen}>
-    {items.map(({ id, title: subTitle, items: subItems }, index) => (
+    {items.map(({ id, title: subTitle, items: subItems, order }, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <ListItemEl key={index}>
         <NestedNav
@@ -76,6 +76,7 @@ export const SideNavBody = ({
           title={subTitle}
           id={id}
           isOpen={isOpen}
+          isFirstItem={order === 0}
           depth={depth + 1}
         />
       </ListItemEl>
@@ -103,6 +104,7 @@ const NestedNav = ({
   renderItem,
   depth,
   forwardedRef,
+  isFirstItem,
 }) => {
   const uniqueId = id || slugify(title);
   const { isChildActive, isActive } = useSidebar({
@@ -111,9 +113,25 @@ const NestedNav = ({
   });
   const isOpen = isChildActive || isActive;
 
+  /* Nested navigation's default index.mdx has the same title as 
+    its folder's metadata.json's title which causes redundancy. 
+    For example, "Ledgers" navigation is created from metadata.json 
+    but its content that is in its index.mdx also has the title "Ledgers"
+    which creates two "Ledgers" in the navigation. We are omitting 
+    redundancy by skipping renderItem() if that's the case */
+  const isSubnavOverview = isFirstItem && depth > 0;
+
   return (
     <>
-      {renderItem({ depth, id: uniqueId, isActive, title, forwardedRef })}
+      {!isSubnavOverview &&
+        renderItem({
+          depth,
+          id: uniqueId,
+          isActive,
+          title,
+          forwardedRef,
+          isFirstItem,
+        })}
       {isOpen && items && (
         <>
           {items.map((el, index) => (
@@ -125,6 +143,7 @@ const NestedNav = ({
               key={index}
               items={el.items}
               title={el.title}
+              isFirstItem={el.order === 0}
               isOpen={isOpen}
               depth={depth + 1}
             />
@@ -141,6 +160,7 @@ NestedNav.propTypes = {
   title: PropTypes.string.isRequired,
   renderItem: PropTypes.func.isRequired,
   depth: PropTypes.number,
+  isFirstItem: PropTypes.bool,
   forwardedRef: PropTypes.shape({ current: PropTypes.object }),
   activeNode: PropTypes.shape({
     current: PropTypes.object.isRequired,

--- a/src/components/SideNav/SideNav.js
+++ b/src/components/SideNav/SideNav.js
@@ -66,21 +66,28 @@ export const SideNavBody = ({
   depth = -1,
 }) => (
   <NestedUl isOpen={isOpen}>
-    {items.map(({ id, title: subTitle, items: subItems, order }, index) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <ListItemEl key={index}>
-        <NestedNav
-          renderItem={renderItem}
-          forwardedRef={forwardedRef}
-          items={subItems}
-          title={subTitle}
-          id={id}
-          isOpen={isOpen}
-          isFirstItem={order === 0}
-          depth={depth + 1}
-        />
-      </ListItemEl>
-    ))}
+    {items.map(
+      ({ id, title: subTitle, items: subItems, order, parent }, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <ListItemEl key={index}>
+          <NestedNav
+            renderItem={renderItem}
+            forwardedRef={forwardedRef}
+            items={subItems}
+            title={subTitle}
+            id={id}
+            isOpen={isOpen}
+            isFirstItem={
+              order === 0 &&
+              parent.relativePath.split("/")[
+                parent.relativePath.split("/").length - 1
+              ] === "index.mdx"
+            }
+            depth={depth + 1}
+          />
+        </ListItemEl>
+      ),
+    )}
   </NestedUl>
 );
 
@@ -143,7 +150,13 @@ const NestedNav = ({
               key={index}
               items={el.items}
               title={el.title}
-              isFirstItem={el.order === 0}
+              relativePath={el.parent.relativePath}
+              isFirstItem={
+                el.order === 0 &&
+                el.parent.relativePath.split("/")[
+                  el.parent.relativePath.split("/").length - 1
+                ] === "index.mdx"
+              }
               isOpen={isOpen}
               depth={depth + 1}
             />

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -177,12 +177,27 @@ const NavItem = ({ isActive, forwardedRef, children, depth }) => {
 };
 
 // This is a function, not a component
-// eslint-disable-next-line react/prop-types
-const renderItem = ({ depth, id, isActive, title, forwardedRef }) => (
-  <NavItem depth={depth} forwardedRef={forwardedRef} isActive={isActive}>
-    <NavLinkEl href={id}>{title}</NavLinkEl>
-  </NavItem>
-);
+const renderItem = ({
+  /* eslint-disable react/prop-types */
+  depth,
+  id,
+  isActive,
+  title,
+  forwardedRef,
+  isFirstItem,
+  /* eslint-disable react/prop-types */
+}) => {
+  /* There are cases when folder's index.mdx shares the same title as
+    its metadata.json's title. We are preventing redundancy by replacing
+    its sub navigation's title to "Overview" if its title is the same
+    as its metadata.json's */
+  const navTitle = isFirstItem ? "Overview" : title;
+  return (
+    <NavItem depth={depth} forwardedRef={forwardedRef} isActive={isActive}>
+      <NavLinkEl href={id}>{navTitle}</NavLinkEl>
+    </NavItem>
+  );
+};
 
 const componentMap = {
   ...components,


### PR DESCRIPTION
**Before:**
![api_ref_structure](https://user-images.githubusercontent.com/3912060/75059148-5c6c5b00-54aa-11ea-8aa7-c55eb722895e.jpg)

**After:**
<img width="285" alt="new_api_ref_structure" src="https://user-images.githubusercontent.com/3912060/75059548-34c9c280-54ab-11ea-8094-4c1e7a0d7769.png">

Updates: **1.** There are cases when folder's index.mdx shares the same title as its metadata.json's title. We are preventing redundancy by replacing its sub navigation's title to "Overview" if its title is the same as its metadata.json's. **2.** Nested navigation's default index.mdx has the same title as its folder's metadata.json's title which causes redundancy. For example, "Ledgers" navigation is created from metadata.json but its content that is in its index.mdx also has the title "Ledgers" which creates two "Ledgers" in the navigation. We are omitting redundancy by skipping renderItem() if that's the case