### PR TITLE
Polish/docs > Fixing its 'NEXT UP' link

### DIFF
--- a/content/docs/building-apps/metadata.json
+++ b/content/docs/building-apps/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 40,
+  "order": 50,
   "title": "Building Apps"
 }

--- a/content/docs/glossary/metadata.json
+++ b/content/docs/glossary/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 60,
+  "order": 110,
   "title": "Glossary"
 }

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,6 +3,8 @@ title: Docs Specimen Page
 order: -100
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 This is the docs specimen page. Ideally, it will help ensure we implement everything we need to implement.
 
 # Errant H1 Tag
@@ -71,7 +73,7 @@ Once you’ve chosen an asset code and someone else has created a trustline for 
 
 Here's a short code example:
 
-<code-example name="Representing Assets">
+<CodeExample title="Representing Assets">
 
 ```js
 var astroDollar = new StellarSdk.Asset(
@@ -88,10 +90,11 @@ Asset astroDollar = Asset.createNonNativeAsset("AstroDollar", issuer);
 
 ### More on that: a longer code example
 
-</code-example>
+</CodeExample>
+
 Here’s a longer example in Javascript, Java, and Go:
 
-<code-example name="Send Custom Assets">
+<CodeExample title="Send Custom Assets">
 
 ```js
 var StellarSdk = require("stellar-sdk");
@@ -234,7 +237,7 @@ _, err = horizon.DefaultTestNetClient.SubmitTransaction(paymentTxeB64)
 if err != nil { log.Fatal(err) }
 ```
 
-</code-example>
+</CodeExample>
 
 ## This is the third point
 

--- a/content/docs/issuing-assets/anatomy-of-an-asset.mdx
+++ b/content/docs/issuing-assets/anatomy-of-an-asset.mdx
@@ -3,6 +3,8 @@ title: Anatomy of an asset
 order: 15
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 Each Stellar asset has two characteristics: the asset code and the issuer. When you look up or interact with an asset on Stellar, you always use both to identify it.
 
 Many Stellar tokens represent credits that can be redeemed for something outside the network—often fiat currency, but also bonds, carbon credits, gold, etc.—and since more than one organization can issue a credit representing the same underlying asset, asset codes often overlap. More than one company offers a USD token on Stellar, for instance.

--- a/content/docs/issuing-assets/connect-to-infrastructure/metadata.json
+++ b/content/docs/issuing-assets/connect-to-infrastructure/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 100,
+  "order": 40,
   "title": "Connecting To Outside Infrastructure"
 }

--- a/content/docs/issuing-assets/connect-to-infrastructure/setting-up-test-server.mdx
+++ b/content/docs/issuing-assets/connect-to-infrastructure/setting-up-test-server.mdx
@@ -3,6 +3,8 @@ title: Setting Up a Test Server
 order: 30
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 Before setting up a server that connects to live banking rails and real money, you should build out a test rig connected to the [Stellar test network (aka testnet)](link). The testnet works just like the main Stellar network, but it uses test data and allows you to fund test accounts for free using a tool called [Friendbot](link).
 
 <Alert

--- a/content/docs/issuing-assets/connect-to-infrastructure/setting-up-test-server.mdx
+++ b/content/docs/issuing-assets/connect-to-infrastructure/setting-up-test-server.mdx
@@ -39,7 +39,7 @@ Since those are both pretty straightforward, the `/info` endpoint can convey tho
 
 Here's an example `/info` response:
 
-<CodeExample title="Example Info Response" />
+<CodeExample title="Example Info Response">
 
 ```json
 {
@@ -75,6 +75,8 @@ Here's an example `/info` response:
   }
 }
 ```
+
+</CodeExample>
 
 You can find the complete parameters for the `/info` endpoint in the [Interactive Anchor/Wallet Asset Transfer Server spec](link).
 

--- a/content/docs/issuing-assets/control-asset-access.mdx
+++ b/content/docs/issuing-assets/control-asset-access.mdx
@@ -3,6 +3,8 @@ title: Controlling access to an asset
 order: 50
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 ## High-level view of authorization flags
 When you issue an asset on Stellar, anyone can hold it by default.  In general, that’s a good thing: easy access means better reach and better liquidity, and most of the time, issuers with KYC requirements can handle those when an asset moves onto or off of the network.  Most fiat-backed token issuers, for instance, use the transfer server protocol specified in SEP-24 to decide whether to honor deposits and withdrawals rather than setting account-level flags.      
 
@@ -30,10 +32,12 @@ To get a sense of how authorization flags work, you can step through how an issu
 7. User cannot send or accept this asset
 
 ## Sample code
-The following example sets authorization to be both required and revocable:
-<CodeExample name="Asset Authorization">
 
-```js
+The following example sets authorization to be both required and revocable:
+
+<CodeExample title="Asset Authorization">
+
+```JavaScript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
@@ -88,11 +92,4 @@ server.submitTransaction(setAuthorization);
 
 </CodeExample>
 
-
 The following example authorizes an account to hold an `auth_required` asset:
-<CodeExample name="Allow Trust">
-```
-Need code badly
-```
-</CodeExample>
-

--- a/content/docs/issuing-assets/how-to-issue-an-asset.mdx
+++ b/content/docs/issuing-assets/how-to-issue-an-asset.mdx
@@ -3,6 +3,8 @@ title: How to issue an asset
 order: 20
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 ## High-level view of the steps
 There is no dedicated operation to create an asset on Stellar.  Instead, assets are created with a payment operation: an issuing account makes a payment using the asset it’s issuing, and that payment actually creates the asset on the network.
 
@@ -47,9 +49,10 @@ If you’re planning to do, really, anything with your asset, your next step is 
 Once you’ve done that, you can also create a sell offer to get your asset onto the Stellar decentralized exchange, and put some effort into market making to create liquidity for it.     
 
 ## Sample Code
-<code-example name="Issuing an Asset">
 
-```js
+<CodeExample title="Issuing an Asset">
+
+```JavaScript
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
 
@@ -190,4 +193,4 @@ _, err = horizon.DefaultTestNetClient.SubmitTransaction(paymentTxeB64)
 if err != nil { log.Fatal(err) }
 ```
 
-</code-example>
+</CodeExample>

--- a/content/docs/issuing-assets/publishing-asset-info.mdx
+++ b/content/docs/issuing-assets/publishing-asset-info.mdx
@@ -3,6 +3,8 @@ title: Publishing information about an asset
 order: 40
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 When you issue an asset, it’s crucial to provide clear information about it represents. On Stellar, you do that by linking your issuing account to a home domain, publishing a `stellar.toml` file on that domain, and making sure that file is complete.  
 
 The most successful asset issuers give exchanges, wallets, and potential buyers lots of information about themselves in order to establish trust. More information in your `stellar.toml` will mean:
@@ -139,7 +141,8 @@ Set a `text/plain` content type so that browsers render the contents, rather tha
 You should also use the `set_options` operation to set the home domain on your issueing account.
 
 ## Sample code to set the home domain of your issuing account
-<CodeExample name="Set Home Domain">
+
+<CodeExample title="Set Home Domain">
 
 ```js
 var StellarSdk = require('stellar-sdk');

--- a/content/docs/run-api-server/administration/metadata.json
+++ b/content/docs/run-api-server/administration/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 50,
+  "order": 90,
   "title": "Administration"
 }

--- a/content/docs/run-api-server/metadata.json
+++ b/content/docs/run-api-server/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 70,
+  "order": 80,
   "title": "Run an API Server"
 }

--- a/content/docs/run-core-node/administration/metadata.json
+++ b/content/docs/run-core-node/administration/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 30,
+  "order": 70,
   "title": "Administration"
 }

--- a/content/docs/software-and-sdks/metadata.json
+++ b/content/docs/software-and-sdks/metadata.json
@@ -1,4 +1,4 @@
 {
-  "order": 80,
+  "order": 100,
   "title": "Software and SDKs"
 }

--- a/src/basics/Text.js
+++ b/src/basics/Text.js
@@ -222,7 +222,7 @@ export const Preformatted = styled.pre`
     line-height: inherit;
     white-space: pre-wrap;
     max-width: 90rem;
-    width: 1000rem;
+    width: 100%;
     word-break: break-all;
   }
   && .line-numbers-rows {

--- a/src/basics/Text.js
+++ b/src/basics/Text.js
@@ -222,7 +222,7 @@ export const Preformatted = styled.pre`
     line-height: inherit;
     white-space: pre-wrap;
     max-width: 90rem;
-    width: 100%;
+    width: 1000rem;
     word-break: break-all;
   }
   && .line-numbers-rows {

--- a/src/components/Documentation/Articles.js
+++ b/src/components/Documentation/Articles.js
@@ -33,6 +33,7 @@ const ModifiedArrowIcon = styled(ArrowIcon)`
 `;
 const NestedArticleTopicExpander = styled(BasicButton)`
   ${topLevelNavItem};
+  text-align: left;
   padding-bottom: 0.5rem;
 `;
 

--- a/src/components/Documentation/Subscribe.js
+++ b/src/components/Documentation/Subscribe.js
@@ -66,7 +66,7 @@ const EmailInput = styled.input.attrs({
   "aria-label": "mce-EMAIL",
 })`
   width: 100%;
-  min-width: 291px;
+  max-width: 291px;
   transition: border ${CSS_TRANSITION_SPEED.default} ease;
   color: ${PALETTE.black80};
   background: none;

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -73,6 +73,7 @@ const RightNavEl = styled(StickyEl)`
 const NavItemEl = styled(BasicButton)`
   display: block;
   line-height: 1.5rem;
+  font-size: 0.875rem;
   font-weight: ${FONT_WEIGHT.normal};
   color: ${(props) => (props.isActive ? THEME.text : THEME.lightGrey)};
   padding: 0.5rem 0;


### PR DESCRIPTION
- [/issuing-assets/control-asset-access/'s next up doesn't link to its next one](https://app.asana.com/0/1130719348309291/1163413894876105)

<img width="600" alt="issuing_assets" src="https://user-images.githubusercontent.com/3912060/75391006-5534bb00-58b7-11ea-9550-a25ba857c771.png">

For example, `Issuing Assets > Control Asset Access` was pointing at its next parent level `Run an API Server`'s `Administration` instead of its sibling element `Connecting To Outside Infrastructure` because its `nextUp()` that links to its next element is based on `metadata.json` order.

See the following:
<img width="711" alt="sortedDocs" src="https://user-images.githubusercontent.com/3912060/75390460-4ac5f180-58b6-11ea-8440-6bcc24d5d436.png">

Because the next element after `docs/issuing-assets` is `docs/run-core-node/administration`, `Issuing Assets > Control Asset Access` was pointing at `run-core-node/administration` instead of its nested element.

So I corrected the order of metadata.json but let me know if I should use a sorting algorithm to re-sort `sortedDocs`.

- Added the missing `<CodeExample/>` so I won't get errors in my console and it looks good