### PR TITLE
bugfix/nested > nested items need to be re-ordered

### DIFF
--- a/content/api/errors/result-codes/operation-specific/metadata.json
+++ b/content/api/errors/result-codes/operation-specific/metadata.json
@@ -1,4 +1,4 @@
 {
-  "title": "HTTP Status Codes",
+  "title": "Operation-Specific Result Codes",
   "order": 20
 }

--- a/content/api/errors/result-codes/operations.mdx
+++ b/content/api/errors/result-codes/operations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Operation Result Codes
-order: 20
+order: 30
 ---
 
 import { ExampleResponse } from "components/ExampleResponse";

--- a/src/components/SideNav/SideNav.js
+++ b/src/components/SideNav/SideNav.js
@@ -58,7 +58,9 @@ export const SideNavBody = ({
             title={subTitle}
             id={id}
             isOpen={isOpen}
-            isFirstItem={order === 0 && checkIfOverview(parent.relativePath)}
+            isFirstItem={
+              order === 0 && parent && checkIfOverview(parent.relativePath)
+            }
             depth={depth + 1}
           />
         </ListItemEl>
@@ -129,6 +131,7 @@ const NestedNav = ({
               relativePath={subnavItem.parent && subnavItem.parent.relativePath}
               isFirstItem={
                 subnavItem.order === 0 &&
+                subnavItem.parent &&
                 checkIfOverview(subnavItem.parent.relativePath)
               }
               isOpen={isOpen}

--- a/src/helpers/documentation.js
+++ b/src/helpers/documentation.js
@@ -2,6 +2,7 @@ import { graphql } from "gatsby";
 
 import { groupBy } from "helpers/groupBy";
 import { buildPathFromFile } from "helpers/routes";
+import { compareOrders } from "helpers/sortReference";
 
 export const DOCS_CONTENT_URL =
   "https://github.com/stellar/new-docs/blob/master/content/";
@@ -318,12 +319,12 @@ const createNestedItems = (totalCategories, currentCategoryItems) => ({
   directory: currentCategoryItems[0].directory,
   previousParent: totalCategories[totalCategories.length - 2],
   currentDirectory: currentCategoryItems[0].currentDirectory,
+  order: currentCategoryItems[0].frontmatter.order,
   items: currentCategoryItems.map(useHrefAsId),
 });
 
 export const groupByCategory = (referenceDocs) => {
   const groupByParentCategory = groupBy(referenceDocs, "directory");
-
   return Object.keys(groupByParentCategory).reduce((acc, category) => {
     const splitCategories = category.split("/");
     const numberOfCategories = splitCategories.length;
@@ -335,7 +336,6 @@ export const groupByCategory = (referenceDocs) => {
 
     if (numberOfCategories > 1) {
       const currentCategoryItems = groupByParentCategory[category];
-
       const nestedItemsObj = createNestedItems(
         splitCategories,
         currentCategoryItems,
@@ -346,8 +346,10 @@ export const groupByCategory = (referenceDocs) => {
           (el) => el.currentDirectory === nestedItemsObj.previousParent,
         );
         newItems.items.push(nestedItemsObj);
+        newItems.items.sort(compareOrders);
       } else {
         acc[categoryName].push(nestedItemsObj);
+        acc[categoryName].sort(compareOrders);
       }
     }
     return acc;

--- a/src/helpers/documentation.js
+++ b/src/helpers/documentation.js
@@ -319,7 +319,9 @@ const createNestedItems = (totalCategories, currentCategoryItems) => ({
   directory: currentCategoryItems[0].directory,
   previousParent: totalCategories[totalCategories.length - 2],
   currentDirectory: currentCategoryItems[0].currentDirectory,
-  order: currentCategoryItems[0].frontmatter.order,
+  order: currentCategoryItems[0].folder
+    ? currentCategoryItems[0].folder.order
+    : currentCategoryItems[0].frontmatter.order,
   items: currentCategoryItems.map(useHrefAsId),
 });
 
@@ -349,9 +351,9 @@ export const groupByCategory = (referenceDocs) => {
         newItems.items.sort(compareOrders);
       } else {
         acc[categoryName].push(nestedItemsObj);
-        acc[categoryName].sort(compareOrders);
       }
     }
+
     return acc;
   }, {});
 };

--- a/src/helpers/sortReference.js
+++ b/src/helpers/sortReference.js
@@ -1,8 +1,4 @@
-import { normalizeMdx } from "helpers/mdx";
-import { DOCS_CONTENT_URL } from "helpers/documentation";
-
 export const compareOrders = (a, b) => a.order - b.order;
-
 const compareNestedEntries = (a, b) => compareOrders(a[1], b[1]);
 const makeBlank = () => ({
   order: 0,
@@ -113,7 +109,7 @@ const flattenAndSort = (node) =>
         hasNestedItems.sections[0].directory.split("/").length > 2;
       let reorderedItems;
 
-      if (hasNestedItems && isDoubleNested) {
+      if (isDoubleNested) {
         reorderedItems = sortWithNestedOrder(
           nestedNode.sections,
           nestedNode.nested,

--- a/src/helpers/sortReference.js
+++ b/src/helpers/sortReference.js
@@ -1,6 +1,9 @@
-const compareOrders = (a, b) => a.order - b.order;
-const compareNestedEntries = (a, b) => compareOrders(a[1], b[1]);
+import { normalizeMdx } from "helpers/mdx";
+import { DOCS_CONTENT_URL } from "helpers/documentation";
 
+export const compareOrders = (a, b) => a.order - b.order;
+
+const compareNestedEntries = (a, b) => compareOrders(a[1], b[1]);
 const makeBlank = () => ({
   order: 0,
   sections: [],
@@ -42,12 +45,54 @@ const buildTree = (keys, doc, node) => {
   }
   buildTree(keys.slice(1), doc, currentNode);
 };
+
 const recreateFileTree = (docs) =>
   docs.reduce((accum, doc) => {
     const keys = doc.directory.split("/");
     buildTree(keys, doc, accum);
     return accum;
   }, makeBlank()).nested;
+
+/**
+ * insert takes an array which is going to be a list of sections,
+ * index that will put newItems in this specified index,
+ * and newItems that are going to be flattened and inserted into an arr at specified index
+ * @param {array} arr An array of sections that is going to be re-ordered based on its folder's order
+ * @param {number} index The specified index that newItems will be inserted at
+ * @param {object} newItems Object of items that is going to be inserted
+ * @returns {array} A flat list of nodes in reorder.
+ */
+const insert = (arr, index, newItems) => [
+  // part of the array before the specified index
+  ...arr.slice(0, index),
+  // run a flattenAndSort() and to insert its flat nested items
+  ...flattenAndSort(newItems),
+  // part of the array after the specified index
+  ...arr.slice(index),
+];
+
+/**
+ * sortWithNestedOrder takes the nestedNode's items and
+ * its sister sections that nestedNode's items need to be a part of
+ * then take the nested items and reorder the sections in the correct spot
+ * @param {array} sections The array of the sections that current nestedNode needs to be a part of and re-ordered
+ * @param {object} nestedNode The nested items node that need to be flatten
+ * @returns {array} A re-ordered flat list of nodes.
+ */
+const sortWithNestedOrder = (sections, nestedNode) => {
+  const nestedItems = Object.entries(nestedNode);
+
+  nestedItems.forEach((nestedSectionEntry) => {
+    const nestedItemOrder = nestedSectionEntry[1].order.toString()[0];
+    const obj = {};
+    obj[nestedSectionEntry[0]] = nestedSectionEntry[1];
+
+    /* eslint-disable no-param-reassign */
+    sections = insert(sections, nestedItemOrder, obj);
+  });
+
+  return sections;
+};
 
 /**
  * flattenAndSort takes the file tree we create with `recreateFileTree` and
@@ -61,6 +106,21 @@ const flattenAndSort = (node) =>
     .sort(compareNestedEntries)
     .flatMap((entry) => {
       const nestedNode = entry[1];
+      const hasNestedItems =
+        Object.values(nestedNode.nested) && Object.values(nestedNode.nested)[0];
+      const isDoubleNested =
+        hasNestedItems &&
+        hasNestedItems.sections[0].directory.split("/").length > 2;
+      let reorderedItems;
+
+      if (hasNestedItems && isDoubleNested) {
+        reorderedItems = sortWithNestedOrder(
+          nestedNode.sections,
+          nestedNode.nested,
+        );
+        return reorderedItems;
+      }
+
       return [
         ...nestedNode.sections,
         ...flattenAndSort(nestedNode.nested),
@@ -77,6 +137,5 @@ const flattenAndSort = (node) =>
  */
 export const sortReference = (docs) => {
   const tree = recreateFileTree(docs);
-
   return flattenAndSort(tree);
 };


### PR DESCRIPTION
* `SideNav` to be re-ordered by running `.sort(compareOrders);`
* Previously, `flattenAndSort`'s `return [...nestedNode.sections, ...flattenAndSort(nestedNode.nested)]` sorted and flattened its `nestedNode.nested`'s items but didn't put its parent subject in the correct order within `sections`. For example, `The Operation Object` was appended at the end because it was within `nestedNode.nested` even though its order was 10 and should have been placed first but its spread operator put it in at the end instead of re-ordering its sister `sections`