### PR TITLE
Fix metadata, improve content rebuild performance

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -27,6 +27,7 @@
         "loose": true
       }
     ],
+    "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-syntax-dynamic-import",
     "babel-plugin-macros",
     [

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   transform: {
     "^.+\\.jsx?$": `<rootDir>/jest-preprocess.js`,
   },
+  moduleDirectories: ["node_modules", "src"],
   moduleNameMapper: {
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/core": "^7.4.4",
     "@babel/plugin-proposal-class-properties": "^7.4.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.3",
     "@babel/preset-env": "^7.4.3",

--- a/src/helpers/__tests__/fixtures/mdx.js
+++ b/src/helpers/__tests__/fixtures/mdx.js
@@ -1,4 +1,5 @@
-export const basic = {
+export const mdxAsts = {};
+mdxAsts.basic = {
   type: "root",
   children: [
     {
@@ -225,4 +226,28 @@ export const basic = {
     },
   ],
   position: {},
+};
+
+export const mdxNodes = {
+  basic: {
+    id: "4e754fbc-ac44-5769-920c-7c1a1faf4af0",
+    frontmatter: {
+      title: "Literally a title",
+      order: 0,
+    },
+    body: "some long body string",
+    parent: {
+      relativePath: "some/path/index.mdx",
+      relativeDirectory: "some/path",
+      fields: {
+        metadata: {
+          data: {
+            order: 10,
+            title: "Folder title",
+          },
+        },
+      },
+    },
+  },
+  empty: {},
 };

--- a/src/helpers/__tests__/mdx.js
+++ b/src/helpers/__tests__/mdx.js
@@ -1,10 +1,43 @@
-import { extractTextFromAst } from "../mdx";
-import { basic } from "./fixtures/mdx";
+import { extractTextFromAst, normalizeMdx } from "../mdx";
+import { mdxAsts, mdxNodes } from "./fixtures/mdx";
 
 describe("extractTextFromAst", () => {
   it("extracts text without headers", () => {
-    expect(extractTextFromAst(basic)).toBe(
+    expect(extractTextFromAst(mdxAsts.basic)).toBe(
       "Horizon is an API for interacting with the Stellar network. This API serves the bridge between apps and stellar-core. Projects like wallets, decentralized exchanges, and asset issuers use Horizon to submit transactions, query an account balance, or stream events like transactions to an account. Horizon is a RESTful API and can be accessed via cURL, a browser, or one of the Stellar SDKs. To reduce the complexity of your project, we recommend you use an SDK instead of making direct API calls. The Stellar Development Foundation (SDF) runs two instances of Horizon: https://horizon.stellar.org/ for interacting with the public network https://horizon-testnet.stellar.org/ for interacting with the testnet",
     );
+  });
+});
+
+describe("normalizeMdx", () => {
+  it("converts nodes", () => {
+    expect(normalizeMdx(mdxNodes.basic)).toMatchObject({
+      id: expect.any(String),
+      order: expect.any(Number),
+      title: expect.any(String),
+      githubLink: expect.any(String),
+      body: expect.any(String),
+      directory: expect.any(String),
+      currentDirectory: expect.any(String),
+      folder: {
+        order: expect.any(Number),
+        title: expect.any(String),
+      },
+    });
+  });
+  it("gracefully fails on missing fields", () => {
+    expect(normalizeMdx(mdxNodes.empty)).toMatchObject({
+      id: undefined,
+      order: undefined,
+      title: undefined,
+      githubLink: undefined,
+      body: undefined,
+      directory: undefined,
+      currentDirectory: undefined,
+      folder: {
+        order: undefined,
+        title: undefined,
+      },
+    });
   });
 });

--- a/src/helpers/documentation.js
+++ b/src/helpers/documentation.js
@@ -1,7 +1,7 @@
 import { graphql } from "gatsby";
 
 import { groupBy } from "helpers/groupBy";
-import { buildPathFromFile } from "utils";
+import { buildPathFromFile } from "helpers/routes";
 
 export const DOCS_CONTENT_URL =
   "https://github.com/stellar/new-docs/blob/master/content/";

--- a/src/helpers/mdx.js
+++ b/src/helpers/mdx.js
@@ -1,3 +1,5 @@
+import { DOCS_CONTENT_URL } from "helpers/documentation";
+
 export const extractTextFromAst = (ast) =>
   ast.children
     .flatMap(handleNode)
@@ -41,4 +43,58 @@ export const getDescriptionFromAst = (ast) => {
     }
     return newDescription;
   }, "");
+};
+
+/**
+ *
+ * @param {object} node a Gatsby MDX node.
+ * @param {string} node.id MDX id
+ * @param {object} node.frontmatter frontmatter
+ * @param {string} node.frontmatter.order order
+ * @param {string} node.frontmatter.title title
+ * @param {string} node.body body
+ * @param {object} node.parent parent
+ * @param {string} node.parent.relativeDirectory relativeDirectory
+ * @param {string} [node.parent.relativePath] relativePath
+ * @param {object} [node.parent.fields] fields
+ * @param {object} [node.parent.fields.metadata.data.order] order
+ * @param {object} [node.parent.fields.metadata.data.title] title
+ *
+ * @returns {object} An object with the below keys. Any missing fields on the
+ * input will produce `undefined`. on the output.
+ * id
+ * order
+ * title
+ * githubLink
+ * body
+ * directory
+ * currentDirectory
+ * folder: {
+ *   order
+ *   title
+ * }
+ * ...node
+ */
+export const normalizeMdx = (node) => {
+  const { id, frontmatter = {}, body, parent = {} } = node;
+  const metadata = parent.fields?.metadata.data || {};
+  const parentRelativeDirSplit = parent.relativeDirectory?.split("/");
+  const mdxLink = parent.relativePath && DOCS_CONTENT_URL + parent.relativePath;
+
+  return {
+    ...node,
+    id,
+    order: frontmatter.order,
+    title: frontmatter.title,
+    githubLink: mdxLink,
+    body,
+    // paths always start with `docs` or `api` which isn't useful. Strip it.
+    directory: parentRelativeDirSplit?.slice(1).join("/"),
+    currentDirectory:
+      parentRelativeDirSplit?.[parentRelativeDirSplit.length - 1],
+    folder: {
+      order: metadata.order,
+      title: metadata.title,
+    },
+  };
 };

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -1,0 +1,5 @@
+export {
+  buildRoute,
+  buildPathFromFile,
+  normalizeRoute,
+} from "../../buildHelpers/routes";

--- a/src/helpers/sortReference.js
+++ b/src/helpers/sortReference.js
@@ -1,28 +1,3 @@
-import { DOCS_CONTENT_URL } from "helpers/documentation";
-
-export const normalizeMdx = (node) => {
-  const { id, frontmatter, body, parent } = node;
-  const metadata = (parent.fields && parent.fields.metadata.data) || {};
-  const parentRelativeDirSplit = parent.relativeDirectory.split("/");
-  const mdxLink = parent.relativePath && DOCS_CONTENT_URL + parent.relativePath;
-
-  return {
-    ...node,
-    id,
-    order: frontmatter.order,
-    title: frontmatter.title,
-    githubLink: mdxLink,
-    body,
-    // paths always start with `docs` or `api` which isn't useful. Strip it.
-    directory: parentRelativeDirSplit.slice(1).join("/"),
-    currentDirectory: parentRelativeDirSplit[parentRelativeDirSplit.length - 1],
-    folder: {
-      order: metadata.order,
-      title: metadata.title,
-    },
-  };
-};
-
 const compareOrders = (a, b) => a.order - b.order;
 const compareNestedEntries = (a, b) => compareOrders(a[1], b[1]);
 

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -19,6 +19,7 @@ import { docType } from "constants/docType";
 import { sortReference, normalizeMdx } from "helpers/sortReference";
 import { groupByCategory } from "helpers/documentation";
 import { makeLinkedHeader } from "helpers/makeLinkedHeader";
+import { buildPathFromFile } from "helpers/routes";
 
 import { Column } from "basics/Grid";
 import { H1, H2, H3, H4, H5, H6, HorizontalRule } from "basics/Text";
@@ -48,7 +49,6 @@ import {
 import { Expansion } from "components/Expansion";
 
 import DevelopersPreview from "assets/images/og_developers.jpg";
-import { buildPathFromFile } from "../../buildHelpers/routes";
 
 const NAV_BAR_HEIGHT = 89;
 const FIXED_NAV_DISTANCE = 140 + NAV_BAR_HEIGHT;

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -16,9 +16,10 @@ import {
 import { components } from "constants/docsComponentMapping";
 import { docType } from "constants/docType";
 
-import { sortReference, normalizeMdx } from "helpers/sortReference";
+import { sortReference } from "helpers/sortReference";
 import { groupByCategory } from "helpers/documentation";
 import { makeLinkedHeader } from "helpers/makeLinkedHeader";
+import { normalizeMdx } from "helpers/mdx";
 import { buildPathFromFile } from "helpers/routes";
 
 import { Column } from "basics/Grid";

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -310,6 +310,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
       <MDXProvider components={componentMap}>
         <LayoutBase
           previewImage={DevelopersPreview}
+          title="Stellar API Reference"
           description="The complete API reference for the Stellar network. Includes descriptions of Horizon endpoints, network concepts, and example code for some languages."
           pageContext={pageContext}
         >

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -162,14 +162,13 @@ const Documentation = ({ data, pageContext, location }) => {
     rootDir,
   );
 
-  const { body, mdxAST: mdxAst } = articleBody.childMdx;
+  const { body, headings, mdxAST: mdxAst } = articleBody.childMdx;
   const {
     title: header,
     description: contentDescription,
     modifiedTime,
     githubLink,
     nextUp: articleNextUp,
-    headings,
   } = findArticle(pagePath, docsContents)[name];
 
   const description = React.useMemo(
@@ -301,6 +300,9 @@ export const pageQuery = graphql`
       childMdx {
         body
         mdxAST
+        headings(depth: h2) {
+          value
+        }
       }
     }
     allFile(
@@ -319,9 +321,6 @@ export const pageQuery = graphql`
           name
           relativePath
           childMdx {
-            headings(depth: h2) {
-              value
-            }
             id
             frontmatter {
               title

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -26,6 +26,7 @@ import {
   buildDocsContents,
 } from "helpers/documentation";
 import { getDescriptionFromAst } from "helpers/mdx";
+import { normalizeRoute } from "helpers/routes";
 
 import { BasicButton } from "basics/Buttons";
 import { EditIcon } from "basics/Icons";
@@ -245,7 +246,7 @@ const Documentation = ({ data, pageContext, location }) => {
     <MDXProvider components={componentMapping}>
       <LayoutBase
         title={
-          location.pathname === "/docs"
+          normalizeRoute(location.pathname) === "/docs/"
             ? "Stellar Documentation"
             : `${header} – Stellar Documentation`
         }

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -127,7 +127,10 @@ const componentMap = {
 };
 
 // eslint-disable-next-line react/no-multi-comp
-const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
+const SingleApiReference = React.memo(function ApiReference({
+  data,
+  pageContext,
+}) {
   const referenceDocs = sortReference(
     data.referenceDocs.edges.map(({ node }) => normalizeMdx(node)),
   );
@@ -189,12 +192,12 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
   );
 });
 
-ApiReference.propTypes = {
+SingleApiReference.propTypes = {
   data: PropTypes.object.isRequired,
   pageContext: PropTypes.object.isRequired,
 };
 
-export default ApiReference;
+export default SingleApiReference;
 
 export const pageQuery = graphql`
   query SingleApiReferenceQuery($ids: [String], $docId: String) {
@@ -205,7 +208,25 @@ export const pageQuery = graphql`
     referenceDocs: allMdx(filter: { id: { in: $ids } }) {
       edges {
         node {
-          ...ApiReferencePage
+          id
+          frontmatter {
+            title
+            order
+          }
+          parent {
+            ... on File {
+              relativePath
+              relativeDirectory
+              fields {
+                metadata {
+                  data {
+                    order
+                    title
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -14,6 +14,7 @@ import { sortReference, normalizeMdx } from "helpers/sortReference";
 import { groupByCategory } from "helpers/documentation";
 import { makeLinkedHeader } from "helpers/makeLinkedHeader";
 import { getDescriptionFromAst } from "helpers/mdx";
+import { buildPathFromFile } from "helpers/routes";
 
 import { BasicButton } from "basics/Buttons";
 import { H1, H2, H3, H4, H5, H6, HorizontalRule } from "basics/Text";
@@ -35,7 +36,6 @@ import {
 import { SideNavBackground } from "components/Navigation/SharedStyles";
 
 import DevelopersPreview from "assets/images/og_developers.jpg";
-import { buildPathFromFile } from "../../buildHelpers/routes";
 
 const GreenTableCell = styled.td`
   color: ${PALETTE.lightGreen};

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -10,10 +10,10 @@ import { MDXProvider } from "@mdx-js/react";
 import { CSS_TRANSITION_SPEED, FONT_WEIGHT, PALETTE } from "constants/styles";
 import { components } from "constants/docsComponentMapping";
 
-import { sortReference, normalizeMdx } from "helpers/sortReference";
+import { sortReference } from "helpers/sortReference";
 import { groupByCategory } from "helpers/documentation";
 import { makeLinkedHeader } from "helpers/makeLinkedHeader";
-import { getDescriptionFromAst } from "helpers/mdx";
+import { getDescriptionFromAst, normalizeMdx } from "helpers/mdx";
 import { buildPathFromFile } from "helpers/routes";
 
 import { BasicButton } from "basics/Buttons";

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,3 @@
-import { buildPathFromFile } from "../../buildHelpers/routes";
-
 /**
  * @desc calculates the column width in percentage (%)
  * @param {number} col - { # of columns we want / a total # of columns }
@@ -136,5 +134,3 @@ export const extractStringChildren = (codeSnippet, finalString = "") => {
   }
   return finalString;
 };
-
-export { buildPathFromFile };

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,6 +428,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-chaining" "^7.7.4"
 
+"@babel/plugin-proposal-optional-chaining@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz#ae10b3214cb25f7adb1f3bc87ba42ca10b7e2543"
+  integrity sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+
 "@babel/plugin-proposal-unicode-property-regex@^7.7.7":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz#433fa9dac64f953c12578b29633f456b68831c4e"
@@ -512,6 +520,13 @@
   integrity sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
+  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-top-level-await@^7.7.4":
   version "7.7.4"


### PR DESCRIPTION
I realized that rebuilds when mdx content changes was running extremely slowly, which was frustrating while trying to iterate.

also:
* Fix imports in Jest
* Add optional chaining syntax to babel (`?.`)
* Add some tests to normalizeMdx
* Change how route helpers are imported from site code

Rebuild timings:
before:
```
info changed file at /Users/carlvitullo/workspace/new-docs/content/docs/index.mdx
success createPages - 0.179s
success write out requires - 0.010s
success Re-building development bundle - 0.460s
success run queries - 14.622s - 119/119 8.14/s
```

after: 
```
info changed file at /Users/carlvitullo/workspace/new-docs/content/docs/index.mdx
success createPages - 0.130s
success write out requires - 0.023s
success Re-building development bundle - 0.778s
success run queries - 6.165s - 119/119 19.30/s
```
A little improved, anyway. This might also help with initial build as well. 