### PR TITLE
Disable mobile view

### DIFF
--- a/src/components/CodeExample.js
+++ b/src/components/CodeExample.js
@@ -17,9 +17,11 @@ import { DividerEl } from "components/Documentation/SharedStyles";
 
 const CODE_LANGS = {
   curl: "cURL",
+  scss: "SCSS",
   go: "Go",
   javascript: "JavaScript",
   ts: "TypeScript",
+  tsx: "TSX",
   java: "Java",
   bash: "bash",
   json: "json",

--- a/src/components/Documentation/SharedStyles.js
+++ b/src/components/Documentation/SharedStyles.js
@@ -69,7 +69,7 @@ ApiReferenceWrapper.propTypes = {
 
 const { getSizeGrid, COL_SIZES, COLUMNS } = gridHelpers;
 const { count, size, margin } = COLUMNS[COL_SIZES.md];
-export const ApiReferenceRow = styled.div`
+export const OneSizeRow = styled.div`
   // Treat md as smallest size
   display: grid;
   grid-template-columns: repeat(${count}, ${size}rem);

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -42,7 +42,7 @@ import {
 } from "components/ApiRefRouting/ScrollRouter";
 import { Route, SectionPathContext } from "components/ApiRefRouting/Route";
 import {
-  ApiReferenceRow,
+  OneSizeRow,
   ApiReferenceWrapper,
   Container,
   NestedRow,
@@ -318,7 +318,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
         >
           <PrismStyles />
           <Container>
-            <ApiReferenceRow>
+            <OneSizeRow>
               <SideNavColumn xs={3} lg={3} xl={4}>
                 <SideNavBackground />
                 <SideNav docType={docType.api}>
@@ -364,7 +364,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                 <Footer />
               </Column>
               <Column xs={4} xl={9} />
-            </ApiReferenceRow>
+            </OneSizeRow>
           </Container>
         </LayoutBase>
       </MDXProvider>

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -30,7 +30,7 @@ import { normalizeRoute } from "helpers/routes";
 
 import { BasicButton } from "basics/Buttons";
 import { EditIcon } from "basics/Icons";
-import { Column, Container, Row } from "basics/Grid";
+import { Column, Row } from "basics/Grid";
 import { Link } from "basics/Links";
 import { PrismStyles } from "basics/Prism";
 import { ListItem } from "basics/Text";
@@ -38,7 +38,12 @@ import { ListItem } from "basics/Text";
 import Articles from "components/Documentation/Articles";
 import { LayoutBase } from "components/layout/LayoutBase";
 import { SideNav, SideNavBody, TrackedContent } from "components/SideNav";
-import { Content, SideNavColumn } from "components/Documentation/SharedStyles";
+import {
+  Content,
+  SideNavColumn,
+  OneSizeRow,
+  Container,
+} from "components/Documentation/SharedStyles";
 import { Footer } from "components/Documentation/Footer";
 import {
   NavAbsoluteEl,
@@ -58,6 +63,7 @@ const Topics = styled.ul`
   padding: 0;
   max-width: ${DEFAULT_COLUMN_WIDTH.leftColumn}rem;
   padding-bottom: 1rem;
+  margin-right: 1rem;
 `;
 
 const RightNavEl = styled(StickyEl)`
@@ -256,8 +262,8 @@ const Documentation = ({ data, pageContext, location }) => {
       >
         <PrismStyles isDoc />
         <Container id={contentId}>
-          <Row>
-            <SideNavColumn md={3} lg={3}>
+          <OneSizeRow>
+            <SideNavColumn xs={3}>
               <SideNavBackground />
               <SideNav docType={docType.doc}>
                 <NavAbsoluteEl>{left}</NavAbsoluteEl>
@@ -266,16 +272,16 @@ const Documentation = ({ data, pageContext, location }) => {
                 </AbsoluteNavFooterEl>
               </SideNav>
             </SideNavColumn>
-            {/*
-              We want the right hand side to appear above content on mobile
-            */}
-            <Column md={{ hide: true }}>{right}</Column>
-            <Column md={7}>
+            <Column xs={9} md={7}>
               {center}
               <Footer />
             </Column>
-            <Column md={2}>{right}</Column>
-          </Row>
+            {headings.length > 0 && (
+              <Column xs={{ hide: true }} md={2}>
+                {right}
+              </Column>
+            )}
+          </OneSizeRow>
         </Container>
       </LayoutBase>
     </MDXProvider>

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -30,7 +30,7 @@ import { normalizeRoute } from "helpers/routes";
 
 import { BasicButton } from "basics/Buttons";
 import { EditIcon } from "basics/Icons";
-import { Column, Row } from "basics/Grid";
+import { Column } from "basics/Grid";
 import { Link } from "basics/Links";
 import { PrismStyles } from "basics/Prism";
 import { ListItem } from "basics/Text";

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -28,7 +28,7 @@ import { Expansion } from "components/Expansion";
 import { SideNav, SideNavBody } from "components/SideNav";
 import {
   Container,
-  ApiReferenceRow,
+  OneSizeRow,
   ApiReferenceWrapper,
   SideNavColumn,
   NestedRow,
@@ -151,7 +151,7 @@ const SingleApiReference = React.memo(function ApiReference({
         pageContext={pageContext}
       >
         <Container>
-          <ApiReferenceRow style={{ marginTop: "5rem" }}>
+          <OneSizeRow style={{ marginTop: "5rem" }}>
             <SideNavColumn xs={3} lg={3} xl={4}>
               <SideNavBackground />
               <SideNav>
@@ -185,7 +185,7 @@ const SingleApiReference = React.memo(function ApiReference({
               <Footer />
             </Column>
             <Column xs={4} xl={9} />
-          </ApiReferenceRow>
+          </OneSizeRow>
         </Container>
       </LayoutBase>
     </MDXProvider>


### PR DESCRIPTION
Since we are not doing any mobile view for `/api` and `/docs` in this phase, I removed mobile version from `/docs`. Also hiding Page Outlines if there is no H2 tags.

[Disable mobile view](https://app.asana.com/0/1119309091112078/1167805374149396)