### PR TITLE
bugfix/docs-order > order its parent at the end instead of in the beginning

### DIFF
--- a/src/helpers/documentation.js
+++ b/src/helpers/documentation.js
@@ -217,9 +217,10 @@ export const buildDocsContents = (data, rootDir) => {
 
   /* After its nested page data are sorted and added in,
   sort its parent by topicOrder which is metadata.data.order */
-  const sortedDocs = Object.fromEntries(
-    Object.entries(contents).sort(compareNestedEntries),
-  );
+  const sortedDocs = Object.entries(contents)
+    .sort(compareNestedEntries)
+    /* reverse it to object */
+    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
 
   return sortedDocs;
 };

--- a/src/helpers/sortReference.js
+++ b/src/helpers/sortReference.js
@@ -1,5 +1,5 @@
 export const compareOrders = (a, b) => a.order - b.order;
-const compareNestedEntries = (a, b) => compareOrders(a[1], b[1]);
+export const compareNestedEntries = (a, b) => compareOrders(a[1], b[1]);
 const makeBlank = () => ({
   order: 0,
   sections: [],


### PR DESCRIPTION
Instead of sorting its parent `metadata.json`'s order in the beginning, I sorted it in the end. 

For example, previously, `/building-apps/create-stellar-wallet/index.mdx` was placed before `/building-apps/index.mdx` because the order number of `metadata.json` of `/building-apps/create-stellar-wallet` is less than the order number of `metadata.json` of `/building-apps/`. We start out with correctly ordered mdx files thanks to `DocumentationQuery` but running sorting parent function in the beginning ignored its metadata.json's hierarchy. 

Before (by sorting parent metadata in the beginning, its order is incorrect)
<img width="450" alt="before" src="https://user-images.githubusercontent.com/3912060/77477209-60b1ce00-6df2-11ea-9c08-814e249fc6cd.png">

Correct order done by graphql
<img width="456" alt="after" src="https://user-images.githubusercontent.com/3912060/77477212-61e2fb00-6df2-11ea-95b3-e8406e7b9006.png">

By sorting parent metadata in the end, we keep the children's order in correct place and just sort the parent
<img width="451" alt="final" src="https://user-images.githubusercontent.com/3912060/77478121-d9fdf080-6df3-11ea-8fbb-6d544251c995.png">