### PR TITLE
Bugfix/scroll > allowing independent scrolling panels with no body scrolls

### DIFF
--- a/src/basics/Grid.js
+++ b/src/basics/Grid.js
@@ -107,6 +107,13 @@ const ColumnEl = styled.div`
   ${({ md }) => getColStyle(COL_SIZES.md, md)};
   ${({ lg }) => getColStyle(COL_SIZES.lg, lg)};
   ${({ xl }) => (xl ? getColStyle(COL_SIZES.xl, xl) : "")};
+
+  ${({ isIndependentScroll }) =>
+    isIndependentScroll &&
+    css`
+      overflow-y: scroll;
+      height: 100vh;
+    `}
 `;
 
 export const Column = (props) => {

--- a/src/components/ApiRefRouting/ScrollRouter.js
+++ b/src/components/ApiRefRouting/ScrollRouter.js
@@ -27,35 +27,36 @@ export const ScrollRouter = ({ children }) => {
     smoothScrollTo(elementMap.get(route).current, { duration: 0 });
   }, []);
 
-  const handler = throttle(() => {
-    // If we haven't scrolled at least 20 pixels, just bail.
-    if (Math.abs(window.scrollY - lastScrollPosition) < 20) {
-      return;
-    }
-    isScrollingDown.current = window.scrollY > lastScrollPosition;
-    lastScrollPosition = window.scrollY;
-
-    const newActiveNode = findActiveNode(
-      trackedElementsRef.current,
-      isScrollingDown.current,
-    );
-    // If we've found an active node and it's not the same one as we had
-    // before, update the route.
-    if (newActiveNode && newActiveNode !== activeNodeRef.current) {
-      activeNodeRef.current = newActiveNode;
-      window.history.replaceState(null, null, routeMap.get(newActiveNode));
-    }
-  }, 60);
-
   // Scroll listener
   React.useEffect(() => {
-    window.addEventListener("scroll", handler);
+    const contentDom = document.querySelector("#content-column");
+    const handler = throttle(() => {
+      // If we haven't scrolled at least 20 pixels, just bail.
+      if (Math.abs(contentDom.scrollY - lastScrollPosition) < 20) {
+        return;
+      }
+      isScrollingDown.current = contentDom.scrollY > lastScrollPosition;
+      lastScrollPosition = contentDom.scrollY;
+
+      const newActiveNode = findActiveNode(
+        trackedElementsRef.current,
+        isScrollingDown.current,
+      );
+      // If we've found an active node and it's not the same one as we had
+      // before, update the route.
+      if (newActiveNode && newActiveNode !== activeNodeRef.current) {
+        activeNodeRef.current = newActiveNode;
+        window.history.replaceState(null, null, routeMap.get(newActiveNode));
+      }
+    }, 60);
+
+    contentDom.addEventListener("scroll", handler);
     handler();
 
     return () => {
-      window.removeEventListener("scroll", handler);
+      contentDom.removeEventListener("scroll", handler);
     };
-  }, [handler]);
+  }, []);
 
   // Tracked sections
   const trackElement = React.useCallback((ref, route) => {

--- a/src/components/ApiRefRouting/ScrollRouter.js
+++ b/src/components/ApiRefRouting/ScrollRouter.js
@@ -1,6 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { throttle } from "lodash";
+
+import { DOM_TARGETS } from "constants/domNodes";
+
 import { smoothScrollTo, findActiveNode } from "helpers/dom";
 
 export const Context = React.createContext();
@@ -29,7 +32,7 @@ export const ScrollRouter = ({ children }) => {
 
   // Scroll listener
   React.useEffect(() => {
-    const contentDom = document.querySelector("#content-column");
+    const contentDom = document.querySelector(`#${DOM_TARGETS.contentColumn}`);
     const handler = throttle(() => {
       // If we haven't scrolled at least 20 pixels, just bail.
       if (Math.abs(contentDom.scrollY - lastScrollPosition) < 20) {

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -140,6 +140,7 @@ export const NavItem = styled.div`
 export const StickyEl = styled.div`
   width: 100%;
   height: 100vh;
+  overflow-y: scroll;
   position: sticky;
   top: 0;
   z-index: 3;

--- a/src/components/SideNav/Provider.js
+++ b/src/components/SideNav/Provider.js
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { DOM_TARGETS } from "constants/domNodes";
+
 import { findActiveNode } from "helpers/dom";
 
 const sortByPosition = (a, b) => {
@@ -24,7 +26,7 @@ export const Provider = ({ children }) => {
   );
 
   React.useEffect(() => {
-    const contentDom = document.querySelector("#content-column");
+    const contentDom = document.querySelector(`#${DOM_TARGETS.contentColumn}`);
 
     const handler = () => {
       // If we haven't scrolled at least 20 pixels, just bail.

--- a/src/components/SideNav/Provider.js
+++ b/src/components/SideNav/Provider.js
@@ -24,9 +24,11 @@ export const Provider = ({ children }) => {
   );
 
   React.useEffect(() => {
+    const contentDom = document.querySelector("#content-column");
+
     const handler = () => {
       // If we haven't scrolled at least 20 pixels, just bail.
-      if (Math.abs(window.scrollY - lastScrollPosition) < 20) {
+      if (Math.abs(contentDom.scrollY - lastScrollPosition) < 20) {
         return;
       }
       // A tracked element becomes "active" if it enters the part of the screen
@@ -34,18 +36,19 @@ export const Provider = ({ children }) => {
       // offset from the top enough that it's definitely in view.
       // If we're scrolling up, then we're watching for elements to come down
       // from the top. If scrolling down, watching about the midpoint.
-      const isScrollingDown = window.scrollY > lastScrollPosition;
-      lastScrollPosition = window.scrollY;
+      const isScrollingDown = contentDom.scrollY > lastScrollPosition;
+      lastScrollPosition = contentDom.scrollY;
 
       const newActiveNode = findActiveNode(trackedElements, isScrollingDown);
       if (newActiveNode && newActiveNode !== activeNode) {
         setActiveNode(newActiveNode);
       }
     };
-    window.addEventListener("scroll", handler);
+
+    contentDom.addEventListener("scroll", handler);
     handler();
     return () => {
-      window.removeEventListener("scroll", handler);
+      contentDom.removeEventListener("scroll", handler);
     };
   }, [activeNode, backwardsElements, trackedElements]);
 

--- a/src/components/SideNav/SideNav.js
+++ b/src/components/SideNav/SideNav.js
@@ -128,7 +128,7 @@ const NestedNav = ({
               key={index}
               items={subnavItem.items}
               title={subnavItem.title}
-              relativePath={subnavItem.parent && subnavItem.parent.relativePath}
+              relativePath={subnavItem.parent?.relativePath}
               isFirstItem={
                 subnavItem.order === 0 &&
                 subnavItem.parent &&

--- a/src/constants/domNodes.js
+++ b/src/constants/domNodes.js
@@ -3,3 +3,7 @@ export const PORTAL_TARGETS = {
   scrim: "scrim",
   tooltip: "tooltip",
 };
+
+export const DOM_TARGETS = {
+  contentColumn: "content-column",
+};

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -349,7 +349,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                   </AbsoluteNavFooterEl>
                 </SideNav>
               </SideNavColumn>
-              <Column xs={9} xl={18} isIndependentScroll>
+              <Column xs={9} xl={18} isIndependentScroll id="content-column">
                 {referenceDocs.map(
                   ({ body, id, parent, title, githubLink }) => (
                     <ReferenceSection

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -15,6 +15,7 @@ import {
 } from "constants/styles";
 import { components } from "constants/docsComponentMapping";
 import { docType } from "constants/docType";
+import { DOM_TARGETS } from "constants/domNodes";
 
 import { sortReference } from "helpers/sortReference";
 import { groupByCategory } from "helpers/documentation";
@@ -349,7 +350,12 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                   </AbsoluteNavFooterEl>
                 </SideNav>
               </SideNavColumn>
-              <Column xs={9} xl={18} isIndependentScroll id="content-column">
+              <Column
+                xs={9}
+                xl={18}
+                isIndependentScroll
+                id={`${DOM_TARGETS.contentColumn}`}
+              >
                 {referenceDocs.map(
                   ({ body, id, parent, title, githubLink }) => (
                     <ReferenceSection

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -349,7 +349,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                   </AbsoluteNavFooterEl>
                 </SideNav>
               </SideNavColumn>
-              <Column xs={9} xl={18}>
+              <Column xs={9} xl={18} isIndependentScroll>
                 {referenceDocs.map(
                   ({ body, id, parent, title, githubLink }) => (
                     <ReferenceSection
@@ -363,7 +363,6 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                 )}
                 <Footer />
               </Column>
-              <Column xs={4} xl={9} />
             </OneSizeRow>
           </Container>
         </LayoutBase>

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -68,7 +68,9 @@ const Topics = styled.ul`
 const RightNavEl = styled(StickyEl)`
   font-size: 0.875rem;
   line-height: 1rem;
-  margin: 1em 0;
+  padding-top: 4.25rem;
+  overflow-y: hidden;
+  margin: 0;
 
   li:before {
     display: none;
@@ -285,7 +287,7 @@ const Documentation = ({ data, pageContext, location }) => {
                 </AbsoluteNavFooterEl>
               </SideNav>
             </SideNavColumn>
-            <Column xs={9} md={7}>
+            <Column xs={9} md={7} isIndependentScroll>
               {center}
               <Footer />
             </Column>

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -287,7 +287,7 @@ const Documentation = ({ data, pageContext, location }) => {
                 </AbsoluteNavFooterEl>
               </SideNav>
             </SideNavColumn>
-            <Column xs={9} md={7} isIndependentScroll>
+            <Column xs={9} md={7} isIndependentScroll id="content-column">
               {center}
               <Footer />
             </Column>

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -15,6 +15,7 @@ import {
 } from "constants/styles";
 import { components } from "constants/docsComponentMapping";
 import { docType } from "constants/docType";
+import { DOM_TARGETS } from "constants/domNodes";
 
 import { slugify } from "helpers/slugify";
 import { smoothScrollTo } from "helpers/dom";
@@ -287,7 +288,12 @@ const Documentation = ({ data, pageContext, location }) => {
                 </AbsoluteNavFooterEl>
               </SideNav>
             </SideNavColumn>
-            <Column xs={9} md={7} isIndependentScroll id="content-column">
+            <Column
+              xs={9}
+              md={7}
+              isIndependentScroll
+              id={`${DOM_TARGETS.contentColumn}`}
+            >
               {center}
               <Footer />
             </Column>

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -174,7 +174,7 @@ const SingleApiReference = React.memo(function ApiReference({
                 ))}
               </SideNav>
             </SideNavColumn>
-            <Column xs={9} xl={18}>
+            <Column xs={9} xl={18} isIndependentScroll>
               <section>
                 <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
                 <NestedRow>
@@ -184,7 +184,6 @@ const SingleApiReference = React.memo(function ApiReference({
               </section>
               <Footer />
             </Column>
-            <Column xs={4} xl={9} />
           </OneSizeRow>
         </Container>
       </LayoutBase>

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -174,7 +174,7 @@ const SingleApiReference = React.memo(function ApiReference({
                 ))}
               </SideNav>
             </SideNavColumn>
-            <Column xs={9} xl={18} isIndependentScroll>
+            <Column xs={9} xl={18} isIndependentScroll id="content-column">
               <section>
                 <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
                 <NestedRow>

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -9,6 +9,7 @@ import { MDXProvider } from "@mdx-js/react";
 
 import { CSS_TRANSITION_SPEED, FONT_WEIGHT, PALETTE } from "constants/styles";
 import { components } from "constants/docsComponentMapping";
+import { DOM_TARGETS } from "constants/domNodes";
 
 import { sortReference } from "helpers/sortReference";
 import { groupByCategory } from "helpers/documentation";
@@ -174,7 +175,12 @@ const SingleApiReference = React.memo(function ApiReference({
                 ))}
               </SideNav>
             </SideNavColumn>
-            <Column xs={9} xl={18} isIndependentScroll id="content-column">
+            <Column
+              xs={9}
+              xl={18}
+              isIndependentScroll
+              id={`${DOM_TARGETS.contentColumn}`}
+            >
               <section>
                 <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
                 <NestedRow>


### PR DESCRIPTION
[Fix sidebar scroll](https://app.asana.com/0/1119309091112078/1163228700401441)
- When you scroll to the bottom of the API ref or doc' sidebar nav, scrolling should stop and not affect the content column. Right now, when you scroll to the bottom of the sidebar nav and keep scrolling, it causes the content column to scroll down as well.

- Disabling body scroll means `window.addEventListener("scroll")` no longer works since its content scroll is based on the `<Column/>` instead of `window` in `ScrollRouter.js``SideNav/Provider.js`
- I thought about using `useRef` instead of `document.querySelector`, but am not sure about passing the ref around. Let me know.