### PR TITLE
revert/mobile > reverting back the mobile view from PR 70

### DIFF
--- a/src/components/Documentation/SharedStyles.js
+++ b/src/components/Documentation/SharedStyles.js
@@ -69,7 +69,7 @@ ApiReferenceWrapper.propTypes = {
 
 const { getSizeGrid, COL_SIZES, COLUMNS } = gridHelpers;
 const { count, size, margin } = COLUMNS[COL_SIZES.md];
-export const OneSizeRow = styled.div`
+export const ApiReferenceRow = styled.div`
   // Treat md as smallest size
   display: grid;
   grid-template-columns: repeat(${count}, ${size}rem);

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -43,7 +43,7 @@ import {
 } from "components/ApiRefRouting/ScrollRouter";
 import { Route, SectionPathContext } from "components/ApiRefRouting/Route";
 import {
-  OneSizeRow,
+  ApiReferenceRow,
   ApiReferenceWrapper,
   Container,
   NestedRow,
@@ -319,7 +319,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
         >
           <PrismStyles />
           <Container>
-            <OneSizeRow>
+            <ApiReferenceRow>
               <SideNavColumn xs={3} lg={3} xl={4}>
                 <SideNavBackground />
                 <SideNav docType={docType.api}>
@@ -369,7 +369,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                 )}
                 <Footer />
               </Column>
-            </OneSizeRow>
+            </ApiReferenceRow>
           </Container>
         </LayoutBase>
       </MDXProvider>

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -30,7 +30,7 @@ import { normalizeRoute } from "helpers/routes";
 
 import { BasicButton } from "basics/Buttons";
 import { EditIcon } from "basics/Icons";
-import { Column } from "basics/Grid";
+import { Column, Container, Row } from "basics/Grid";
 import { Link } from "basics/Links";
 import { PrismStyles } from "basics/Prism";
 import { ListItem, Text } from "basics/Text";
@@ -38,12 +38,7 @@ import { ListItem, Text } from "basics/Text";
 import Articles from "components/Documentation/Articles";
 import { LayoutBase } from "components/layout/LayoutBase";
 import { SideNav, SideNavBody, TrackedContent } from "components/SideNav";
-import {
-  Content,
-  SideNavColumn,
-  OneSizeRow,
-  Container,
-} from "components/Documentation/SharedStyles";
+import { Content, SideNavColumn } from "components/Documentation/SharedStyles";
 import { Footer } from "components/Documentation/Footer";
 import {
   NavAbsoluteEl,
@@ -279,8 +274,8 @@ const Documentation = ({ data, pageContext, location }) => {
       >
         <PrismStyles isDoc />
         <Container id={contentId}>
-          <OneSizeRow>
-            <SideNavColumn xs={3}>
+          <Row>
+            <SideNavColumn md={3} lg={3}>
               <SideNavBackground />
               <SideNav docType={docType.doc}>
                 <NavAbsoluteEl>{left}</NavAbsoluteEl>
@@ -289,8 +284,11 @@ const Documentation = ({ data, pageContext, location }) => {
                 </AbsoluteNavFooterEl>
               </SideNav>
             </SideNavColumn>
+            {/*
+              We want the right hand side to appear above content on mobile
+            */}
+            <Column md={{ hide: true }}>{right}</Column>
             <Column
-              xs={9}
               md={7}
               isIndependentScroll
               id={`${DOM_TARGETS.contentColumn}`}
@@ -298,12 +296,8 @@ const Documentation = ({ data, pageContext, location }) => {
               {center}
               <Footer />
             </Column>
-            {headings.length > 0 && (
-              <Column xs={{ hide: true }} md={2}>
-                {right}
-              </Column>
-            )}
-          </OneSizeRow>
+            <Column md={2}>{right}</Column>
+          </Row>
         </Container>
       </LayoutBase>
     </MDXProvider>

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -29,7 +29,7 @@ import { Expansion } from "components/Expansion";
 import { SideNav, SideNavBody } from "components/SideNav";
 import {
   Container,
-  OneSizeRow,
+  ApiReferenceRow,
   ApiReferenceWrapper,
   SideNavColumn,
   NestedRow,
@@ -152,7 +152,7 @@ const SingleApiReference = React.memo(function ApiReference({
         pageContext={pageContext}
       >
         <Container>
-          <OneSizeRow style={{ marginTop: "5rem" }}>
+          <ApiReferenceRow style={{ marginTop: "5rem" }}>
             <SideNavColumn xs={3} lg={3} xl={4}>
               <SideNavBackground />
               <SideNav>
@@ -190,7 +190,7 @@ const SingleApiReference = React.memo(function ApiReference({
               </section>
               <Footer />
             </Column>
-          </OneSizeRow>
+          </ApiReferenceRow>
         </Container>
       </LayoutBase>
     </MDXProvider>


### PR DESCRIPTION
* [PR 70](https://deploy-preview-70--stellar-documentation.netlify.com/docs/) is where I disabled the mobile view because it wasn't completed
* [PR 53 Deploy](https://deploy-preview-53--stellar-documentation.netlify.com/docs/) is how it used to look on mobile
* Now that we have some time, we can implement mobile view