### PR TITLE
Bugfix/api-mobile > api ref to be functional on mobile

### DIFF
--- a/src/basics/Grid.js
+++ b/src/basics/Grid.js
@@ -113,6 +113,8 @@ const ColumnEl = styled.div`
     css`
       overflow-y: scroll;
       height: 100vh;
+      /* --vh will be set via setViewportHeight() ApiReference.js */
+      height: calc(var(--vh, 1vh) * 100);
     `}
 `;
 

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -22,6 +22,11 @@ export const NavAbsoluteEl = styled.div`
   top: 4rem;
   bottom: 4.31rem;
 
+  /* <SideNav/> does not have mobile friendly design (API REF) */
+  @media (${MEDIA_QUERIES.ltLaptop}) {
+    overflow-y: scroll;
+  }
+
   &:hover {
     overflow-y: scroll;
   }
@@ -140,6 +145,8 @@ export const NavItem = styled.div`
 export const StickyEl = styled.div`
   width: 100%;
   height: 100vh;
+  /* --vh will be set via setViewportHeight() ApiReference.js */
+  height: calc(var(--vh, 1vh) * 100);
   overflow-y: scroll;
   position: sticky;
   top: 0;

--- a/src/components/SideNav/SideNav.js
+++ b/src/components/SideNav/SideNav.js
@@ -2,7 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
+import { MEDIA_QUERIES } from "constants/styles";
+
 import { slugify } from "helpers/slugify";
+import { useMatchMedia } from "helpers/useMatchMedia";
 
 import { List, ListItem } from "basics/Text";
 
@@ -96,7 +99,12 @@ const NestedNav = ({
     childOptions: items,
     id: uniqueId,
   });
-  const isOpen = isChildActive || isActive;
+  const isMobile = useMatchMedia(`(${MEDIA_QUERIES.ltLaptop})`);
+
+  /* On Mobile, SideNav's stay sticky and highlight as you scroll is disabled
+  Therefore, SideNav is displaying all of its sub navigation items by default on mobile
+  Its example can be seen in /api */
+  const isOpen = isMobile ? true : isChildActive || isActive;
 
   /* Nested navigation's default index.mdx has the same title as 
     its folder's metadata.json's title which causes redundancy. 

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -323,7 +323,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
     window.addEventListener("resize", setViewportHeight);
 
     return () => {
-      window.removeEventListener("scroll", setViewportHeight);
+      window.removeEventListener("resize", setViewportHeight);
     };
   }, []);
 

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -307,7 +307,7 @@ const Documentation = ({ data, pageContext, location }) => {
               {center}
               <Footer />
             </Column>
-            <Column md={2}>{right}</Column>
+            {pageOutline.length > 0 && <Column md={2}>{right}</Column>}
           </Row>
         </Container>
       </LayoutBase>


### PR DESCRIPTION
[Disable Scroll Highlight functionality on mobile](https://app.asana.com/0/1119309091112078/1169602362766355)
- Disable the highlight as you scroll functionality on mobile
- Keep the "current" highlighting functionality on mobile
- Nested navigation items should be visible by default

* Using `document.documentElement.style.setProperty` so that our `height: 100vh;` will be always 100vh via its `window.innerHeight` on mobile devices when users have to zoom out to see the whole page since `/api` is using its desktop design on mobile
-- Based on [the trick to viewport units on mobile](https://css-tricks.com/the-trick-to-viewport-units-on-mobile/)

* Hide **Page Outlines** on the right column on `/docs` when there is no items available to be highlighted

**iphone-6-landscape**

<img width="669" alt="iphone-6-landscape" src="https://user-images.githubusercontent.com/3912060/78403002-9a8c8c80-75c9-11ea-9d43-b597507c9447.png">

**iphone-6-portrait**

<img width="361" alt="iphone-6-portrait" src="https://user-images.githubusercontent.com/3912060/78403003-9a8c8c80-75c9-11ea-9c40-734ccc853efb.png">
