### PR TITLE
bugfix/grid > implemented a small hack in order to make grid work on a large screen

### DIFF
--- a/src/components/Documentation/SharedStyles.js
+++ b/src/components/Documentation/SharedStyles.js
@@ -27,7 +27,11 @@ export const Content = styled.article`
   position: relative;
   margin: 0 auto;
 `;
-
+const CustomColumn = styled(Column)`
+  @media (${MEDIA_QUERIES.gtXlDesktop}) {
+    grid-column: ${(props) => (props.xlColumn ? props.xlColumn : "inherit")};
+  }
+`;
 const RIGHT_COLUMN_COMPONENTS_NAME = {
   CodeExample: "CodeExample",
   EndpointsTable: "EndpointsTable",
@@ -54,12 +58,20 @@ export const ApiReferenceWrapper = ({ children, ...props }) => {
 
   return (
     <React.Fragment>
-      <Column xs={5} xl={9}>
+      {/* Hack to make it look appear as if we had a column-gap
+      4rem in between <CustomColumn/> on a large screen (min-width: 1440px)
+      skip the 1st column to use it as column-gap, start at the 2nd column and
+      span through then next 8 columns (ends at column 9) */}
+      <CustomColumn xs={5} xl={9} xlColumn="2 / span 8">
         <Content {...props}>{MiddleColumnContent}</Content>
-      </Column>
-      <Column xs={4} xl={9}>
+      </CustomColumn>
+      {/* Hack to make it look appear as if we had a column-gap
+      4rem in between <CustomColumn/> on a large screen (min-width: 1440px)
+      skip the 10th column to use it as column-gap, start at the 11th column and
+      span through the next 8 columns (ends at column 18) */}
+      <CustomColumn xs={4} xl={9} xlColumn="11 / span 8">
         {rightColumnContent}
-      </Column>
+      </CustomColumn>
     </React.Fragment>
   );
 };

--- a/src/components/Documentation/SharedStyles.js
+++ b/src/components/Documentation/SharedStyles.js
@@ -27,7 +27,7 @@ export const Content = styled.article`
   position: relative;
   margin: 0 auto;
 `;
-const CustomColumn = styled(Column)`
+export const CustomColumn = styled(Column)`
   @media (${MEDIA_QUERIES.gtXlDesktop}) {
     grid-column: ${(props) => (props.xlColumn ? props.xlColumn : "inherit")};
   }

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -47,9 +47,9 @@ import { Route, SectionPathContext } from "components/ApiRefRouting/Route";
 import {
   ApiReferenceRow,
   ApiReferenceWrapper,
-  Container,
   NestedRow,
   SideNavColumn,
+  CustomColumn,
 } from "components/Documentation/SharedStyles";
 import { Expansion } from "components/Expansion";
 
@@ -278,17 +278,25 @@ const ReferenceSection = React.memo(
       <SectionEl>
         <Route originalFilePath={relativePath} path={path}>
           <>
-            <TrackedContent>
-              <TrackedEl id={path}>
-                <ApiRefLinkedH1 id={path}>{title}</ApiRefLinkedH1>
-                {githubLink && (
-                  <Link href={githubLink} newTab>
-                    <EditIcon color={PALETTE.purpleBlue} />
-                  </Link>
-                )}
-              </TrackedEl>
-            </TrackedContent>
-
+            <NestedRow>
+              {/* Hack to make it look appear as if we had a column-gap
+                4rem in between <CustomColumn/> on a large screen (min-width: 1440px)
+                skip the 1st column to use it as column-gap, start at the 2nd column and
+                span through then next 8 columns (ends at column 9)
+              */}
+              <CustomColumn xs={5} xl={9} xlColumn="2 / span 8">
+                <TrackedContent>
+                  <TrackedEl id={path}>
+                    <ApiRefH1 id={path}>{title}</ApiRefH1>
+                    {githubLink && (
+                      <Link href={githubLink} newTab>
+                        <EditIcon color={PALETTE.purpleBlue} />
+                      </Link>
+                    )}
+                  </TrackedEl>
+                </TrackedContent>
+              </CustomColumn>
+            </NestedRow>
             <NestedRow>
               <MDXRenderer>{body}</MDXRenderer>
             </NestedRow>
@@ -333,59 +341,56 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
           viewport="width=1366, initial-scale=.1"
         >
           <PrismStyles />
-          <Container>
-            <ApiReferenceRow>
-              <SideNavColumn xs={3} lg={3} xl={4}>
-                <SideNavBackground />
-                <SideNav docType={docType.api}>
-                  <NavAbsoluteEl ref={sideNavRef}>
-                    {Object.entries(docsBySubCategory).map((nav, i) => (
-                      <ExpansionContainerEl
-                        // eslint-disable-next-line react/no-array-index-key
-                        key={i}
+
+          <ApiReferenceRow>
+            <SideNavColumn xs={3} lg={3} xl={4}>
+              <SideNavBackground />
+              <SideNav docType={docType.api}>
+                <NavAbsoluteEl ref={sideNavRef}>
+                  {Object.entries(docsBySubCategory).map((nav, i) => (
+                    <ExpansionContainerEl
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={i}
+                    >
+                      <Expansion
+                        title={<NavTitleEl>{nav[0]}</NavTitleEl>}
+                        expandedModeTitle={<NavTitleEl>{nav[0]}</NavTitleEl>}
+                        collapseIcon={<ArrowIcon direction="up" />}
+                        expandIcon={<ArrowIcon direction="down" />}
+                        isDefaultExpanded={true}
                       >
-                        <Expansion
-                          title={<NavTitleEl>{nav[0]}</NavTitleEl>}
-                          expandedModeTitle={<NavTitleEl>{nav[0]}</NavTitleEl>}
-                          collapseIcon={<ArrowIcon direction="up" />}
-                          expandIcon={<ArrowIcon direction="down" />}
-                          isDefaultExpanded={true}
-                        >
-                          <SideNavBody
-                            items={nav[1]}
-                            renderItem={renderItem}
-                            forwardedRef={sideNavRef}
-                          />
-                        </Expansion>
-                      </ExpansionContainerEl>
-                    ))}
-                  </NavAbsoluteEl>
-                  <AbsoluteNavFooterEl>
-                    <StyledLink href="/docs">Documentation</StyledLink>
-                  </AbsoluteNavFooterEl>
-                </SideNav>
-              </SideNavColumn>
-              <Column
-                xs={9}
-                xl={18}
-                isIndependentScroll
-                id={`${DOM_TARGETS.contentColumn}`}
-              >
-                {referenceDocs.map(
-                  ({ body, id, parent, title, githubLink }) => (
-                    <ReferenceSection
-                      relativePath={parent.relativePath}
-                      key={id}
-                      title={title}
-                      githubLink={githubLink}
-                      body={body}
-                    />
-                  ),
-                )}
-                <Footer />
-              </Column>
-            </ApiReferenceRow>
-          </Container>
+                        <SideNavBody
+                          items={nav[1]}
+                          renderItem={renderItem}
+                          forwardedRef={sideNavRef}
+                        />
+                      </Expansion>
+                    </ExpansionContainerEl>
+                  ))}
+                </NavAbsoluteEl>
+                <AbsoluteNavFooterEl>
+                  <StyledLink href="/docs">Documentation</StyledLink>
+                </AbsoluteNavFooterEl>
+              </SideNav>
+            </SideNavColumn>
+            <Column
+              xs={9}
+              xl={18}
+              isIndependentScroll
+              id={`${DOM_TARGETS.contentColumn}`}
+            >
+              {referenceDocs.map(({ body, id, parent, title, githubLink }) => (
+                <ReferenceSection
+                  relativePath={parent.relativePath}
+                  key={id}
+                  title={title}
+                  githubLink={githubLink}
+                  body={body}
+                />
+              ))}
+              <Footer />
+            </Column>
+          </ApiReferenceRow>
         </LayoutBase>
       </MDXProvider>
     </ScrollRouter>

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -34,7 +34,6 @@ import { Expansion } from "components/Expansion";
 
 import { SideNav, SideNavBody } from "components/SideNav";
 import {
-  Container,
   ApiReferenceRow,
   ApiReferenceWrapper,
   SideNavColumn,
@@ -168,46 +167,45 @@ const SingleApiReference = React.memo(function ApiReference({
         description={description}
         pageContext={pageContext}
       >
-        <Container>
-          <ApiReferenceRow>
-            <SideNavColumn xs={3} lg={3} xl={4}>
-              <SideNavBackground />
-              <SideNav docType={docType.api}>
-                {Object.entries(docsBySubCategory).map((nav, i) => (
-                  <ExpansionContainerEl
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={i}
+        <ApiReferenceRow style={{ marginTop: "5rem" }}>
+          <SideNavColumn xs={3} lg={3} xl={4}>
+            <SideNavBackground />
+            <SideNav>
+              {Object.entries(docsBySubCategory).map((nav, i) => (
+                <ExpansionContainerEl
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={i}
+                >
+                  <Expansion
+                    title={nav[0]}
+                    expandedModeTitle={nav[0]}
+                    hasBorder
+                    collapseIcon={<ArrowIcon direction="up" />}
+                    expandIcon={<ArrowIcon direction="down" />}
+                    isDefaultExpanded={true}
                   >
-                    <Expansion
-                      title={<NavTitleEl>{nav[0]}</NavTitleEl>}
-                      expandedModeTitle={<NavTitleEl>{nav[0]}</NavTitleEl>}
-                      collapseIcon={<ArrowIcon direction="up" />}
-                      expandIcon={<ArrowIcon direction="down" />}
-                      isDefaultExpanded={true}
-                    >
-                      <SideNavBody items={nav[1]} renderItem={renderItem} />
-                    </Expansion>
-                  </ExpansionContainerEl>
-                ))}
-              </SideNav>
-            </SideNavColumn>
-            <Column
-              xs={9}
-              xl={18}
-              isIndependentScroll
-              id={`${DOM_TARGETS.contentColumn}`}
-            >
-              <section>
-                <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
-                <NestedRow>
-                  <MDXRenderer>{body}</MDXRenderer>
-                </NestedRow>
-                <HorizontalRule />
-              </section>
-              <Footer />
-            </Column>
-          </ApiReferenceRow>
-        </Container>
+                    <SideNavBody items={nav[1]} renderItem={renderItem} />
+                  </Expansion>
+                </ExpansionContainerEl>
+              ))}
+            </SideNav>
+          </SideNavColumn>
+          <Column
+            xs={9}
+            xl={18}
+            isIndependentScroll
+            id={`${DOM_TARGETS.contentColumn}`}
+          >
+            <section>
+              <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
+              <NestedRow>
+                <MDXRenderer>{body}</MDXRenderer>
+              </NestedRow>
+              <HorizontalRule />
+            </section>
+            <Footer />
+          </Column>
+        </ApiReferenceRow>
       </LayoutBase>
     </MDXProvider>
   );

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -167,19 +167,18 @@ const SingleApiReference = React.memo(function ApiReference({
         description={description}
         pageContext={pageContext}
       >
-        <ApiReferenceRow style={{ marginTop: "5rem" }}>
+        <ApiReferenceRow>
           <SideNavColumn xs={3} lg={3} xl={4}>
             <SideNavBackground />
-            <SideNav>
+            <SideNav docType={docType.api}>
               {Object.entries(docsBySubCategory).map((nav, i) => (
                 <ExpansionContainerEl
                   // eslint-disable-next-line react/no-array-index-key
                   key={i}
                 >
                   <Expansion
-                    title={nav[0]}
-                    expandedModeTitle={nav[0]}
-                    hasBorder
+                    title={<NavTitleEl>{nav[0]}</NavTitleEl>}
+                    expandedModeTitle={<NavTitleEl>{nav[0]}</NavTitleEl>}
                     collapseIcon={<ArrowIcon direction="up" />}
                     expandIcon={<ArrowIcon direction="down" />}
                     isDefaultExpanded={true}


### PR DESCRIPTION
[Padding between columns](https://app.asana.com/0/1119309091112078/1162530625941540)
* This bug is for xl screen `(min-width: 1441px)`
* As Carl noted, it's impossible to set a minimum width for `column-gap`
* I implemented a hack to skip the first column for each column in the middle two sections on a xl screen to give 4rem padding

**Before**
<img width="500" alt="before" src="https://user-images.githubusercontent.com/3912060/78938414-30b82b00-7a80-11ea-85a6-a2dff078c138.png">

**After**
<img width="500" alt="after" src="https://user-images.githubusercontent.com/3912060/78938427-357cdf00-7a80-11ea-89ef-cea4027edc83.png">
