### PR TITLE
Bugfix/tooltip

### DIFF
--- a/src/components/CodeExample.js
+++ b/src/components/CodeExample.js
@@ -8,6 +8,7 @@ import ExternalLinkIcon from "assets/icons/icon-external-link.svg";
 import CopyIcon from "assets/icons/icon-copy.svg";
 
 import { PALETTE, FONT_FAMILY, FONT_WEIGHT } from "constants/styles";
+import { DOM_TARGETS } from "constants/domNodes";
 
 import { getCookie } from "helpers/getCookie";
 import { extractStringChildren } from "helpers/extractStringChildren";
@@ -154,7 +155,7 @@ const CodeSnippet = ({ codeSnippets, title, href }) => {
   const [activeLang, setActiveLang] = React.useState("");
   const [isCopied, setCopy] = React.useState(false);
   const [isHovered, setHover] = React.useState(false);
-  const [dimension, setDimension] = React.useState({ right: 0, top: 0 });
+  const [position, setPosition] = React.useState({ right: 0, top: 0 });
 
   const codeSnippetsArr = React.Children.toArray(codeSnippets);
   const selectedSnippet =
@@ -163,14 +164,17 @@ const CodeSnippet = ({ codeSnippets, title, href }) => {
     ) || codeSnippetsArr[0];
   const SelectedSnippetStr = mdxJsxToString(selectedSnippet);
 
-  const CopyToClipboardRef = React.useCallback((node) => {
-    if (node !== null) {
-      setDimension({
-        right: Math.floor(node.getBoundingClientRect().right),
-        top: Math.floor(node.getBoundingClientRect().top),
-      });
-    }
-  }, []);
+  const CopyToClipboardRef = React.useCallback(
+    (node) => {
+      if (node !== null && isHovered) {
+        setPosition({
+          right: Math.floor(node.getBoundingClientRect().right),
+          top: Math.floor(node.getBoundingClientRect().top),
+        });
+      }
+    },
+    [isHovered],
+  );
 
   const onChange = React.useCallback((e) => {
     const { value } = e.target;
@@ -180,6 +184,23 @@ const CodeSnippet = ({ codeSnippets, title, href }) => {
     });
     setActiveLang(value);
   }, []);
+
+  React.useEffect(() => {
+    const contentDom = document.querySelector(`#${DOM_TARGETS.contentColumn}`);
+
+    const setHoverFalse = () => {
+      if (isHovered) setHover(false);
+    };
+
+    /* Setting 'isHovered' to false while scrolling is necessary to 
+    prevent a tooltip to be displayed and its position to be scrolled 
+    together when a user scrolls while hovering on an icon */
+    contentDom.addEventListener("scroll", setHoverFalse);
+
+    return () => {
+      contentDom.removeEventListener("scroll", setHoverFalse);
+    };
+  }, [isHovered]);
 
   React.useEffect(() => {
     const langCookie = getCookie("lang");
@@ -255,9 +276,11 @@ const CodeSnippet = ({ codeSnippets, title, href }) => {
         </OptionsContainer>
       </TitleEl>
       <ContentEl>{selectedSnippet}</ContentEl>
-      <Tooltip in={isHovered} isCopied={isCopied} parentDimension={dimension}>
-        {isCopied ? "Copied" : "Click to copy"}
-      </Tooltip>
+      {isHovered && (
+        <Tooltip in={isHovered} isCopied={isCopied} parentPosition={position}>
+          {isCopied ? "Copied" : "Click to copy"}
+        </Tooltip>
+      )}
     </MethodContentEl>
   );
 };

--- a/src/components/CodeExample.js
+++ b/src/components/CodeExample.js
@@ -251,9 +251,7 @@ const CodeSnippet = ({ codeSnippets, title, href }) => {
           <DividerEl />
           <CopyToClipboard
             text={SelectedSnippetStr && SelectedSnippetStr}
-            onCopy={() => {
-              setCopy((x) => !x);
-            }}
+            onCopy={() => !isCopied && setCopy(true)}
           >
             <CopyIconWrapper
               ref={CopyToClipboardRef}

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Transition } from "react-transition-group";
 import styled from "styled-components";
 
-import { PORTAL_TARGETS, DOM_TARGETS } from "constants/domNodes";
+import { PORTAL_TARGETS } from "constants/domNodes";
 import { PALETTE, Z_INDEXES } from "constants/styles";
 
 import { renderToPortal } from "helpers/renderToPortal";
@@ -36,7 +36,7 @@ const TooltipEl = styled.div`
 export const Tooltip = ({
   in: inProp,
   duration = 200,
-  parentDimension,
+  parentPosition,
   children,
 }) => {
   const [tooltipDimension, setTooltipDimension] = React.useState({
@@ -57,30 +57,12 @@ export const Tooltip = ({
     }
   }, []);
 
-  React.useLayoutEffect(() => {
-    const targetDom = document.querySelector(`#${DOM_TARGETS.contentColumn}`);
-
-    const onResize = () => {
-      if (tooltipDimension.width > 0) {
-        setTooltipPosition({
-          left: parentDimension.right - tooltipDimension.width + 16,
-          top: Math.abs(
-            targetDom.scrollTop -
-              parentDimension.top +
-              tooltipDimension.height +
-              24,
-          ),
-        });
-      }
-    };
-
-    window.addEventListener("resize", onResize);
-    onResize();
-
-    return () => {
-      window.removeEventListener("resize", onResize);
-    };
-  }, [tooltipDimension, parentDimension]);
+  React.useEffect(() => {
+    setTooltipPosition({
+      left: parentPosition.right - tooltipDimension.width + 16,
+      top: parentPosition.top + tooltipDimension.height - 90,
+    });
+  }, [tooltipDimension, parentPosition]);
 
   return (
     <Transition
@@ -107,7 +89,7 @@ export const Tooltip = ({
 };
 
 Tooltip.propTypes = {
-  parentDimension: PropTypes.object.isRequired,
+  parentPosition: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
   in: PropTypes.bool,
   duration: PropTypes.number,


### PR DESCRIPTION
* [Tooltip > Weird spacing when scroll fast;](https://app.asana.com/0/1119309091112078/1162498707069777)
-- `isHovered` to set to `false` when scrolled to prevent a tooltip to be displayed and its position to be scrolled together when a user scrolls while hovering on an copy icon
-- Renamed `parentDimension` to `parentPosition`
* Retrieve `<CodeExample/>` and `<ToolTip/>` element's position only when their `isHovered` is set to true
-- Removed `resize` functionality. It is no longer needed since we get the position only when is hovered
* `<CopyToClipboard/>`'s `onCopy` functionality to only act when its `isCopied` is false. Previously if a user double clicked, it would display 'Click to Copy' right away instead of waiting for `setTimeout` to complete.