### PR TITLE
Api/bugfix

### DIFF
--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -57,7 +57,7 @@ export const Tooltip = ({
     }
   }, []);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     setTooltipPosition({
       left: parentPosition.right - tooltipDimension.width + 16,
       top: parentPosition.top + tooltipDimension.height - 90,

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -96,6 +96,11 @@ const ApiRefH1 = styled(H1)`
   margin-top: 0.25rem;
   margin-bottom: 0;
 `;
+const ApiRefH2 = styled(H2)`
+  padding-top: 0;
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+`;
 const NavItemEl = styled.div`
   display: block;
   text-align: left;
@@ -244,7 +249,7 @@ const headerOptions = {
 };
 
 const ApiRefLinkedH1 = makeLinkedHeader(ApiRefH1, headerOptions);
-const ApiRefLinkedH2 = makeLinkedHeader(H2, headerOptions);
+const ApiRefLinkedH2 = makeLinkedHeader(ApiRefH2, headerOptions);
 
 const componentMap = {
   ...components,
@@ -271,6 +276,18 @@ const componentMap = {
 const ReferenceSection = React.memo(
   ({ body, relativePath, title, githubLink }) => {
     const path = buildPathFromFile(relativePath);
+    const splitRelativePath = relativePath.split("/");
+
+    /* Check to see if a section is a nested item */
+    const isNestedSection =
+      relativePath.split("/").length > 3 &&
+      splitRelativePath[splitRelativePath.length - 1] !== "index.mdx";
+
+    const SectionHeader = isNestedSection ? (
+      <ApiRefH2 id={path}>{title}</ApiRefH2>
+    ) : (
+      <ApiRefH1 id={path}>{title}</ApiRefH1>
+    );
 
     return (
       <SectionEl>
@@ -282,10 +299,10 @@ const ReferenceSection = React.memo(
                 skip the 1st column to use it as column-gap, start at the 2nd column and
                 span through then next 8 columns (ends at column 9)
               */}
-              <CustomColumn xs={5} xl={9} xlColumn="2 / span 8">
+              <CustomColumn xs={9} xlColumn="2 / span 8">
                 <TrackedContent>
                   <TrackedEl id={path}>
-                    <ApiRefH1 id={path}>{title}</ApiRefH1>
+                    {SectionHeader}
                     {githubLink && (
                       <Link href={githubLink} newTab>
                         <EditIcon color={PALETTE.purpleBlue} />

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -89,11 +89,9 @@ const NavTitleEl = styled(H5)`
 `;
 const activeStyles = `
   color: ${PALETTE.purpleBlue};
-  background: rgba(0,0,0,0.04);
-  border-radius: 2px;
-  padding-left: 0.75rem;
   font-weight: ${FONT_WEIGHT.bold};
 `;
+
 const ApiRefH1 = styled(H1)`
   margin-top: 0.25rem;
   margin-bottom: 0;


### PR DESCRIPTION
- [Header should span throughout the <Row/>](https://app.asana.com/0/1119309091112078/1171278354578258)
-- Header to be full width so that a long text such as [this](https://developers.stellar.org/api/aggregations/paths/strict-receive/) will not break into a new line
-- Also looking at the design, its sub nav section's titles should be smaller than its parent so I activated `<H2/>`

- Currently `<Tooltip/>`'s new position shows a second after its initial position on [our API](https://developers.stellar.org/api/). Using `useLayoutEffect` to see if rendering before DOM repainting works.