### PR TITLE
Bugfix/nav

### DIFF
--- a/src/basics/Links.js
+++ b/src/basics/Links.js
@@ -13,10 +13,6 @@ const basicLinkStyles = css`
   color: inherit;
   font-weight: ${FONT_WEIGHT.bold};
   line-height: 1.5;
-
-  &:hover {
-    color: #1c0c62;
-  }
 `;
 const BasicLink = styled(GatsbyLink)`
   ${basicLinkStyles};

--- a/src/components/Documentation/MobileLeftNav.js
+++ b/src/components/Documentation/MobileLeftNav.js
@@ -11,11 +11,7 @@ import { CloseIcon, Menu } from "basics/Icons";
 import { BasicButton } from "basics/Buttons";
 import { Link } from "basics/Links";
 
-import {
-  BetaBadge,
-  NavDivider,
-  NavLogo,
-} from "components/Navigation/SharedStyles";
+import { NavDivider, NavLogo } from "components/Navigation/SharedStyles";
 import { LeftNav } from "./LeftNav";
 
 const El = styled.div`
@@ -136,7 +132,7 @@ export const MobileLeftNav = ({
               <LinkEl href="https://github.com/stellar/new-docs/issues">
                 here
               </LinkEl>
-              .<BetaBadge>beta</BetaBadge>
+              .
             </BetaNoticeEl>
           </NavSectionEl>
         </NavBarEl>

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -128,7 +128,7 @@ export const NavImage = styled(Image)`
 `;
 export const AbsoluteNavFooterEl = styled.div`
   list-style: none;
-  padding: 0.75rem 0;
+  padding: 0.75rem 0 2rem;
 
   // borderline
   &::before {

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 
 import {
-  DEFAULT_COLUMN_WIDTH,
   FONT_WEIGHT,
   MEDIA_QUERIES,
   PALETTE,
@@ -39,13 +38,21 @@ export const NavAbsoluteEl = styled.div`
 `;
 
 export const El = styled.div`
-  max-width: ${DEFAULT_COLUMN_WIDTH.leftColumn}rem;
+  position: relative;
   padding: 1.5rem 0;
   line-height: 1.5rem;
   display: flex;
   align-items: center;
 
-  position: relative;
+  &::before {
+    content: "";
+    height: 1px;
+    background-color: ${PALETTE.white60};
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+  }
+
   &::after {
     content: "";
     z-index: 2;
@@ -104,6 +111,7 @@ NavLogo.propTypes = {
 export const SideNavBackground = styled.div`
   position: absolute;
   background-color: ${REDESIGN_PALETTE.grey[0]};
+  border-right: 1px solid ${PALETTE.white60};
   left: -100rem;
   right: 0;
   top: -10rem;
@@ -120,8 +128,17 @@ export const NavImage = styled(Image)`
 `;
 export const AbsoluteNavFooterEl = styled.div`
   list-style: none;
-  border-top: 1px solid ${PALETTE.white60};
-  padding: 0.75rem 0 2rem;
+  padding: 0.75rem 0;
+
+  // borderline
+  &::before {
+    content: "";
+    height: 1px;
+    background-color: ${PALETTE.white60};
+    width: 100%;
+    position: absolute;
+    top: 0;
+  }
 
   // Bottom scroll gradient
   position: relative;

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -40,7 +40,7 @@ export const NavAbsoluteEl = styled.div`
 
 export const El = styled.div`
   max-width: ${DEFAULT_COLUMN_WIDTH.leftColumn}rem;
-  padding: 0.5rem 0;
+  padding: 1.5rem 0;
   line-height: 1.5rem;
   display: flex;
   align-items: center;
@@ -72,33 +72,28 @@ const LogoEl = styled(Logo).attrs({ width: 100, height: 24 })`
   fill: ${theme.logo};
 `};
 `;
-const PageNameEl = styled.span`
-  font-size: 1.125rem;
-  margin-bottom: -0.25rem;
-`;
+
 export const NavDivider = styled(DividerEl)`
   height: 2.75rem;
   background-color: ${PALETTE.white60};
 `;
-export const BetaBadge = styled.div`
+export const Badge = styled.div`
   display: inline-block;
   background-color: ${PALETTE.purpleBlue};
   border-radius: 0.125rem;
-  padding: 0.25rem;
-  font-size: 0.75rem;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.875rem;
   text-transform: uppercase;
   line-height: 1;
+  font-weight: ${FONT_WEIGHT.bold};
   color: ${PALETTE.white};
-  margin-bottom: -0.25rem;
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 `;
 
 export const NavLogo = ({ pageName }) => (
   <El>
     <LogoEl />
-    <NavDivider />
-    <PageNameEl>{pageName}</PageNameEl>
-    <BetaBadge>beta</BetaBadge>
+    <Badge>{pageName}</Badge>
   </El>
 );
 

--- a/src/constants/docsComponentMapping.js
+++ b/src/constants/docsComponentMapping.js
@@ -97,6 +97,9 @@ export const components = {
   hr: TextComponents.HorizontalRule,
   a: styled(Link)`
     color: ${PALETTE.purple};
+    &:hover {
+      color: #1c0c62;
+    }
   `,
   img: styled(BasicImage)`
     display: block;

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -107,7 +107,7 @@ const NavItemEl = styled.div`
   white-space: nowrap;
   font-size: ${(props) => (props.depth > 0 ? "0.875rem" : "1rem")};
   color: ${(props) => (props.depth === 0 ? PALETTE.black80 : PALETTE.black60)};
-  padding: 0.375rem 0;
+  padding: 0.25rem 0;
   padding-left: ${(props) => (props.depth > 1 ? `${props.depth - 1}rem` : 0)};
   transition: opacity ${CSS_TRANSITION_SPEED.default} ease-out;
   font-weight: ${FONT_WEIGHT.normal};

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -118,13 +118,10 @@ const NavItemEl = styled.div`
           ${activeStyles}
         `
       : ""}
-
-  &:hover {
-    color: ${PALETTE.lightGrey};
-  }
 `;
 
 const StyledLink = components.a;
+
 // eslint-disable-next-line react/prop-types
 const DocsLink = ({ href, ...props }) => {
   const originalPath = React.useContext(SectionPathContext);
@@ -154,6 +151,10 @@ const NavLinkEl = styled(DocsLink)`
   color: inherit;
   font-weight: unset;
   display: block;
+
+  &:hover {
+    color: ${PALETTE.lightGrey};
+  }
 `;
 
 const isInViewport = (elem) => {


### PR DESCRIPTION
[Navigation Update](https://app.asana.com/0/1119309091112078/1172089378013081)
* Add an #F2F2F2 1px solid border to the right side of the side nav?
* the hover states go in and out with light gray and dark purple (video in Slack with Charles)
* Subnav spacing to be narrower
* Beta logo to be API and remove it from mobile navigation on /docs
* Footer Text & Logo Bottom should have a borderline 