### PR TITLE
removing a semicolon that is appearing before the title

### DIFF
--- a/src/components/ApiRefRouting/Route.js
+++ b/src/components/ApiRefRouting/Route.js
@@ -21,7 +21,7 @@ export const Route = ({ children, originalFilePath, path }) => {
 
   return (
     <OriginalFileContext.Provider value={originalFilePath}>
-      <El ref={ref}>{React.Children.only(children)}</El>;
+      <El ref={ref}>{React.Children.only(children)}</El>
     </OriginalFileContext.Provider>
   );
 };


### PR DESCRIPTION
<img width="410" alt="semicolon" src="https://user-images.githubusercontent.com/3912060/81093520-3adb1700-8ed0-11ea-8a06-02488e22f71f.png">
I noticed a semicolon before each title on `/api` while checking out the send payments path for the take home test