### PR TITLE
bugfix/keydown-scroll > allow scrolling by keyboard arrow down and arrow up

### DIFF
--- a/src/basics/Grid.js
+++ b/src/basics/Grid.js
@@ -119,7 +119,7 @@ const ColumnEl = styled.div`
     `}
 `;
 
-export const Column = (props) => {
+export const Column = React.forwardRef((props, ref) => {
   const {
     xs = COLUMNS[COL_SIZES.xs].count,
     sm = xs || COLUMNS[COL_SIZES.sm].count,
@@ -127,8 +127,8 @@ export const Column = (props) => {
     lg = md || COLUMNS[COL_SIZES.lg].count,
     ...rest
   } = props;
-  return <ColumnEl {...rest} {...{ xs, sm, md, lg }} />;
-};
+  return <ColumnEl ref={ref} {...rest} {...{ xs, sm, md, lg }} />;
+});
 
 const ColumnSizePropType = PropTypes.oneOfType([
   PropTypes.number.isRequired,

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -59,6 +59,7 @@ import DevelopersPreview from "assets/images/og_developers.jpg";
 
 const NAV_BAR_HEIGHT = 89;
 const FIXED_NAV_DISTANCE = 140 + NAV_BAR_HEIGHT;
+const SCROLLED_PX = 24;
 
 const GreenTableCell = styled.td`
   color: ${PALETTE.lightGreen};
@@ -304,8 +305,23 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
   const referenceDocs = sortReference(
     data.referenceDocs.edges.map(({ node }) => normalizeMdx(node)),
   );
-  const sideNavRef = React.useRef();
   const docsBySubCategory = groupByCategory(referenceDocs);
+
+  const sideNavRef = React.useRef();
+  const contentDomRef = React.useRef();
+
+  React.useEffect(() => {
+    const onKeyDownScroll = (e) => {
+      if (e.key === "ArrowDown") {
+        contentDomRef.current.scrollTop += SCROLLED_PX;
+      }
+      if (e.key === "ArrowUp") {
+        contentDomRef.current.scrollTop -= SCROLLED_PX;
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDownScroll);
+  }, []);
 
   return (
     <ScrollRouter>
@@ -362,6 +378,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
               xl={18}
               isIndependentScroll
               id={`${DOM_TARGETS.contentColumn}`}
+              ref={contentDomRef}
             >
               <BetaNotice />
               {referenceDocs.map(({ body, id, parent, title, githubLink }) => (

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -48,6 +48,8 @@ import { MobileLeftNav } from "components/Documentation/MobileLeftNav";
 const contentId = "content";
 const { h1: H1, h2: H2, td: TD } = components;
 
+const SCROLLED_PX = 24;
+
 const RightNavEl = styled.div`
   font-size: 0.875rem;
   line-height: 1rem;
@@ -189,6 +191,21 @@ const Documentation = ({ data, pageContext, location }) => {
     title: value,
   }));
 
+  const contentDomRef = React.useRef();
+
+  React.useEffect(() => {
+    const onKeyDownScroll = (e) => {
+      if (e.key === "ArrowDown") {
+        contentDomRef.current.scrollTop += SCROLLED_PX;
+      }
+      if (e.key === "ArrowUp") {
+        contentDomRef.current.scrollTop -= SCROLLED_PX;
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDownScroll);
+  }, []);
+
   const left = (
     <LeftNav
       docsContents={docsContents}
@@ -266,6 +283,7 @@ const Documentation = ({ data, pageContext, location }) => {
                 md={7}
                 isIndependentScroll
                 id={`${DOM_TARGETS.contentColumn}`}
+                ref={contentDomRef}
               >
                 {center}
               </Column>


### PR DESCRIPTION
[Typeform - Allow keyboard scrolling](https://app.asana.com/0/1119309091112078/1174808027885137)

We disabled body scroll when we implemented independent scrolls for each div to prevent the content from scrolling down when the user is on side navigation, for example. Added an event listener to scroll down and up when arrow down/up key is pressed.