### PR TITLE
Doc's right sidebar needs to be sticky

### DIFF
--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -52,6 +52,8 @@ const RightNavEl = styled.div`
   line-height: 1rem;
   padding-top: 4.25rem;
   overflow-y: hidden;
+  position: sticky;
+  top: 0;
   margin: 0;
 
   li:before {


### PR DESCRIPTION
Enable the position sticky for the right sidebar on /docs.