### PR TITLE
outline-tracking-docs > polish tracking on /docs; separate logic for click and scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "lodash": "^4.17.15",
-    "memoize-one": "^5.1.1",
     "prettier": "^1.17.0",
     "pretty-quick": "^1.10.0",
     "prismjs": "^1.17.1",

--- a/src/components/SideNav/Provider.js
+++ b/src/components/SideNav/Provider.js
@@ -17,6 +17,8 @@ export const Provider = ({ children }) => {
   const [activeContent, setActiveNode] = React.useState({ id: "", ref: null });
   const [trackedElements, setTrackedElements] = React.useState([]);
 
+  const [isNavClicked, onNavClick] = React.useState(false);
+
   // We need to search just the refs pretty frequently, so memoize it so we
   // don't generate a ton of garbage.
   const elementRefs = React.useMemo(() => trackedElements.map((e) => e.ref), [
@@ -29,11 +31,18 @@ export const Provider = ({ children }) => {
       if (Math.abs(window.scrollY - lastScrollPosition) < 100) {
         return;
       }
+
       const isScrollingDown = window.scrollY > lastScrollPosition;
       lastScrollPosition = window.scrollY;
 
       const newActiveRef = findActiveNode(elementRefs, isScrollingDown);
+
+      if (isNavClicked) {
+        return;
+      }
+
       const newActiveNode = trackedElements.find((e) => e.ref === newActiveRef);
+
       if (newActiveNode && newActiveNode !== activeContent) {
         setActiveNode(newActiveNode);
       }
@@ -41,10 +50,11 @@ export const Provider = ({ children }) => {
 
     window.addEventListener("scroll", handler);
     handler();
+
     return () => {
       window.removeEventListener("scroll", handler);
     };
-  }, [activeContent, elementRefs, trackedElements]);
+  }, [activeContent, elementRefs, trackedElements, isNavClicked]);
 
   const trackElement = React.useCallback(
     (ref) => {
@@ -64,8 +74,16 @@ export const Provider = ({ children }) => {
       activeContent,
       stopTrackingElement,
       trackElement,
+      setActiveNode,
+      onNavClick,
     }),
-    [activeContent, stopTrackingElement, trackElement],
+    [
+      activeContent,
+      stopTrackingElement,
+      trackElement,
+      setActiveNode,
+      onNavClick,
+    ],
   );
 
   return (

--- a/src/helpers/documentation.js
+++ b/src/helpers/documentation.js
@@ -380,11 +380,12 @@ export const groupByCategory = (referenceDocs) => {
  * consolidateToSection is a reducer function to consolidate
  * all of subsequent items after <h2/> into an array of section
  * For <TrackedContent/> to surround its H2 and the content for /docs
+ * @returns {array} An array of objects with sections grouped
  */
 export const consolidateToSection = () => {
   let lastH2Index;
 
-  return function(acc, ele, index) {
+  return function consolidateReducer(acc, ele, index) {
     const arr = [];
 
     if (ele.props.mdxType === "h2") {

--- a/src/helpers/documentation.js
+++ b/src/helpers/documentation.js
@@ -376,8 +376,38 @@ export const groupByCategory = (referenceDocs) => {
   }, {});
 };
 
+/**
+ * consolidateToSection is a reducer function to consolidate
+ * all of subsequent items after <h2/> into an array of section
+ * For <TrackedContent/> to surround its H2 and the content for /docs
+ */
+export const consolidateToSection = () => {
+  let lastH2Index;
+
+  return function(acc, ele, index) {
+    const arr = [];
+
+    if (ele.props.mdxType === "h2") {
+      if (!lastH2Index) {
+        lastH2Index = index;
+      } else {
+        lastH2Index += 1;
+      }
+      arr.push(ele);
+      acc.push(arr);
+    } else if (lastH2Index && index > lastH2Index) {
+      acc[lastH2Index].push(ele);
+    } else {
+      acc.push(ele);
+    }
+
+    return acc;
+  };
+};
+
 export const ensureArray = (maybeArray) =>
   Array.isArray(maybeArray) ? maybeArray : [maybeArray];
+
 const combineAdjacentStrings = (list) =>
   list.reduce((accum, item) => {
     const lastIndex = accum.length - 1;

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -35,7 +35,7 @@ export const findActiveNode = (possibleNodes, isScrollingDown) => {
     possibleNodes = reverse(possibleNodes);
   }
 
-  return possibleNodes.find((x) => {
+  const activeNodes = possibleNodes.filter((x) => {
     if (!x.current) {
       return false;
     }
@@ -44,4 +44,6 @@ export const findActiveNode = (possibleNodes, isScrollingDown) => {
       ? top < bottomEdge && top > 0
       : bottom > topEdge && bottom < window.innerHeight;
   });
+
+  return isScrollingDown ? activeNodes[activeNodes.length - 1] : activeNodes[0];
 };

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -1,4 +1,3 @@
-import memoize from "memoize-one";
 import { TweenLite } from "gsap/TweenLite";
 import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 
@@ -19,8 +18,6 @@ export const smoothScrollTo = (node, onCompleteFn) => {
   });
 };
 
-const reverse = memoize((arr) => arr.slice().reverse());
-
 /**
  * findActiveNode expects a list of react refs and whether we're scrolling down
  * or not, and returns which node is most likely to be in focus.
@@ -30,35 +27,27 @@ const reverse = memoize((arr) => arr.slice().reverse());
  */
 export const findActiveNode = (possibleNodes, isScrollingDown) => {
   const topEdge = window.innerHeight * 0.125;
-  const bottomEdge = window.innerHeight * 0.875;
+  const bottomEdge = window.innerHeight * 0.5;
 
-  if (!isScrollingDown) {
-    // eslint-disable-next-line no-param-reassign
-    possibleNodes = reverse(possibleNodes);
-  }
+  const isReachedBottom =
+    window.innerHeight + window.scrollY >= document.body.offsetHeight - topEdge;
 
-  const activeNodes = possibleNodes.filter((x) => {
+  return possibleNodes.find((x) => {
     if (!x.current) {
       return false;
     }
     const { top, bottom } = x.current.getBoundingClientRect();
 
-    return isScrollingDown
-      ? top < bottomEdge && top > 0
-      : bottom > topEdge && bottom < window.innerHeight;
+    if (isScrollingDown) {
+      // For Edge case
+      // The last two items on https://developers.stellar.org/docs/
+      // Has equal hiearachy when scrolled all the way down
+      // Display the last item when scrolled all the way to the bottom
+      return isReachedBottom
+        ? bottom + bottomEdge > window.innerHeight - topEdge
+        : top < bottomEdge && top > 0;
+    }
+
+    return bottom > topEdge && bottom < window.innerHeight;
   });
-
-  const isReachedBottom =
-    window.innerHeight + window.scrollY >= document.body.offsetHeight - topEdge;
-
-  if (isScrollingDown) {
-    // For Edge case
-    // The last two items on https://developers.stellar.org/docs/
-    // Has equal hiearachy when scrolled all the way down
-    // Display the last item when scrolled all the way to the bottom
-    return isReachedBottom
-      ? activeNodes[activeNodes.length - 1]
-      : activeNodes[0];
-  }
-  return activeNodes[activeNodes.length - 1];
 };

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -7,13 +7,15 @@ import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 // eslint-disable-next-line
 const scrollPlugin = ScrollToPlugin;
 
-export const smoothScrollTo = (node, options = {}) => {
-  const { offset = 0, duration = 0.55 } = options;
+export const smoothScrollTo = (node, onCompleteFn) => {
+  const offset = 0;
+  const duration = 0.55;
 
   TweenLite.to(window, duration, {
     scrollTo: {
       y: node.offsetTop + offset,
     },
+    onComplete: onCompleteFn,
   });
 };
 
@@ -40,10 +42,23 @@ export const findActiveNode = (possibleNodes, isScrollingDown) => {
       return false;
     }
     const { top, bottom } = x.current.getBoundingClientRect();
+
     return isScrollingDown
       ? top < bottomEdge && top > 0
       : bottom > topEdge && bottom < window.innerHeight;
   });
 
-  return isScrollingDown ? activeNodes[activeNodes.length - 1] : activeNodes[0];
+  const isReachedBottom =
+    window.innerHeight + window.scrollY >= document.body.offsetHeight - topEdge;
+
+  if (isScrollingDown) {
+    // For Edge case
+    // The last two items on https://developers.stellar.org/docs/
+    // Has equal hiearachy when scrolled all the way down
+    // Display the last item when scrolled all the way to the bottom
+    return isReachedBottom
+      ? activeNodes[activeNodes.length - 1]
+      : activeNodes[0];
+  }
+  return activeNodes[activeNodes.length - 1];
 };

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -36,6 +36,9 @@ import {
   Provider as SideNavProvider,
   TrackedContent,
 } from "components/SideNav";
+
+import { SideNavProgressContext } from "components/SideNav/Provider";
+
 import { Content, SideNavColumn } from "components/Documentation/SharedStyles";
 import { LeftNav } from "components/Documentation/LeftNav";
 import { Footer } from "components/Documentation/Footer";
@@ -109,17 +112,27 @@ const ModifiedEl = styled.div`
 
 const SectionEl = styled.section``;
 
-const PageOutlineItem = ({ id, isActive, title }) => (
-  <NavItemEl
-    isActive={isActive}
-    onClick={(e) => {
-      e.preventDefault();
-      smoothScrollTo(document.getElementById(id));
-    }}
-  >
-    {title}
-  </NavItemEl>
-);
+const PageOutlineItem = ({ id, isActive, title }) => {
+  const { setActiveNode, onNavClick } = React.useContext(
+    SideNavProgressContext,
+  );
+
+  return (
+    <NavItemEl
+      isActive={isActive}
+      onClick={(e) => {
+        e.preventDefault();
+        onNavClick(true);
+        setActiveNode(document.getElementById(id));
+        smoothScrollTo(document.getElementById(id), () => {
+          onNavClick(false);
+        });
+      }}
+    >
+      {title}
+    </NavItemEl>
+  );
+};
 
 const componentMapping = {
   ...components,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11551,7 +11551,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.0.0, memoize-one@^5.1.1:
+memoize-one@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==


### PR DESCRIPTION
[Docs outline active section tracking shows previous section](https://app.asana.com/0/1130719348309291/1175224232695578)
- Unlike /api, /docs was only tracking the headings instead of the sections themselves. Consolidated the flat structure to group sections to track better. This solved a lot of the issues we had with /docs' highlighting bugs
- Added a new state to detect if a user clicks a nav link, highlight that link regardless the position of the content by overwriting it.
- Previously, when a user scrolled up we highlighted the last element in view. After adding a `click and highlight` state, it had an unintended result. See below gif.

With highlighting the last element when scrolling up - after a user clicks `Run an API Server` and scrolls up, it highlights `Software and SDKs` instead of `Run a Core Node`.

Before:
![before-fixing](https://user-images.githubusercontent.com/3912060/82696355-d7254d80-9c34-11ea-9356-6ba0294c54db.gif)

After updating it to highlighting the first shown element instead of the last when scrolling up:
![after-fixing](https://user-images.githubusercontent.com/3912060/82696351-d55b8a00-9c34-11ea-9735-4e7b596a9c1c.gif)

This matches the behavior on our stellar.org's side nav [highlighting](https://www.stellar.org/start).

This doesn't seem to affect /api. But I will double check again.