### PR TITLE
Fix flash of fonts reloading on some interactions

### DIFF
--- a/src/basics/GlobalStyles.js
+++ b/src/basics/GlobalStyles.js
@@ -1,10 +1,11 @@
-import { createGlobalStyle, css } from "styled-components";
+import React from "react";
+import { createGlobalStyle } from "styled-components";
 import styledNormalize from "styled-normalize";
 
 import { FONTS } from "constants/fonts";
 import { FONT_FAMILY } from "constants/styles";
 
-export const GlobalStyles = createGlobalStyle`
+const Styles = createGlobalStyle`
   body,
   html,
   input,
@@ -38,9 +39,10 @@ export const GlobalStyles = createGlobalStyle`
   twitter-widget {
     margin: auto;
   }
+`;
 
-${FONTS.map(
-  (font) => css`
+const fontStyles = FONTS.map(
+  (font) => `
     @font-face {
       font-display: ${font.fontDisplay || "swap"};
       font-family: "${font.fontFamily}";
@@ -52,6 +54,11 @@ ${FONTS.map(
       ${font.unicodeRange && `unicode-range: ${font.unicodeRange};`}
     }
   `,
-)}
-  }
-`;
+).join("");
+
+export const GlobalStyles = () => (
+  <>
+    <style dangerouslySetInnerHTML={{ __html: fontStyles }} />
+    <Styles />
+  </>
+);

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -61,6 +61,7 @@ export const El = styled.div`
     left: 0;
     width: 100%;
     height: 2.5rem;
+    pointer-events: none;
     background: rgb(250, 250, 250);
     background: linear-gradient(
       180deg,
@@ -150,6 +151,7 @@ export const AbsoluteNavFooterEl = styled.div`
     left: 0;
     width: 100%;
     height: 3.125rem;
+    pointer-events: none;
     background: rgb(250, 250, 250);
     background: linear-gradient(
       0deg,


### PR DESCRIPTION
FONTS

We've had persistent issues with fonts. Hopefully this will be the last PR to adjust them. There are some (older) relevant issues to what we've seen, styled-components/styled-components#1593 and gatsbyjs/gatsby#9826. In the past we've had issues with client-side hydration triggering fonts to re-load, this _appears_ now to be a matter of `GlobalStyles` rerendering and thus re-triggering downloads, though I can't find what specifically is triggering it.

By moving font declarations into a plain ol `<style>` tag, we'll hopefully avoid any future problems.