### PR TITLE
Added the latest prettier in order to prettify mdx files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 package.json
-*.mdx

--- a/content/api/introduction/index.mdx
+++ b/content/api/introduction/index.mdx
@@ -7,22 +7,32 @@ import { NavTable } from "components/NavTable";
 
 Horizon is an API for interacting with the Stellar network.
 
-This API serves the bridge between apps and [stellar-core](../../docs/glossary/stellar-core.mdx). Projects like wallets, decentralized exchanges, and asset issuers use Horizon to submit transactions, query an account balance, or stream events like transactions to an account.
+This API serves the bridge between apps and
+[stellar-core](../../docs/glossary/stellar-core.mdx). Projects like wallets,
+decentralized exchanges, and asset issuers use Horizon to submit transactions,
+query an account balance, or stream events like transactions to an account.
 
-Horizon is a [RESTful API](https://en.wikipedia.org/wiki/Representational_state_transfer) and can be accessed via cURL, a browser, or one of the [Stellar SDKs](../../docs/software-and-sdks/overview.mdx). To reduce the complexity of your project, we recommend you use an SDK instead of making direct API calls.
+Horizon is a
+[RESTful API](https://en.wikipedia.org/wiki/Representational_state_transfer) and
+can be accessed via cURL, a browser, or one of the
+[Stellar SDKs](../../docs/software-and-sdks/overview.mdx). To reduce the
+complexity of your project, we recommend you use an SDK instead of making direct
+API calls.
 
 The Stellar Development Foundation (SDF) runs two instances of Horizon:
 
-- [https://horizon.stellar.org/](https://horizon.stellar.org/) for interacting with the public network
-- [https://horizon-testnet.stellar.org/](https://horizon-testnet.stellar.org/) for interacting with the [testnet](../../docs/glossary/testnet.mdx)
+- [https://horizon.stellar.org/](https://horizon.stellar.org/) for interacting
+  with the public network
+- [https://horizon-testnet.stellar.org/](https://horizon-testnet.stellar.org/)
+  for interacting with the [testnet](../../docs/glossary/testnet.mdx)
 
 <NavTable title="API Reference Sections">
 
-|  |  |
-| --- | --- |
-| [Introduction](../introduction/index.mdx) | How Horizon is structured. |
-| [Resources](../resources/index.mdx) | Descriptions of resources and their endpoints. |
-| [Aggregations](../aggregations/index.mdx) | Descriptions of specialized endpoints. |
-| [Errors](../errors/index.mdx) | Potential errors and what they mean. |
+|                                           |                                                |
+| ----------------------------------------- | ---------------------------------------------- |
+| [Introduction](../introduction/index.mdx) | How Horizon is structured.                     |
+| [Resources](../resources/index.mdx)       | Descriptions of resources and their endpoints. |
+| [Aggregations](../aggregations/index.mdx) | Descriptions of specialized endpoints.         |
+| [Errors](../errors/index.mdx)             | Potential errors and what they mean.           |
 
 </NavTable>

--- a/content/api/introduction/pagination/index.mdx
+++ b/content/api/introduction/pagination/index.mdx
@@ -7,11 +7,16 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-To make it possible to explore the millions of records for resources like transactions and operations, Horizon paginates the data it returns for collection-based endpoints.
+To make it possible to explore the millions of records for resources like
+transactions and operations, Horizon paginates the data it returns for
+collection-based endpoints.
 
-Each individual transaction, operation, ledger, etc. is returned as a record, and a group of records is called a collection. Records are returned as an array under the `_embedded` attribute.
+Each individual transaction, operation, ledger, etc. is returned as a record,
+and a group of records is called a collection. Records are returned as an array
+under the `_embedded` attribute.
 
-To move between pages of a collection of records, use the links in the `next` and `prev` attributes nested under the top-level `_links` attribute.
+To move between pages of a collection of records, use the links in the `next`
+and `prev` attributes nested under the top-level `_links` attribute.
 
 <AttributeTable>
 
@@ -26,10 +31,12 @@ To move between pages of a collection of records, use the links in the `next` an
       - An `href` key with a link to the response itself as the value.
     - \_links.next
       - array
-      - An `href` key with a link to the next page for this endpoint as the value.
+      - An `href` key with a link to the next page for this endpoint as the
+        value.
     - \_links.prev
       - array
-      - An `href` key with a link to the next page for this endpoint as the value.
+      - An `href` key with a link to the next page for this endpoint as the
+        value.
 - \_embedded
   - array
   - An `href` key with a link to the next page for this endpoint as the value.
@@ -42,24 +49,24 @@ To move between pages of a collection of records, use the links in the `next` an
 <CodeExample title="Example Request">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.transactions()
-.call()
-.then(function(resp) {
-  // page 1
-  console.log(resp)
-  return resp.next()
-})
-.then(function(resp) {
-  // page 2
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .transactions()
+  .call()
+  .then(function (resp) {
+    // page 1
+    console.log(resp);
+    return resp.next();
+  })
+  .then(function (resp) {
+    // page 2
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/introduction/pagination/page-arguments.mdx
+++ b/content/api/introduction/pagination/page-arguments.mdx
@@ -23,13 +23,18 @@ import { CodeExample } from "components/CodeExample";
   - DESCRIPTION
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -40,22 +45,22 @@ curl "https://horizon.stellar.org/ledgers/26478723/operations?cursor=11372524932
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.operations()
-.forLedger('26478723')
-.cursor('113725249324879872')
-.limit(5)
-.order('asc')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .operations()
+  .forLedger("26478723")
+  .cursor("113725249324879872")
+  .limit(5)
+  .order("asc")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/introduction/rate-limiting.mdx
+++ b/content/api/introduction/rate-limiting.mdx
@@ -3,6 +3,8 @@ title: Rate Limiting
 order: 40
 ---
 
-Horizon rate limits on a per-IP-address basis. By default, a client is limited to 3600 requests per hour - one request per second on average.
+Horizon rate limits on a per-IP-address basis. By default, a client is limited
+to 3600 requests per hour - one request per second on average.
 
-While streaming, each update of the stream counts as a request and against a client’s allotted rate limit.
+While streaming, each update of the stream counts as a request and against a
+client’s allotted rate limit.

--- a/content/api/introduction/response-format.mdx
+++ b/content/api/introduction/response-format.mdx
@@ -6,16 +6,24 @@ order: 10
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Horizon delivers responses as JSON objects formatted according to [HAL](https://en.wikipedia.org/wiki/Hypertext_Application_Language). The HAL format makes Horizon more explorable, paginates responses, and connects parent and child resources. Consuming this format is simple using one of the many [open source libraries available](https://github.com/mikekelly/hal_specification/wiki/Libraries) for most major programming languages.
+Horizon delivers responses as JSON objects formatted according to
+[HAL](https://en.wikipedia.org/wiki/Hypertext_Application_Language). The HAL
+format makes Horizon more explorable, paginates responses, and connects parent
+and child resources. Consuming this format is simple using one of the many
+[open source libraries available](https://github.com/mikekelly/hal_specification/wiki/Libraries)
+for most major programming languages.
 
 HAL is just JSON with two reserved attribute names:
 
 - `_links`
 - `_embedded`
 
-If a response is a single record, the `_links` section will provide links to any parent or child records, and there will be no `_embedded` property.
+If a response is a single record, the `_links` section will provide links to any
+parent or child records, and there will be no `_embedded` property.
 
-If a response is a collection, the `_links` section will provide [pagination](./pagination/index.mdx) links, and the response’s list of records will be nested underneath the `_embedded` property.
+If a response is a collection, the `_links` section will provide
+[pagination](./pagination/index.mdx) links, and the response’s list of records
+will be nested underneath the `_embedded` property.
 
 <AttributeTable>
 
@@ -27,7 +35,8 @@ If a response is a collection, the `_links` section will provide [pagination](./
   - Provides links for navigating to other pages or to parents and children.
 - \_embedded
   - array
-  - Present when querying an endpoint that responds with a collection of records.
+  - Present when querying an endpoint that responds with a collection of
+    records.
 
 </AttributeTable>
  

--- a/content/api/introduction/streaming.mdx
+++ b/content/api/introduction/streaming.mdx
@@ -5,11 +5,19 @@ order: 30
 
 import { NavTable } from "components/NavTable";
 
-Horizon provides a streaming mechanism for receiving events in near real time. Instead of repeatedly sending requests to Horizon for batch updates, a connection is established between a client and Horizon with updates to an endpoint response streaming as new ledgers close and updates occur.
+Horizon provides a streaming mechanism for receiving events in near real time.
+Instead of repeatedly sending requests to Horizon for batch updates, a
+connection is established between a client and Horizon with updates to an
+endpoint response streaming as new ledgers close and updates occur.
 
-This reduces requests that return no data and allows near instantaneous updates client-side.
+This reduces requests that return no data and allows near instantaneous updates
+client-side.
 
-All attributes for the endpoints that allow streaming are the same as regular responses. A caller can initiate streaming by setting ‘Accept: text/event-stream’ in the HTTP header when making the request. Study an example of using streaming in the [Follow Received Payments tutorial](../../docs/tutorials/follow-received-payments.mdx).
+All attributes for the endpoints that allow streaming are the same as regular
+responses. A caller can initiate streaming by setting ‘Accept:
+text/event-stream’ in the HTTP header when making the request. Study an example
+of using streaming in the
+[Follow Received Payments tutorial](../../docs/tutorials/follow-received-payments.mdx).
 
 <NavTable title="Endpoints with Streaming">
 

--- a/content/api/introduction/xdr.mdx
+++ b/content/api/introduction/xdr.mdx
@@ -6,15 +6,25 @@ order: 50
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-In the Stellar network, transactions are encoded using a standardized protocol called [External Data Representation](https://en.wikipedia.org/wiki/External_Data_Representation) (XDR).
+In the Stellar network, transactions are encoded using a standardized protocol
+called
+[External Data Representation](https://en.wikipedia.org/wiki/External_Data_Representation)
+(XDR).
 
-In Horizon, you will only encounter XDR when [posting](../resources/transactions/post.mdx) and [getting](../resources/transactions/retrieve.mdx) transactions and in the [ledger](../resources/ledgers/retrieve.mdx) header.
+In Horizon, you will only encounter XDR when
+[posting](../resources/transactions/post.mdx) and
+[getting](../resources/transactions/retrieve.mdx) transactions and in the
+[ledger](../resources/ledgers/retrieve.mdx) header.
 
-When you post a transaction, a client will encode the transaction as XDR before submitting it to Horizon.
+When you post a transaction, a client will encode the transaction as XDR before
+submitting it to Horizon.
 
-When you request a transaction, Horizon returns some data about the transaction in human-readable JSON. The full canonical data about the transaction is encoded in machine-readable XDR, available in XDR attributes at the end of the response.
+When you request a transaction, Horizon returns some data about the transaction
+in human-readable JSON. The full canonical data about the transaction is encoded
+in machine-readable XDR, available in XDR attributes at the end of the response.
 
-You can decode this XDR in the Stellar Laboratory’s [XDR Viewer](https://www.stellar.org/laboratory#xdr-viewer).
+You can decode this XDR in the Stellar Laboratory’s
+[XDR Viewer](https://www.stellar.org/laboratory#xdr-viewer).
 
 <AttributeTable>
 

--- a/content/api/resources/accounts/data.mdx
+++ b/content/api/resources/accounts/data.mdx
@@ -12,8 +12,8 @@ This endpoint represents a single data for a given account.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                 |
+| --- | ------------------------------- |
 | GET | /accounts/:account_id/data/:key |
 
 </Endpoint>
@@ -39,20 +39,20 @@ curl "https://horizon.stellar.org/accounts/GCAXBKU3AKYJPLQ6PEJ6L47KOATCYCBJ2NFRG
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.loadAccount('GCAXBKU3AKYJPLQ6PEJ6L47KOATCYCBJ2NFRGAK7FUUA2DCEUC265SU2')
-.then(function(account) {
-  return account.data({key: 'config.memo_required'})
-})
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .loadAccount("GCAXBKU3AKYJPLQ6PEJ6L47KOATCYCBJ2NFRGAK7FUUA2DCEUC265SU2")
+  .then(function (account) {
+    return account.data({ key: "config.memo_required" });
+  })
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/accounts/effects.mdx
+++ b/content/api/resources/accounts/effects.mdx
@@ -8,14 +8,19 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint returns the effects of a specific account and can be used in streaming mode.
+This endpoint returns the effects of a specific account and can be used in
+streaming mode.
 
-Streaming mode allows you to listen for new effects for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known effect unless a `cursor` is set, in which case it will start from that `cursor`. By setting the `cursor` value to `now`, you can stream effects created since your request time.
+Streaming mode allows you to listen for new effects for this account as they are
+added to the Stellar ledger. If called in streaming mode, Horizon will start at
+the earliest known effect unless a `cursor` is set, in which case it will start
+from that `cursor`. By setting the `cursor` value to `now`, you can stream
+effects created since your request time.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                    |
+| --- | ---------------------------------------------------------------------------------- |
 | GET | /accounts/:account_id/effects?cursor={paging_token}&order={asc,desc}&limit={1-200} |
 
 </Endpoint>
@@ -30,13 +35,18 @@ Streaming mode allows you to listen for new effects for this account as they are
   - This account's public key encoded in a base32 string representation.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -47,19 +57,19 @@ curl "https://horizon.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPN
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.effects()
-.forAccount('GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .effects()
+  .forAccount("GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -191,18 +201,18 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.effects()
-.forAccount('GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE')
-.cursor('now')
-.stream({onmessage: callback})
+  .effects()
+  .forAccount("GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE")
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/accounts/index.mdx
+++ b/content/api/resources/accounts/index.mdx
@@ -5,21 +5,23 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-Users interact with the Stellar network through accounts. Everything else in the ledger—assets, offers, trustlines, etc.—are owned by accounts, and accounts must authorize all changes to the ledger through signed transactions.
+Users interact with the Stellar network through accounts. Everything else in the
+ledger—assets, offers, trustlines, etc.—are owned by accounts, and accounts must
+authorize all changes to the ledger through signed transactions.
 
 Learn more about [accounts](../../../docs/glossary/accounts.mdx).
 
 <EndpointsTable title="Endpoints">
 
-|     |                                                           |
-| --- | --------------------------------------------------------- |
-| GET | [/accounts/:account_id](./single.mdx)                     |
-| GET | [/accounts/:account_id/transactions](./transactions.mdx)  |
-| GET | [/accounts/:account_id/operations](./operations.mdx)      |
-| GET | [/accounts/:account_id/payments](./payments.mdx)          |
-| GET | [/accounts/:account_id/effects](./effects.mdx)            |
-| GET | [/accounts/:account_id/offers](./offers.mdx)              |
-| GET | [/accounts/:account_id/trades](./trades.mdx)              |
-| GET | [/accounts/:account_id/data](./data.mdx)                  |
+|     |                                                          |
+| --- | -------------------------------------------------------- |
+| GET | [/accounts/:account_id](./single.mdx)                    |
+| GET | [/accounts/:account_id/transactions](./transactions.mdx) |
+| GET | [/accounts/:account_id/operations](./operations.mdx)     |
+| GET | [/accounts/:account_id/payments](./payments.mdx)         |
+| GET | [/accounts/:account_id/effects](./effects.mdx)           |
+| GET | [/accounts/:account_id/offers](./offers.mdx)             |
+| GET | [/accounts/:account_id/trades](./trades.mdx)             |
+| GET | [/accounts/:account_id/data](./data.mdx)                 |
 
 </EndpointsTable>

--- a/content/api/resources/accounts/offers.mdx
+++ b/content/api/resources/accounts/offers.mdx
@@ -8,14 +8,19 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint represents all offers a given account has currently open and can be used in streaming mode.
+This endpoint represents all offers a given account has currently open and can
+be used in streaming mode.
 
-Streaming mode allows you to listen for new offers for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known offer unless a `cursor` is set, in which case it will start from that `cursor`. By setting the `cursor` value to `now`, you can stream offers created since your request time.
+Streaming mode allows you to listen for new offers for this account as they are
+added to the Stellar ledger. If called in streaming mode, Horizon will start at
+the earliest known offer unless a `cursor` is set, in which case it will start
+from that `cursor`. By setting the `cursor` value to `now`, you can stream
+offers created since your request time.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                   |
+| --- | --------------------------------------------------------------------------------- |
 | GET | /accounts/:account_id/offers?cursor={paging_token}&order={asc,desc}&limit={1-200} |
 
 </Endpoint>
@@ -30,13 +35,18 @@ Streaming mode allows you to listen for new offers for this account as they are 
   - This account's public key encoded in a base32 string representation.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -47,19 +57,19 @@ curl "https://horizon.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUE
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.offers()
-.forAccount('GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .offers()
+  .forAccount("GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -149,18 +159,18 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.offers()
-.forAccount('GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K')
-.cursor('now')
-.stream({onmessage: callback})
+  .offers()
+  .forAccount("GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K")
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/accounts/operations.mdx
+++ b/content/api/resources/accounts/operations.mdx
@@ -8,14 +8,19 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint represents successful operations for a given account and can be used in streaming mode.
+This endpoint represents successful operations for a given account and can be
+used in streaming mode.
 
-Streaming mode allows you to listen for new operations for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a `cursor` is set, in which case it will start from that `cursor`. By setting the `cursor` value to `now`, you can stream operations created since your request time.
+Streaming mode allows you to listen for new operations for this account as they
+are added to the Stellar ledger. If called in streaming mode, Horizon will start
+at the earliest known operation unless a `cursor` is set, in which case it will
+start from that `cursor`. By setting the `cursor` value to `now`, you can stream
+operations created since your request time.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                                                                      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | GET | /accounts/:account_id/operations?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false}&join={transactions} |
 
 </Endpoint>
@@ -30,19 +35,26 @@ Streaming mode allows you to listen for new operations for this account as they 
   - This account's public key encoded in a base32 string representation.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed operations in results. Options include `true` and `false`.
+  - Set to true to include failed operations in results. Options include `true`
+    and `false`.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the operations in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    operations in the response.
 
 </AttributeTable>
 
@@ -53,19 +65,19 @@ curl "https://horizon.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW3
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.operations()
-.forAccount('GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .operations()
+  .forAccount("GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -191,18 +203,18 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.operations()
-.forAccount('GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA')
-.cursor('now')
-.stream({onmessage: callback})
+  .operations()
+  .forAccount("GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA")
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/accounts/payments.mdx
+++ b/content/api/resources/accounts/payments.mdx
@@ -8,14 +8,19 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint represents successful payments for a given account and can be used in streaming mode.
+This endpoint represents successful payments for a given account and can be used
+in streaming mode.
 
-Streaming mode allows you to listen for new payments for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known payment unless a `cursor` is set, in which case it will start from that `cursor`. By setting the `cursor` value to `now`, you can stream payments created since your request time.
+Streaming mode allows you to listen for new payments for this account as they
+are added to the Stellar ledger. If called in streaming mode, Horizon will start
+at the earliest known payment unless a `cursor` is set, in which case it will
+start from that `cursor`. By setting the `cursor` value to `now`, you can stream
+payments created since your request time.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                                                                    |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | GET | /accounts/:account_id/payments?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false}&join={transactions} |
 
 </Endpoint>
@@ -30,19 +35,26 @@ Streaming mode allows you to listen for new payments for this account as they ar
   - This account's public key encoded in a base32 string representation.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed operations in results. Options include `true` and `false`.
+  - Set to true to include failed operations in results. Options include `true`
+    and `false`.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the operations in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    operations in the response.
 
 </AttributeTable>
 
@@ -53,19 +65,19 @@ curl "https://horizon.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPN
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.payments()
-.forAccount('GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .payments()
+  .forAccount("GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -251,18 +263,18 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.payments()
-.forAccount('GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE')
-.cursor('now')
-.stream({onmessage: callback})
+  .payments()
+  .forAccount("GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE")
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/accounts/single.mdx
+++ b/content/api/resources/accounts/single.mdx
@@ -10,12 +10,16 @@ import { AttributeTable } from "components/AttributeTable";
 
 The single account endpoint provides information on a specific account.
 
-The balances section in the response will also list all the trustlines this account has established. Note this will only return trustlines that have the necessary authorization to work. If an account `A` trusts another account `B` that has the authorization required flag set, the trustline won’t show up until account `B` allows account `A` to hold its assets.
+The balances section in the response will also list all the trustlines this
+account has established. Note this will only return trustlines that have the
+necessary authorization to work. If an account `A` trusts another account `B`
+that has the authorization required flag set, the trustline won’t show up until
+account `B` allows account `A` to hold its assets.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                       |
+| --- | --------------------- |
 | GET | /accounts/:account_id |
 
 </Endpoint>
@@ -38,17 +42,17 @@ curl "https://horizon.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW3
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.loadAccount('GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA')
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .loadAccount("GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA")
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/accounts/trades.mdx
+++ b/content/api/resources/accounts/trades.mdx
@@ -8,14 +8,19 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint represents all trades for a given account and can be used in streaming mode.
+This endpoint represents all trades for a given account and can be used in
+streaming mode.
 
-Streaming mode allows you to listen for trades for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known trade unless a `cursor` is set, in which case it will start from that `cursor`. By setting the `cursor` value to `now`, you can stream trades created since your request time.
+Streaming mode allows you to listen for trades for this account as they are
+added to the Stellar ledger. If called in streaming mode, Horizon will start at
+the earliest known trade unless a `cursor` is set, in which case it will start
+from that `cursor`. By setting the `cursor` value to `now`, you can stream
+trades created since your request time.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                   |
+| --- | --------------------------------------------------------------------------------- |
 | GET | /accounts/:account_id/trades?cursor={paging_token}&order={asc,desc}&limit={1-200} |
 
 </Endpoint>
@@ -30,13 +35,18 @@ Streaming mode allows you to listen for trades for this account as they are adde
   - This account's public key encoded in a base32 string representation.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -47,19 +57,19 @@ curl "https://horizon.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUE
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.trades()
-.forAccount('GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .trades()
+  .forAccount("GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -196,18 +206,18 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.trades()
-.forAccount('GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K')
-.cursor('now')
-.stream({onmessage: callback})
+  .trades()
+  .forAccount("GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K")
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/accounts/transactions.mdx
+++ b/content/api/resources/accounts/transactions.mdx
@@ -8,14 +8,19 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint represents successful transactions for a given account and can be used in streaming mode.
+This endpoint represents successful transactions for a given account and can be
+used in streaming mode.
 
-Streaming mode allows you to listen for new transactions for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known transaction unless a `cursor` is set, in which case it will start from that `cursor`. By setting the `cursor` value to `now`, you can stream transactions created since your request time.
+Streaming mode allows you to listen for new transactions for this account as
+they are added to the Stellar ledger. If called in streaming mode, Horizon will
+start at the earliest known transaction unless a `cursor` is set, in which case
+it will start from that `cursor`. By setting the `cursor` value to `now`, you
+can stream transactions created since your request time.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------ |
 | GET | /accounts/:account_id/transactions?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false} |
 
 </Endpoint>
@@ -30,16 +35,22 @@ Streaming mode allows you to listen for new transactions for this account as the
   - This account's public key encoded in a base32 string representation.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed transactions in results. Options include `true` and `false`.
+  - Set to true to include failed transactions in results. Options include
+    `true` and `false`.
 
 </AttributeTable>
 
@@ -50,19 +61,19 @@ curl "https://horizon.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW3
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.transactions()
-.forAccount('GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .transactions()
+  .forAccount("GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -193,18 +204,18 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.transactions()
-.forAccount('GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA')
-.cursor('now')
-.stream({onmessage: callback})
+  .transactions()
+  .forAccount("GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA")
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/assets/index.mdx
+++ b/content/api/resources/assets/index.mdx
@@ -5,14 +5,15 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-Assets are representations of value issued on the Stellar network. An asset consists of a type, code, and issuer.
+Assets are representations of value issued on the Stellar network. An asset
+consists of a type, code, and issuer.
 
 Learn more about [assets](../../../docs/glossary/assets.mdx).
 
 <EndpointsTable title="Endpoints">
 
-|     |                                    |
-| --- | ---------------------------------- |
-| GET | [/assets](./list.mdx)              |
+|     |                       |
+| --- | --------------------- |
+| GET | [/assets](./list.mdx) |
 
 </EndpointsTable>

--- a/content/api/resources/assets/list.mdx
+++ b/content/api/resources/assets/list.mdx
@@ -12,8 +12,8 @@ This endpoint lists all assets.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                                                                                                                                            |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | GET | /assets?asset_code{:asset_code}&asset_issuer={:account_id}&cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false} |
 
 </Endpoint>
@@ -31,13 +31,18 @@ This endpoint lists all assets.
   - The Stellar address of the issuer for the asset you would like to filter by.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -48,19 +53,19 @@ curl "https://horizon.stellar.org/assets?asset_code=CNY&limit=3"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.assets()
-.forCode('CNY')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .assets()
+  .forCode("CNY")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -146,18 +151,18 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.assets()
-.forCode('CNY')
-.cursor('now')
-.stream({onmessage: callback})
+  .assets()
+  .forCode("CNY")
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/assets/object.mdx
+++ b/content/api/resources/assets/object.mdx
@@ -27,7 +27,10 @@ When Horizon returns information about an asset, it uses the following format:
   - The number of units issued for this asset.
 - num_accounts
   - number
-  - The numnber of accounts that have issued a trustline to this asset. If the `auth_required` flag for this asset's issuer is set to `true`, this number only includes the accounts who have both set up a trustline to the asset and have been authorized to hold the asset.
+  - The numnber of accounts that have issued a trustline to this asset. If the
+    `auth_required` flag for this asset's issuer is set to `true`, this number
+    only includes the accounts who have both set up a trustline to the asset and
+    have been authorized to hold the asset.
 - flags
   - object
   - Flags denote the enabling/disabling of certain asset issuer privileges.
@@ -36,13 +39,16 @@ When Horizon returns information about an asset, it uses the following format:
       - If set to `true`, none of the following flags can be changed.
     - auth_required
       - boolean
-      - If set to `true`, anyone who wants to hold an asset issued by this account must first be approved by this account.
+      - If set to `true`, anyone who wants to hold an asset issued by this
+        account must first be approved by this account.
     - auth_revocable
       - boolean
-      - If set to `true`, this account can freeze the balance of a holder of an asset issued by this account.
+      - If set to `true`, this account can freeze the balance of a holder of an
+        asset issued by this account.
 - paging_token
   - number
-  - A cursor value for use in [pagination](../../introduction/pagination/index.mdx).
+  - A cursor value for use in
+    [pagination](../../introduction/pagination/index.mdx).
 
 </AttributeTable>
 

--- a/content/api/resources/effects/index.mdx
+++ b/content/api/resources/effects/index.mdx
@@ -5,14 +5,16 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-Effects represent specific changes that occur in the ledger as a result of successful operations, but are not necessarily directly reflected in the ledger or history, as transactions and operations are.
+Effects represent specific changes that occur in the ledger as a result of
+successful operations, but are not necessarily directly reflected in the ledger
+or history, as transactions and operations are.
 
 Learn more about [effects](../../../docs/glossary/effects.mdx).
 
 <EndpointsTable title="Endpoints">
 
-|     |                                    |
-| --- | ---------------------------------- |
-| GET | [/effects](./list.mdx)              |
+|     |                        |
+| --- | ---------------------- |
+| GET | [/effects](./list.mdx) |
 
 </EndpointsTable>

--- a/content/api/resources/effects/list.mdx
+++ b/content/api/resources/effects/list.mdx
@@ -8,12 +8,17 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all effects and can be used in [streaming](../../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new effects as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known effect unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream effects created since your request time.
+This endpoint lists all effects and can be used in
+[streaming](../../introduction/streaming.mdx) mode. Streaming mode allows you to
+listen for new effects as they are added to the Stellar ledger. If called in
+streaming mode, Horizon will start at the earliest known effect unless a
+`cursor` is set, in which case it will start from that `cursor`. By setting the
+cursor value to `now`, you can stream effects created since your request time.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                                                               |
+| --- | ------------------------------------------------------------- |
 | GET | /effects?cursor={paging_token}&order={asc,desc}&limit={1-200} |
 
 </Endpoint>
@@ -25,13 +30,18 @@ This endpoint lists all effects and can be used in [streaming](../../introductio
   - DESCRIPTION
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -42,18 +52,19 @@ curl "https://horizon.stellar.org/effects"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk');
-var server = new StellarSdk.Server('https://horizon.stellar.org');
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-server.effects()
+server
+  .effects()
   .call()
   .then(function (effectResults) {
     //page 1
-    console.log(effectResults.records)
+    console.log(effectResults.records);
   })
   .catch(function (err) {
-    console.log(err)
-  })
+    console.log(err);
+  });
 ```
 
 </CodeExample>
@@ -148,18 +159,16 @@ server.effects()
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
 
 var effectHandler = function (effectResponse) {
   console.log(effectResponse);
 };
 
-var es = server.effects()
-  .cursor('now')
-  .stream({
-    onmessage: effectHandler
-  })
+var es = server.effects().cursor("now").stream({
+  onmessage: effectHandler,
+});
 ```
 
 </CodeExample>

--- a/content/api/resources/index.mdx
+++ b/content/api/resources/index.mdx
@@ -5,19 +5,20 @@ order: 0
 
 import { NavTable } from "components/NavTable";
 
-Data on the Stellar ledger is organized according to resources. Each resource has several different endpoints.
+Data on the Stellar ledger is organized according to resources. Each resource
+has several different endpoints.
 
 <NavTable title="Resource Types">
 
-|  |  |
-| --- | --- |
-| [Ledgers](./ledgers/index.mdx) |  |
-| [Transactions](./transactions/index.mdx) |  |
-| [Operations](./operations/index.mdx) |  |
-| [Effects](./effects/index.mdx) |  |
-| [Accounts](./accounts/index.mdx) |  |
-| [Offers](./offers/index.mdx) |  |
-| [Trades](./trades/index.mdx) |  |
-| [Assets](./assets/index.mdx) |  |
+|                                          |     |
+| ---------------------------------------- | --- |
+| [Ledgers](./ledgers/index.mdx)           |     |
+| [Transactions](./transactions/index.mdx) |     |
+| [Operations](./operations/index.mdx)     |     |
+| [Effects](./effects/index.mdx)           |     |
+| [Accounts](./accounts/index.mdx)         |     |
+| [Offers](./offers/index.mdx)             |     |
+| [Trades](./trades/index.mdx)             |     |
+| [Assets](./assets/index.mdx)             |     |
 
 </NavTable>

--- a/content/api/resources/ledgers/index.mdx
+++ b/content/api/resources/ledgers/index.mdx
@@ -5,7 +5,8 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-Each ledger stores the state of the network at a point in time and contains all the changes - transactions, operations, effects, etc. - to that state.
+Each ledger stores the state of the network at a point in time and contains all
+the changes - transactions, operations, effects, etc. - to that state.
 
 Learn more about [ledgers](../../../docs/glossary/ledgers.mdx).
 

--- a/content/api/resources/ledgers/object.mdx
+++ b/content/api/resources/ledgers/object.mdx
@@ -18,16 +18,19 @@ When Horizon returns information about a ledger, it uses the following format:
   - A unique identifier for this ledger.
 - paging_token
   - number
-  - A cursor value for use in [pagination](../../introduction/pagination/index.mdx).
+  - A cursor value for use in
+    [pagination](../../introduction/pagination/index.mdx).
 - hash
   - string
-  - A hex-encoded SHA-256 hash of this ledger’s [XDR](../../../docs/glossary/xdr.mdx)-encoded form.
+  - A hex-encoded SHA-256 hash of this ledger’s
+    [XDR](../../../docs/glossary/xdr.mdx)-encoded form.
 - prev_hash
   - string
   - The hash of the ledger immediately preceding this ledger.
 - sequence
   - number
-  - The sequence number of this ledger, and the parameter used in Horizon calls that require a ledger number.
+  - The sequence number of this ledger, and the parameter used in Horizon calls
+    that require a ledger number.
 - successful_transaction_count
   - number
   - The number of successful transactions in this ledger.
@@ -39,7 +42,8 @@ When Horizon returns information about a ledger, it uses the following format:
   - The number of operations applied in this ledger.
 - closed_at
   - string
-  - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted string of when this ledger was closed.
+  - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted string of
+    when this ledger was closed.
 - total_coins
   - string
   - The total number of lumens in circulation.
@@ -54,13 +58,16 @@ When Horizon returns information about a ledger, it uses the following format:
   - The reserve the network uses when calculating an account’s minimum balance.
 - max_tx_set_size
   - number
-  - The maximum number of transactions validators have agreed to process in a given ledger.
+  - The maximum number of transactions validators have agreed to process in a
+    given ledger.
 - protocol_version
   - number
-  - The protocol version that the Stellar network was running when this ledger was committed.
+  - The protocol version that the Stellar network was running when this ledger
+    was committed.
 - header_xdr
   - string
-  - A base64 encoded string of the raw `LedgerHeader` xdr struct for this ledger.
+  - A base64 encoded string of the raw `LedgerHeader` xdr struct for this
+    ledger.
 
 </AttributeTable>
 

--- a/content/api/resources/ledgers/operations.mdx
+++ b/content/api/resources/ledgers/operations.mdx
@@ -12,8 +12,8 @@ This endpoint returns successful operations in a specific ledger.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                                                                          |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | GET | /ledgers/:ledger_sequence/operations?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false}&join={transactions} |
 
 </Endpoint>
@@ -28,19 +28,26 @@ This endpoint returns successful operations in a specific ledger.
   - The sequence number of a specific ledger.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed operations in results. Options include `true` and `false`.
+  - Set to true to include failed operations in results. Options include `true`
+    and `false`.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the operations in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    operations in the response.
 
 </AttributeTable>
 
@@ -51,19 +58,19 @@ curl "https://horizon.stellar.org/ledgers/27147222/operations?limit=2"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.operations()
-.forLedger('27147222')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .operations()
+  .forLedger("27147222")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/ledgers/payments.mdx
+++ b/content/api/resources/ledgers/payments.mdx
@@ -11,6 +11,7 @@ import { AttributeTable } from "components/AttributeTable";
 This endpoint returns all payment-related operations in a specific ledger.
 
 Operation types that can be returned by this endpoint include:
+
 - `create_account`
 - `payment`
 - `path_payment`
@@ -18,8 +19,8 @@ Operation types that can be returned by this endpoint include:
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                                                                        |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | GET | /ledgers/:ledger_sequence/payments?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false}&join={transactions} |
 
 </Endpoint>
@@ -34,19 +35,26 @@ Operation types that can be returned by this endpoint include:
   - The sequence number of a specific ledger.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed payments in results. Options include `true` and `false`.
+  - Set to true to include failed payments in results. Options include `true`
+    and `false`.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the payments in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    payments in the response.
 
 </AttributeTable>
 
@@ -57,19 +65,19 @@ curl "https://horizon.stellar.org/ledgers/27521176/payments?limit=1"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.payments()
-.forLedger('27521176')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .payments()
+  .forLedger("27521176")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/ledgers/single.mdx
+++ b/content/api/resources/ledgers/single.mdx
@@ -36,19 +36,19 @@ curl "https://horizon.stellar.org/ledgers/69859"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.ledgers()
-.ledger('69858')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .ledgers()
+  .ledger("69858")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/ledgers/transactions.mdx
+++ b/content/api/resources/ledgers/transactions.mdx
@@ -12,8 +12,8 @@ This endpoint represents successful transactions in a given ledger.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                                                        |
+| --- | ---------------------------------------------------------------------------------------------------------------------- |
 | GET | /ledgers/:ledger_sequence/transactions?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false} |
 
 </Endpoint>
@@ -28,16 +28,22 @@ This endpoint represents successful transactions in a given ledger.
   - The sequence number of a specific ledger.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed transactions in results. Options include `true` and `false`.
+  - Set to true to include failed transactions in results. Options include
+    `true` and `false`.
 
 </AttributeTable>
 
@@ -48,19 +54,19 @@ curl "https://horizon.stellar.org/ledgers/27147222/transactions?limit=2"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.transactions()
-.forLedger('27147222')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .transactions()
+  .forLedger("27147222")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/offers/index.mdx
+++ b/content/api/resources/offers/index.mdx
@@ -5,15 +5,16 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-Offers are statements about how much of an asset an account wants to buy or sell.
+Offers are statements about how much of an asset an account wants to buy or
+sell.
 
 Learn more about [offers](../../../docs/glossary/offers.mdx).
 
 <EndpointsTable title="Endpoints">
 
-|     |                                    |
-| --- | ---------------------------------- |
-| GET | [/offers/:offer_id](./single.mdx)  |
-| GET | [/offers](./list.mdx)              |
+|     |                                   |
+| --- | --------------------------------- |
+| GET | [/offers/:offer_id](./single.mdx) |
+| GET | [/offers](./list.mdx)             |
 
 </EndpointsTable>

--- a/content/api/resources/offers/list.mdx
+++ b/content/api/resources/offers/list.mdx
@@ -8,16 +8,24 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all currently open offers and can be used in [streaming](../introduction/streaming.mdx) mode.
+This endpoint lists all currently open offers and can be used in
+[streaming](../introduction/streaming.mdx) mode.
 
-Streaming mode allows you to listen for new offers as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known offer unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream offers created since your request time.
+Streaming mode allows you to listen for new offers as they are added to the
+Stellar ledger. If called in streaming mode, Horizon will start at the earliest
+known offer unless a `cursor` is set, in which case it will start from that
+`cursor`. By setting the cursor value to `now`, you can stream offers created
+since your request time.
 
-When filtering by buying or selling arguments, you must use a combination of `selling_asset_type`, `selling_asset_issuer`, and `selling_asset_code` for the selling asset, or a combination of `buying_asset_type`, `buying_asset_issuer`, and `buying_asset_code` for the buying asset.
+When filtering by buying or selling arguments, you must use a combination of
+`selling_asset_type`, `selling_asset_issuer`, and `selling_asset_code` for the
+selling asset, or a combination of `buying_asset_type`, `buying_asset_issuer`,
+and `buying_asset_code` for the buying asset.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                                                                                                                                                                                                                                                                                                                                                                               |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GET | /offers?seller={:account_id}&selling_asset_type={native,credit_alphanum4,credit_alphanum12}&selling_asset_issuer={:account_id}&selling_asset_code{:asset_code}&buying_asset_type={native,credit_alphanum4,credit_alphanum12}&buying_asset_issuer={:account_id}&buying_asset_code{:asset_code}&cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false} |
 
 </Endpoint>
@@ -32,7 +40,8 @@ When filtering by buying or selling arguments, you must use a combination of `se
   - The account ID of the offer creator.
 - selling_asset_type
   - optional
-  - The type for the selling asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the selling asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - selling_asset_issuer
   - optional
   - The Stellar address of the selling asset’s issuer.
@@ -41,7 +50,8 @@ When filtering by buying or selling arguments, you must use a combination of `se
   - The code for the selling asset.
 - buying_asset_type
   - optional
-  - The type for the buying asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the buying asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - buying_asset_issuer
   - optional
   - The Stellar address of the buying asset’s issuer.
@@ -50,13 +60,18 @@ When filtering by buying or selling arguments, you must use a combination of `se
   - The code for the buying asset.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -67,19 +82,24 @@ curl "https://horizon.stellar.org/offers?selling_asset_type=credit_alphanum4&sel
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.offers()
-.selling(new StellarSdk.Asset('USD', 'GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX'))
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .offers()
+  .selling(
+    new StellarSdk.Asset(
+      "USD",
+      "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+    ),
+  )
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -204,18 +224,23 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.offers()
-.selling(new StellarSdk.Asset('USD', 'GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX'))
-.cursor('now')
-.stream({onmessage: callback})
+  .offers()
+  .selling(
+    new StellarSdk.Asset(
+      "USD",
+      "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+    ),
+  )
+  .cursor("now")
+  .stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/offers/object.mdx
+++ b/content/api/resources/offers/object.mdx
@@ -18,7 +18,8 @@ When Horizon returns information about an offer, it uses the following format:
   - A unique identifier for this offer.
 - paging_token
   - number
-  - A cursor value for use in [pagination](../../introduction/pagination/index.mdx).
+  - A cursor value for use in
+    [pagination](../../introduction/pagination/index.mdx).
 - seller
   - string
   - The account ID of the account making this offer.
@@ -30,7 +31,8 @@ When Horizon returns information about an offer, it uses the following format:
   - The asset this offer wants to buy.
 - amount
   - string
-  - The amount of `selling` that the account making this offer is willing to sell.
+  - The amount of `selling` that the account making this offer is willing to
+    sell.
 - price_r
   - object
   - A precise representation of the buy and sell price of the assets on offer.
@@ -42,7 +44,8 @@ When Horizon returns information about an offer, it uses the following format:
       - The denominator.
 - price
   - string
-  - How many units of `buying` it takes to get 1 unit of `selling`. A number representing the decimal form of `price_r`.
+  - How many units of `buying` it takes to get 1 unit of `selling`. A number
+    representing the decimal form of `price_r`.
 - last_modified_ledger
   - integer
   - The sequence number of the last ledger in which this offer was modified.

--- a/content/api/resources/offers/single.mdx
+++ b/content/api/resources/offers/single.mdx
@@ -36,19 +36,19 @@ curl "https://horizon.stellar.org/offers/165563085"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.offers()
-.offer('165563085')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .offers()
+  .offer("165563085")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/operations/effects.mdx
+++ b/content/api/resources/operations/effects.mdx
@@ -12,8 +12,8 @@ This endpoint returns the effects of a specific operation.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                        |
+| --- | -------------------------------------------------------------------------------------- |
 | GET | /operations/:operation_id/effects?cursor={paging_token}&order={asc,desc}&limit={1-200} |
 
 </Endpoint>
@@ -28,13 +28,18 @@ This endpoint returns the effects of a specific operation.
   - The ID number for this operation.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -45,19 +50,19 @@ curl "https://horizon.stellar.org/operations/121693057904021505/effects"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.effects()
-.forOperation('121693057904021505')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .effects()
+  .forOperation("121693057904021505")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/operations/index.mdx
+++ b/content/api/resources/operations/index.mdx
@@ -5,17 +5,19 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-Operations are objects that represent a desired change to the ledger: payments, offers to exchange currency, changes made to account options, etc. Operations are submitted to the Stellar network grouped in a Transaction.
+Operations are objects that represent a desired change to the ledger: payments,
+offers to exchange currency, changes made to account options, etc. Operations
+are submitted to the Stellar network grouped in a Transaction.
 
 Each of Stellar’s operations have a unique operation object.
 
 <EndpointsTable title="Endpoints">
 
-|     |                                                               |
-| --- | ------------------------------------------------------------- |
-| GET | [/operations/:operation_id](./single.mdx)                 |
-| GET | [/operations/:operation_id/effects](./effects.mdx)        |
-| GET | [/operations](./list.mdx)                                   |
-| GET | [/payments](./list-payments.mdx)                                   |
+|     |                                                    |
+| --- | -------------------------------------------------- |
+| GET | [/operations/:operation_id](./single.mdx)          |
+| GET | [/operations/:operation_id/effects](./effects.mdx) |
+| GET | [/operations](./list.mdx)                          |
+| GET | [/payments](./list-payments.mdx)                   |
 
 </EndpointsTable>

--- a/content/api/resources/operations/list-payments.mdx
+++ b/content/api/resources/operations/list-payments.mdx
@@ -8,9 +8,15 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all successful payment-related operations and can be used in [streaming](../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new payments as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known payment unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream payments created since your request time.
+This endpoint lists all successful payment-related operations and can be used in
+[streaming](../introduction/streaming.mdx) mode. Streaming mode allows you to
+listen for new payments as they are added to the Stellar ledger. If called in
+streaming mode, Horizon will start at the earliest known payment unless a
+`cursor` is set, in which case it will start from that `cursor`. By setting the
+cursor value to `now`, you can stream payments created since your request time.
 
 Operations that can be returned by this endpoint include:
+
 - `create_account`
 - `payment`
 - `path_payment`
@@ -18,8 +24,8 @@ Operations that can be returned by this endpoint include:
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                                                                                                                |
+| --- | -------------------------------------------------------------------------------------------------------------- |
 | GET | /payments?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed={true,false}&join={transactions] |
 
 </Endpoint>
@@ -31,19 +37,26 @@ Operations that can be returned by this endpoint include:
   - DESCRIPTION
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The maximum number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The maximum number of records returned. The limit can range from 1 to 200 -
+    an upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed operations in results. Options include `true` and `false`.
+  - Set to true to include failed operations in results. Options include `true`
+    and `false`.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the operations in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    operations in the response.
 
 </AttributeTable>
 
@@ -54,18 +67,18 @@ curl "https://horizon.stellar.org/payments?limit=3"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.payments()
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .payments()
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -188,17 +201,14 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
-var es = server
-.payments()
-.cursor('now')
-.stream({onmessage: callback})
+var es = server.payments().cursor("now").stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/operations/list.mdx
+++ b/content/api/resources/operations/list.mdx
@@ -8,12 +8,18 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all successful operations and can be used in [streaming](../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new operations as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream operations created since your request time.
+This endpoint lists all successful operations and can be used in
+[streaming](../introduction/streaming.mdx) mode. Streaming mode allows you to
+listen for new operations as they are added to the Stellar ledger. If called in
+streaming mode, Horizon will start at the earliest known operation unless a
+`cursor` is set, in which case it will start from that `cursor`. By setting the
+cursor value to `now`, you can stream operations created since your request
+time.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                                                                                                                  |
+| --- | ---------------------------------------------------------------------------------------------------------------- |
 | GET | /operations?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed={true,false}&join={transactions] |
 
 </Endpoint>
@@ -25,19 +31,26 @@ This endpoint lists all successful operations and can be used in [streaming](../
   - DESCRIPTION
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The maximum number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The maximum number of records returned. The limit can range from 1 to 200 -
+    an upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed operations in results. Options include `true` and `false`.
+  - Set to true to include failed operations in results. Options include `true`
+    and `false`.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the operations in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    operations in the response.
 
 </AttributeTable>
 
@@ -48,18 +61,18 @@ curl "https://horizon.stellar.org/operations?limit=3"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.operations()
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .operations()
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -180,17 +193,14 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var callback = function(resp) {
-  console.log(resp)
-}
+var callback = function (resp) {
+  console.log(resp);
+};
 
-var es = server
-.operations()
-.cursor('now')
-.stream({onmessage: callback})
+var es = server.operations().cursor("now").stream({ onmessage: callback });
 ```
 
 </CodeExample>

--- a/content/api/resources/operations/object/account-merge.mdx
+++ b/content/api/resources/operations/object/account-merge.mdx
@@ -6,9 +6,11 @@ order: 110
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Removes the source account from the Stellar and transfers the source account's lumens to another account.
+Removes the source account from the Stellar and transfers the source account's
+lumens to another account.
 
-See the [`Account Merge` errors](../../../errors/result-codes/operation-specific/account-merge.mdx).
+See the
+[`Account Merge` errors](../../../errors/result-codes/operation-specific/account-merge.mdx).
 
 <AttributeTable>
 

--- a/content/api/resources/operations/object/allow-trust.mdx
+++ b/content/api/resources/operations/object/allow-trust.mdx
@@ -6,9 +6,11 @@ order: 100
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Updates the “authorized” flag of an existing trust line. This must be called by the issuer of the asset.
+Updates the “authorized” flag of an existing trust line. This must be called by
+the issuer of the asset.
 
-See the [`Allow Trust` errors](../../../errors/result-codes/operation-specific/allow-trust.mdx).
+See the
+[`Allow Trust` errors](../../../errors/result-codes/operation-specific/allow-trust.mdx).
 
 <AttributeTable>
 
@@ -17,13 +19,14 @@ See the [`Allow Trust` errors](../../../errors/result-codes/operation-specific/a
   - DESCRIPTION
 - asset_type
   - string
-  - The type of asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type of asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - asset_code
   - string
   - The Stellar address of the asset.
 - asset_issuer
   - string
-  - The code for the asset. 
+  - The code for the asset.
 - authorize
   - boolean
   - Allows or disallows trust.

--- a/content/api/resources/operations/object/bump-sequence.mdx
+++ b/content/api/resources/operations/object/bump-sequence.mdx
@@ -6,9 +6,11 @@ order: 130
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Bumps forward the sequence number of the source account, allowing it to invalidate any transactions with a smaller sequence number.
+Bumps forward the sequence number of the source account, allowing it to
+invalidate any transactions with a smaller sequence number.
 
-See the [`Bump Sequence` errors](../../../errors/result-codes/operation-specific/bump-sequence.mdx).
+See the
+[`Bump Sequence` errors](../../../errors/result-codes/operation-specific/bump-sequence.mdx).
 
 <AttributeTable>
 

--- a/content/api/resources/operations/object/buy-offer.mdx
+++ b/content/api/resources/operations/object/buy-offer.mdx
@@ -6,9 +6,12 @@ order: 60
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Creates, updates, or deletes a buy offer to trade assets. A buy offer specifies a certain amount of the buying asset that should be sold in exchange for the minimum quantity of the selling asset.
+Creates, updates, or deletes a buy offer to trade assets. A buy offer specifies
+a certain amount of the buying asset that should be sold in exchange for the
+minimum quantity of the selling asset.
 
-See the [`Manage Buy Offer` errors](../../../errors/result-codes/operation-specific/buy-offer.mdx).
+See the
+[`Manage Buy Offer` errors](../../../errors/result-codes/operation-specific/buy-offer.mdx).
 
 <AttributeTable>
 
@@ -17,10 +20,12 @@ See the [`Manage Buy Offer` errors](../../../errors/result-codes/operation-speci
   - DESCRIPTION
 - amount
   - string
-  - The amount of `buying_asset` that the account making this offer is willing to buy.
+  - The amount of `buying_asset` that the account making this offer is willing
+    to buy.
 - price
   - string
-  - How many units of `buying_asset` it takes to get 1 unit of `selling_asset`. A number representing the decimal form of `price_r`.
+  - How many units of `buying_asset` it takes to get 1 unit of `selling_asset`.
+    A number representing the decimal form of `price_r`.
 - price_r
   - object
   - A precise representation of the buy and sell price of the assets on offer.
@@ -32,22 +37,28 @@ See the [`Manage Buy Offer` errors](../../../errors/result-codes/operation-speci
       - The denominator.
 - buying_asset_type
   - string
-  - The type for the buying asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the buying asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - buying_asset_issuer
   - string
-  - The Stellar address of the buying asset’s issuer. Appears if the `buying_asset_type` is not `native`.
+  - The Stellar address of the buying asset’s issuer. Appears if the
+    `buying_asset_type` is not `native`.
 - buying_asset_code
   - string
-  - The code for the buying asset. Appears if the `buying_asset_type` is not `native`.
+  - The code for the buying asset. Appears if the `buying_asset_type` is not
+    `native`.
 - selling_asset_type
   - string
-  - The type for the selling asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the selling asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - selling_asset_issuer
   - string
-  - The Stellar address of the selling asset’s issuer. Appears if the `selling_asset_type` is not `native`.
+  - The Stellar address of the selling asset’s issuer. Appears if the
+    `selling_asset_type` is not `native`.
 - selling_asset_code
   - string
-  - The code for the selling asset. Appears if the `selling_asset_type` is not `native`.
+  - The code for the selling asset. Appears if the `selling_asset_type` is not
+    `native`.
 - offer_id
   - string
   - A unique identifier for this offer.

--- a/content/api/resources/operations/object/change-trust.mdx
+++ b/content/api/resources/operations/object/change-trust.mdx
@@ -6,9 +6,11 @@ order: 90
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Creates, updates, or deletes a trust line from the source account to another account's issued asset. 
+Creates, updates, or deletes a trust line from the source account to another
+account's issued asset.
 
-See the [`Change Trust` errors](../../../errors/result-codes/operation-specific/change-trust.mdx).
+See the
+[`Change Trust` errors](../../../errors/result-codes/operation-specific/change-trust.mdx).
 
 <AttributeTable>
 
@@ -17,13 +19,14 @@ See the [`Change Trust` errors](../../../errors/result-codes/operation-specific/
   - DESCRIPTION
 - asset_type
   - string
-  - The type of asset being trusted. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type of asset being trusted. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - asset_code
   - string
   - The Stellar address of the asset being trusted.
 - asset_issuer
   - string
-  - The code for the asset being trusted. 
+  - The code for the asset being trusted.
 - limit
   - string
   - Limits the amount of an asset that the source account can hold.

--- a/content/api/resources/operations/object/create-account.mdx
+++ b/content/api/resources/operations/object/create-account.mdx
@@ -8,7 +8,8 @@ import { AttributeTable } from "components/AttributeTable";
 
 Creates and funds a new account with the specified starting balance.
 
-See the [`Create Account` errors](../../../errors/result-codes/operation-specific/create-account.mdx).
+See the
+[`Create Account` errors](../../../errors/result-codes/operation-specific/create-account.mdx).
 
 <AttributeTable>
 

--- a/content/api/resources/operations/object/index.mdx
+++ b/content/api/resources/operations/object/index.mdx
@@ -6,7 +6,8 @@ order: 0
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Each of Stellar’s operations have unique response shapes. Below are the attributes that are common across individual operation objects.
+Each of Stellar’s operations have unique response shapes. Below are the
+attributes that are common across individual operation objects.
 
 See the [generic Operation errors](../../errors/result-codes/operations.mdx).
 
@@ -20,7 +21,8 @@ See the [generic Operation errors](../../errors/result-codes/operations.mdx).
   - The operation's ID number.
 - paging_token
   - string
-  - A cursor value for use in [pagination](../../introduction/pagination/index.mdx).
+  - A cursor value for use in
+    [pagination](../../introduction/pagination/index.mdx).
 - type_i
   - number
   - A number indicating the operation type.

--- a/content/api/resources/operations/object/manage-data.mdx
+++ b/content/api/resources/operations/object/manage-data.mdx
@@ -8,7 +8,8 @@ import { AttributeTable } from "components/AttributeTable";
 
 Set, modify, or delete a data entry (name/value pair) for an account.
 
-See the [`Manage Data` errors](../../../errors/result-codes/operation-specific/manage-data.mdx).
+See the
+[`Manage Data` errors](../../../errors/result-codes/operation-specific/manage-data.mdx).
 
 <AttributeTable>
 
@@ -17,10 +18,13 @@ See the [`Manage Data` errors](../../../errors/result-codes/operation-specific/m
   - DESCRIPTION
 - name
   - string
-  - The key for this data entry. It can be up to 64 bytes long. If this is a new `Name`, it will add the given name/value pair to the account. If this `Name` is already present, then the associated value will be modified.
+  - The key for this data entry. It can be up to 64 bytes long. If this is a new
+    `Name`, it will add the given name/value pair to the account. If this `Name`
+    is already present, then the associated value will be modified.
 - value
   - string
-  - If present, then this value will be set in the DataEntry. It can be up to 64 bytes long. If not present, then the existing `Name` will be deleted.
+  - If present, then this value will be set in the DataEntry. It can be up to 64
+    bytes long. If not present, then the existing `Name` will be deleted.
 
 </AttributeTable>
 

--- a/content/api/resources/operations/object/passive-sell-offer.mdx
+++ b/content/api/resources/operations/object/passive-sell-offer.mdx
@@ -6,9 +6,13 @@ order: 70
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Creates an offer that will not consume a counter offer that exactly matches this offer. This is useful for offers meant to be 1:1 exchanges for path payments. Use Manage Sell Offer to manage this offer after using this operation to create it.
+Creates an offer that will not consume a counter offer that exactly matches this
+offer. This is useful for offers meant to be 1:1 exchanges for path payments.
+Use Manage Sell Offer to manage this offer after using this operation to create
+it.
 
-See the [`Create Passive Sell Offer` errors](../../../errors/result-codes/operation-specific/passive-sell-offer.mdx).
+See the
+[`Create Passive Sell Offer` errors](../../../errors/result-codes/operation-specific/passive-sell-offer.mdx).
 
 <AttributeTable>
 
@@ -17,10 +21,12 @@ See the [`Create Passive Sell Offer` errors](../../../errors/result-codes/operat
   - DESCRIPTION
 - amount
   - string
-  - The amount of `selling_asset` that the account making this offer is willing to sell.
+  - The amount of `selling_asset` that the account making this offer is willing
+    to sell.
 - price
   - string
-  - How many units of `selling_asset` it takes to get 1 unit of `buying_asset`. A number representing the decimal form of `price_r`.
+  - How many units of `selling_asset` it takes to get 1 unit of `buying_asset`.
+    A number representing the decimal form of `price_r`.
 - price_r
   - object
   - A precise representation of the buy and sell price of the assets on offer.
@@ -32,22 +38,28 @@ See the [`Create Passive Sell Offer` errors](../../../errors/result-codes/operat
       - The denominator.
 - buying_asset_type
   - string
-  - The type for the buying asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the buying asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - buying_asset_issuer
   - string
-  - The Stellar address of the buying asset’s issuer. Appears if the `buying_asset_type` is not `native`.
+  - The Stellar address of the buying asset’s issuer. Appears if the
+    `buying_asset_type` is not `native`.
 - buying_asset_code
   - string
-  - The code for the buying asset. Appears if the `buying_asset_type` is not `native`.
+  - The code for the buying asset. Appears if the `buying_asset_type` is not
+    `native`.
 - selling_asset_type
   - string
-  - The type for the selling asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the selling asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - selling_asset_issuer
   - string
-  - The Stellar address of the selling asset’s issuer. Appears if the `selling_asset_type` is not `native`.
+  - The Stellar address of the selling asset’s issuer. Appears if the
+    `selling_asset_type` is not `native`.
 - selling_asset_code
   - string
-  - The code for the selling asset. Appears if the `selling_asset_type` is not `native`.
+  - The code for the selling asset. Appears if the `selling_asset_type` is not
+    `native`.
 - offer_id
   - string
   - A unique identifier for this offer.

--- a/content/api/resources/operations/object/path-payment-strict-receive.mdx
+++ b/content/api/resources/operations/object/path-payment-strict-receive.mdx
@@ -6,9 +6,12 @@ order: 30
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Sends a payment from one account to another in a path through the order books, starting as one asset and ending as another. Path payments that are `Strict Receive` designate the payment amount in the asset received.
+Sends a payment from one account to another in a path through the order books,
+starting as one asset and ending as another. Path payments that are
+`Strict Receive` designate the payment amount in the asset received.
 
-See the [`Path Payment Strict Receive` errors](../../../errors/result-codes/operation-specific/path-payment-strict-receive.mdx).
+See the
+[`Path Payment Strict Receive` errors](../../../errors/result-codes/operation-specific/path-payment-strict-receive.mdx).
 
 <AttributeTable>
 
@@ -17,13 +20,16 @@ See the [`Path Payment Strict Receive` errors](../../../errors/result-codes/oper
   - DESCRIPTION
 - asset_type
   - string
-  - The type of asset being received. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type of asset being received. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - asset_code
   - string
-  - The code for the asset being received. Appears if the `asset_type` is not `native`.
+  - The code for the asset being received. Appears if the `asset_type` is not
+    `native`.
 - asset_issuer
   - string
-  - The Stellar address of the issuer of the asset being received. Appears if the `asset_type` is not `native`.
+  - The Stellar address of the issuer of the asset being received. Appears if
+    the `asset_type` is not `native`.
 - from
   - string
   - The payment sender’s public key.
@@ -44,7 +50,8 @@ See the [`Path Payment Strict Receive` errors](../../../errors/result-codes/oper
       - The Stellar address of the intermediary asset’s issuer.
     - asset_type
       - string
-      - The type for the intermediary asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      - The type for the intermediary asset. Either `native`,
+        `credit_alphanum4`, or `credit_alphanum12`.
 - source_amount
   - string
   - Amount sent designated in the source asset.
@@ -53,7 +60,8 @@ See the [`Path Payment Strict Receive` errors](../../../errors/result-codes/oper
   - The maximum amount to be sent designated in the source asset.
 - source_asset_type
   - string
-  - The type for the source asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the source asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - source_asset_code
   - string
   - The code for the source asset.

--- a/content/api/resources/operations/object/path-payment-strict-send.mdx
+++ b/content/api/resources/operations/object/path-payment-strict-send.mdx
@@ -6,9 +6,12 @@ order: 40
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Sends a payment from one account to another in a path through the order books, starting as one asset and ending as another. Path payments that are `Strict Send` designate the payment amount in the asset sent.
+Sends a payment from one account to another in a path through the order books,
+starting as one asset and ending as another. Path payments that are
+`Strict Send` designate the payment amount in the asset sent.
 
-See the [`Path Payment Strict Send` errors](../../../errors/result-codes/operation-specific/path-payment-strict-send.mdx).
+See the
+[`Path Payment Strict Send` errors](../../../errors/result-codes/operation-specific/path-payment-strict-send.mdx).
 
 <AttributeTable>
 
@@ -17,13 +20,16 @@ See the [`Path Payment Strict Send` errors](../../../errors/result-codes/operati
   - DESCRIPTION
 - asset_type
   - string
-  - The type of asset being sent. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type of asset being sent. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - asset_code
   - string
-  - The code for the asset being sent. Appears if the `asset_type` is not `native`.
+  - The code for the asset being sent. Appears if the `asset_type` is not
+    `native`.
 - asset_issuer
   - string
-  - The Stellar address of the issuer of the asset being sent. Appears if the `asset_type` is not `native`.
+  - The Stellar address of the issuer of the asset being sent. Appears if the
+    `asset_type` is not `native`.
 - from
   - string
   - The payment sender’s public key.
@@ -44,7 +50,8 @@ See the [`Path Payment Strict Send` errors](../../../errors/result-codes/operati
       - The Stellar address of the intermediary asset’s issuer.
     - asset_type
       - string
-      - The type for the intermediary asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      - The type for the intermediary asset. Either `native`,
+        `credit_alphanum4`, or `credit_alphanum12`.
 - source_amount
   - string
   - Amount sent designated in the source asset.
@@ -53,13 +60,15 @@ See the [`Path Payment Strict Send` errors](../../../errors/result-codes/operati
   - The minimum amount of destination asset expected to be received.
 - source_asset_type
   - string
-  - The type for the source asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the source asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - source_asset_code
   - string
   - The code for the source asset. Appears if the `asset_type` is not `native`.
 - source_asset_issuer
   - string
-  - The Stellar address of the source asset’s issuer. Appears if the `asset_type` is not `native`.
+  - The Stellar address of the source asset’s issuer. Appears if the
+    `asset_type` is not `native`.
 
 </AttributeTable>
 

--- a/content/api/resources/operations/object/payment.mdx
+++ b/content/api/resources/operations/object/payment.mdx
@@ -8,7 +8,8 @@ import { AttributeTable } from "components/AttributeTable";
 
 Sends an amount in a specific asset to a destination account.
 
-See the [`Payment` errors](../../../errors/result-codes/operation-specific/payment.mdx).
+See the
+[`Payment` errors](../../../errors/result-codes/operation-specific/payment.mdx).
 
 <AttributeTable>
 
@@ -17,13 +18,16 @@ See the [`Payment` errors](../../../errors/result-codes/operation-specific/payme
   - DESCRIPTION
 - asset_type
   - string
-  - The type of asset being sent. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type of asset being sent. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - asset_code
   - string
-  - The code for the asset being sent. Appears if the `asset_type` is not `native`.
+  - The code for the asset being sent. Appears if the `asset_type` is not
+    `native`.
 - asset_issuer
   - string
-  - The Stellar address of the issuer of the asset being sent. Appears if the `asset_type` is not `native`.
+  - The Stellar address of the issuer of the asset being sent. Appears if the
+    `asset_type` is not `native`.
 - from
   - string
   - The payment sender’s public key.

--- a/content/api/resources/operations/object/sell-offer.mdx
+++ b/content/api/resources/operations/object/sell-offer.mdx
@@ -6,9 +6,12 @@ order: 50
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-Creates, updates, or deletes a sell offer to trade assets. A sell offer specifies a certain amount of the selling asset that should be sold in exchange for the maximum quantity of the buying asset.
+Creates, updates, or deletes a sell offer to trade assets. A sell offer
+specifies a certain amount of the selling asset that should be sold in exchange
+for the maximum quantity of the buying asset.
 
-See the [`Manage Sell Offer` errors](../../../errors/result-codes/operation-specific/sell-offer.mdx).
+See the
+[`Manage Sell Offer` errors](../../../errors/result-codes/operation-specific/sell-offer.mdx).
 
 <AttributeTable>
 
@@ -17,10 +20,12 @@ See the [`Manage Sell Offer` errors](../../../errors/result-codes/operation-spec
   - DESCRIPTION
 - amount
   - string
-  - The amount of `selling_asset` that the account making this offer is willing to sell.
+  - The amount of `selling_asset` that the account making this offer is willing
+    to sell.
 - price
   - string
-  - How many units of `selling_asset` it takes to get 1 unit of `buying_asset`. A number representing the decimal form of `price_r`.
+  - How many units of `selling_asset` it takes to get 1 unit of `buying_asset`.
+    A number representing the decimal form of `price_r`.
 - price_r
   - object
   - A precise representation of the buy and sell price of the assets on offer.
@@ -32,22 +37,28 @@ See the [`Manage Sell Offer` errors](../../../errors/result-codes/operation-spec
       - The denominator.
 - buying_asset_type
   - string
-  - The type for the buying asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the buying asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - buying_asset_issuer
   - string
-  - The Stellar address of the buying asset’s issuer. Appears if the `buying_asset_type` is not `native`.
+  - The Stellar address of the buying asset’s issuer. Appears if the
+    `buying_asset_type` is not `native`.
 - buying_asset_code
   - string
-  - The code for the buying asset. Appears if the `buying_asset_type` is not `native`.
+  - The code for the buying asset. Appears if the `buying_asset_type` is not
+    `native`.
 - selling_asset_type
   - string
-  - The type for the selling asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the selling asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - selling_asset_issuer
   - string
-  - The Stellar address of the selling asset’s issuer. Appears if the `selling_asset_type` is not `native`.
+  - The Stellar address of the selling asset’s issuer. Appears if the
+    `selling_asset_type` is not `native`.
 - selling_asset_code
   - string
-  - The code for the selling asset. Appears if the `selling_asset_type` is not `native`.
+  - The code for the selling asset. Appears if the `selling_asset_type` is not
+    `native`.
 - offer_id
   - string
   - A unique identifier for this offer.

--- a/content/api/resources/operations/object/set-options.mdx
+++ b/content/api/resources/operations/object/set-options.mdx
@@ -8,7 +8,8 @@ import { AttributeTable } from "components/AttributeTable";
 
 Sets an account's flags, inflation destination, signers, and home domain.
 
-See the [`Set Options` errors](../../../errors/result-codes/operation-specific/set-options.mdx).
+See the
+[`Set Options` errors](../../../errors/result-codes/operation-specific/set-options.mdx).
 
 <AttributeTable>
 
@@ -38,16 +39,24 @@ See the [`Set Options` errors](../../../errors/result-codes/operation-specific/s
   - The home domain used for stellar.toml file discovery.
 - set_flags
   - array
-  - The array of numeric values of flags that has been set in this operation. Options include `1` for `AUTH_REQUIRED_FLAG`, `2` for `AUTH_REVOCABLE_FLAG`, and `4` for `AUTH_IMMUTABLE_FLAG`.
+  - The array of numeric values of flags that has been set in this operation.
+    Options include `1` for `AUTH_REQUIRED_FLAG`, `2` for `AUTH_REVOCABLE_FLAG`,
+    and `4` for `AUTH_IMMUTABLE_FLAG`.
 - set_flags_s
   - array
-  - The array of string values of flags that has been set in this operation. Options include `AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`, and `AUTH_IMMUTABLE_FLAG`.
+  - The array of string values of flags that has been set in this operation.
+    Options include `AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`, and
+    `AUTH_IMMUTABLE_FLAG`.
 - clear_flags
   - array
-  - The array of numeric values of flags that has been cleared in this operation. Options include `1` for `AUTH_REQUIRED_FLAG`, `2` for `AUTH_REVOCABLE_FLAG`, and `4` for `AUTH_IMMUTABLE_FLAG`.
+  - The array of numeric values of flags that has been cleared in this
+    operation. Options include `1` for `AUTH_REQUIRED_FLAG`, `2` for
+    `AUTH_REVOCABLE_FLAG`, and `4` for `AUTH_IMMUTABLE_FLAG`.
 - clear_flags_s
   - array
-  - The array of string values of flags that has been cleared in this operation. Options include `AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`, and `AUTH_IMMUTABLE_FLAG`.
+  - The array of string values of flags that has been cleared in this operation.
+    Options include `AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`, and
+    `AUTH_IMMUTABLE_FLAG`.
 
 </AttributeTable>
 

--- a/content/api/resources/operations/single.mdx
+++ b/content/api/resources/operations/single.mdx
@@ -28,7 +28,8 @@ The single operation endpoint provides information about a specific operation.
   - The ID number for this operation.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the operations in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    operations in the response.
 
 </AttributeTable>
 
@@ -39,19 +40,19 @@ curl "https://horizon.stellar.org/operations/121692259040116737"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.operations()
-.operation('121692259040116737')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .operations()
+  .operation("121692259040116737")
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/trades/index.mdx
+++ b/content/api/resources/trades/index.mdx
@@ -5,16 +5,19 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-When an offer is fully or partially fulfilled, a trade happens. Trades can also be caused by successful path payments, because path payments involve fulfilling offers.
+When an offer is fully or partially fulfilled, a trade happens. Trades can also
+be caused by successful path payments, because path payments involve fulfilling
+offers.
 
-A trade occurs between two parties—`base` and `counter`. Which is which is either arbitrary or determined by the calling query.
+A trade occurs between two parties—`base` and `counter`. Which is which is
+either arbitrary or determined by the calling query.
 
 Learn more about [trades](../../../docs/glossary/trades.mdx).
 
 <EndpointsTable title="Endpoints">
 
-|     |                                    |
-| --- | ---------------------------------- |
-| GET | [/trades](./list.mdx)              |
+|     |                       |
+| --- | --------------------- |
+| GET | [/trades](./list.mdx) |
 
 </EndpointsTable>

--- a/content/api/resources/trades/list.mdx
+++ b/content/api/resources/trades/list.mdx
@@ -8,16 +8,25 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all trades and can be used in [streaming](../introduction/streaming.mdx) mode.
+This endpoint lists all trades and can be used in
+[streaming](../introduction/streaming.mdx) mode.
 
-Streaming mode allows you to listen for new trades as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known trade unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream trades created since your request time.
+Streaming mode allows you to listen for new trades as they are added to the
+Stellar ledger. If called in streaming mode, Horizon will start at the earliest
+known trade unless a `cursor` is set, in which case it will start from that
+`cursor`. By setting the cursor value to `now`, you can stream trades created
+since your request time.
 
-When filtering for a specific orderbook, you must use use all six of these arguments: `base_asset_type`, `base_asset_issuer`, `base_asset_code`, `counter_asset_type`, `counter_asset_issuer`, and `counter_asset_code`. If the base or counter asset is XLM, you only need to indicate the asset type as `native` and do not need to designate the code or the issuer.
+When filtering for a specific orderbook, you must use use all six of these
+arguments: `base_asset_type`, `base_asset_issuer`, `base_asset_code`,
+`counter_asset_type`, `counter_asset_issuer`, and `counter_asset_code`. If the
+base or counter asset is XLM, you only need to indicate the asset type as
+`native` and do not need to designate the code or the issuer.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                                                                                                                                                                                                                                                                                                                                                                         |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GET | /trades?offer_id={:offer_id}&base_asset_type={native,credit_alphanum4,credit_alphanum12}&base_asset_issuer={:account_id}&base_asset_code{:asset_code}&counter_asset_type={native,credit_alphanum4,credit_alphanum12}&counter_asset_issuer={:account_id}&counter_asset_code{:asset_code}&cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false} |
 
 </Endpoint>
@@ -32,7 +41,8 @@ When filtering for a specific orderbook, you must use use all six of these argum
   - The offer ID. Used to filter for trades originating from a specific offer.
 - base_asset_type
   - optional
-  - The type for the base asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the base asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - base_asset_issuer
   - optional
   - The Stellar address of the base asset’s issuer.
@@ -41,7 +51,8 @@ When filtering for a specific orderbook, you must use use all six of these argum
   - The code for the base asset.
 - counter_asset_type
   - optional
-  - The type for the counter asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type for the counter asset. Either `native`, `credit_alphanum4`, or
+    `credit_alphanum12`.
 - counter_asset_issuer
   - optional
   - The Stellar address of the counter asset’s issuer.
@@ -50,13 +61,18 @@ When filtering for a specific orderbook, you must use use all six of these argum
   - The code for the counter asset.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -67,22 +83,25 @@ curl "https://horizon.stellar.org/trades?base_asset_type=credit_alphanum4&base_a
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.trades()
-.forAssetPair(
-  new StellarSdk.Asset('USD', 'GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX'),
-  new StellarSdk.Asset.native(),
-)
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .trades()
+  .forAssetPair(
+    new StellarSdk.Asset(
+      "USD",
+      "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+    ),
+    new StellarSdk.Asset.native(),
+  )
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -219,21 +238,24 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var tradesHandler = function(resp) {
-  console.log(resp)
-}
+var tradesHandler = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.trades()
-.forAssetPair(
-  new StellarSdk.Asset('USD', 'GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX'),
-  new StellarSdk.Asset.native(),
-)
-.cursor('now')
-.stream({onmessage: tradesHandler})
+  .trades()
+  .forAssetPair(
+    new StellarSdk.Asset(
+      "USD",
+      "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+    ),
+    new StellarSdk.Asset.native(),
+  )
+  .cursor("now")
+  .stream({ onmessage: tradesHandler });
 ```
 
 </CodeExample>

--- a/content/api/resources/transactions/effects.mdx
+++ b/content/api/resources/transactions/effects.mdx
@@ -12,8 +12,8 @@ This endpoint returns the effects of a specific transaction.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                              |
+| --- | -------------------------------------------------------------------------------------------- |
 | GET | /transactions/:transaction_hash/effects?cursor={paging_token}&order={asc,desc}&limit={1-200} |
 
 </Endpoint>
@@ -28,13 +28,18 @@ This endpoint returns the effects of a specific transaction.
   - A hex-encoded SHA-256 hash of this transaction’s XDR-encoded form.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 
 </AttributeTable>
 
@@ -45,19 +50,21 @@ curl "https://horizon.stellar.org/transactions/512a9946bc7ff4a363299f14f79e0beb9
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.effects()
-.forTransaction('512a9946bc7ff4a363299f14f79e0beb9b9cdbd0103e3a69a44446a0aa6471a8')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .effects()
+  .forTransaction(
+    "512a9946bc7ff4a363299f14f79e0beb9b9cdbd0103e3a69a44446a0aa6471a8",
+  )
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/transactions/index.mdx
+++ b/content/api/resources/transactions/index.mdx
@@ -5,18 +5,19 @@ order: 0
 
 import { EndpointsTable } from "components/EndpointsTable";
 
-Transactions are commands that modify the ledger state and consist of one or more operations.
+Transactions are commands that modify the ledger state and consist of one or
+more operations.
 
 Learn more about [transactions](../../../docs/glossary/transactions.mdx).
 
 <EndpointsTable title="Endpoints">
 
-|     |                                                               |
-| --- | ------------------------------------------------------------- |
-| GET | [/transactions/:transaction_id](./single.mdx)                 |
-| GET | [/transactions/:transaction_id/operations](./operations.mdx)  |
-| GET | [/transactions/:transaction_id/effects](./effects.mdx)        |
-| GET | [/transactions](./list.mdx)                                   |
+|      |                                                              |
+| ---- | ------------------------------------------------------------ |
+| GET  | [/transactions/:transaction_id](./single.mdx)                |
+| GET  | [/transactions/:transaction_id/operations](./operations.mdx) |
+| GET  | [/transactions/:transaction_id/effects](./effects.mdx)       |
+| GET  | [/transactions](./list.mdx)                                  |
 | POST | [/transactions](./post.mdx)                                  |
 
 </EndpointsTable>

--- a/content/api/resources/transactions/list.mdx
+++ b/content/api/resources/transactions/list.mdx
@@ -8,12 +8,18 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all successful transactions and can be used in [streaming](../../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new transactions as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known transaction unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream transactions created since your request time.
+This endpoint lists all successful transactions and can be used in
+[streaming](../../introduction/streaming.mdx) mode. Streaming mode allows you to
+listen for new transactions as they are added to the Stellar ledger. If called
+in streaming mode, Horizon will start at the earliest known transaction unless a
+`cursor` is set, in which case it will start from that `cursor`. By setting the
+cursor value to `now`, you can stream transactions created since your request
+time.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                                                                                               |
+| --- | --------------------------------------------------------------------------------------------- |
 | GET | /transactions?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false} |
 
 </Endpoint>
@@ -25,16 +31,22 @@ This endpoint lists all successful transactions and can be used in [streaming](.
   - DESCRIPTION
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed operations in results. Options include `true` and `false`.
+  - Set to true to include failed operations in results. Options include `true`
+    and `false`.
 
 </AttributeTable>
 
@@ -45,18 +57,18 @@ curl "https://horizon.stellar.org/transactions?limit=3"
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.transactions()
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .transactions()
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>
@@ -232,17 +244,17 @@ server
 <CodeExample title="JavaScript Streaming Example">
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
-var tradesHandler = function(resp) {
-  console.log(resp)
-}
+var tradesHandler = function (resp) {
+  console.log(resp);
+};
 
 var es = server
-.transactions()
-.cursor('now')
-.stream({onmessage: tradesHandler})
+  .transactions()
+  .cursor("now")
+  .stream({ onmessage: tradesHandler });
 ```
 
 </CodeExample>

--- a/content/api/resources/transactions/object.mdx
+++ b/content/api/resources/transactions/object.mdx
@@ -6,7 +6,8 @@ order: 10
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-When Horizon returns information about a transaction, it uses the following format:
+When Horizon returns information about a transaction, it uses the following
+format:
 
 <AttributeTable>
 
@@ -18,13 +19,15 @@ When Horizon returns information about a transaction, it uses the following form
   - A unique identifier for this transaction.
 - paging_token
   - number
-  - A cursor value for use in [pagination](../../introduction/pagination/index.mdx).
+  - A cursor value for use in
+    [pagination](../../introduction/pagination/index.mdx).
 - successful
   - boolean
   - Indicates if this transaction was successful or not.
 - hash
   - string
-  - A hex-encoded SHA-256 hash of this transaction’s [XDR](../../../docs/glossary/xdr.mdx)-encoded form.
+  - A hex-encoded SHA-256 hash of this transaction’s
+    [XDR](../../../docs/glossary/xdr.mdx)-encoded form.
 - ledger
   - number
   - The sequence number of the ledger that this transaction was included in.
@@ -39,31 +42,38 @@ When Horizon returns information about a transaction, it uses the following form
   - The source account's sequence number that this transaction consumed.
 - fee_charged
   - number
-  - The fee (in [stroops](../../../docs/glossary/stroops.mdx)) paid by the source account to apply this transaction to the ledger.
+  - The fee (in [stroops](../../../docs/glossary/stroops.mdx)) paid by the
+    source account to apply this transaction to the ledger.
 - max_fee
   - number
-  - The maximum fee (in [stroops](../../../docs/glossary/stroops.mdx)) that the source account was willing to pay.
+  - The maximum fee (in [stroops](../../../docs/glossary/stroops.mdx)) that the
+    source account was willing to pay.
 - operation_count
   - number
   - The number of operations contained within this transaction.
 - envelope_xdr
   - string
-  - A base64 encoded string of the raw `TransactionEnvelope` XDR struct for this transaction.
+  - A base64 encoded string of the raw `TransactionEnvelope` XDR struct for this
+    transaction.
 - result_xdr
   - string
-  - A base64 encoded string of the raw `TransactionResult` XDR struct for this transaction.
+  - A base64 encoded string of the raw `TransactionResult` XDR struct for this
+    transaction.
 - result_meta_xdr
   - string
-  - A base64 encoded string of the raw `TransactionMeta` XDR struct for this transaction
+  - A base64 encoded string of the raw `TransactionMeta` XDR struct for this
+    transaction
 - fee_meta_xdr
   - string
-  - A base64 encoded string of the raw `LedgerEntryChanges` XDR struct produced by taking fees for this transaction.
+  - A base64 encoded string of the raw `LedgerEntryChanges` XDR struct produced
+    by taking fees for this transaction.
 - memo
   - string
   - The optional memo attached to a transaction.
 - memo_type
   - string
-  - The type of memo. Potential values include `MEMO_TEXT`, `MEMO_ID`, `MEMO_HASH`, `MEMO_RETURN`.
+  - The type of memo. Potential values include `MEMO_TEXT`, `MEMO_ID`,
+    `MEMO_HASH`, `MEMO_RETURN`.
 - signatures
   - string
   - An array of signatures used to sign this transaction.

--- a/content/api/resources/transactions/operations.mdx
+++ b/content/api/resources/transactions/operations.mdx
@@ -12,8 +12,8 @@ This endpoint returns successful operations for a specific transaction.
 
 <Endpoint>
 
-|  |  |
-| --- | --- |
+|     |                                                                                                                                                |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | GET | /transactions/:transaction_hash/operations?cursor={paging_token}&order={asc,desc}&limit={1-200}&include_failed{true,false}&join={transactions} |
 
 </Endpoint>
@@ -28,19 +28,26 @@ This endpoint returns successful operations for a specific transaction.
   - A hex-encoded SHA-256 hash of this transaction’s XDR-encoded form.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A number that points to a specific location in a collection of responses and
+    is pulled from the `paging_token` value of a record.
 - order
   - optional
-  - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+  - A designation of the order in which records should appear. Options include
+    `asc`(ascending) or `desc` (descending). If this argument isn’t set, it
+    defaults to `asc`.
 - limit
   - optional
-  - The total number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+  - The total number of records returned. The limit can range from 1 to 200 - an
+    upper limit that is hardcoded in Horizon for performance reasons. If this
+    argument isn’t designated, it defaults to 10.
 - include_failed
   - optional
-  - Set to true to include failed operations in results. Options include `true` and `false`.
+  - Set to true to include failed operations in results. Options include `true`
+    and `false`.
 - join
   - optional
-  - Set to `transactions` to include the transactions which created each of the operations in the response.
+  - Set to `transactions` to include the transactions which created each of the
+    operations in the response.
 
 </AttributeTable>
 
@@ -51,19 +58,21 @@ curl "https://horizon.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a0
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk')
-var server = new StellarSdk.Server('https://horizon.stellar.org')
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.operations()
-.forTransaction('6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .operations()
+  .forTransaction(
+    "6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a",
+  )
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/api/resources/transactions/single.mdx
+++ b/content/api/resources/transactions/single.mdx
@@ -12,8 +12,8 @@ The single transaction endpoint provides information on a specific transaction.
 
 <Endpoint>
 
-|     |                              |
-| --- | ---------------------------- |
+|     |                               |
+| --- | ----------------------------- |
 | GET | /transactions/:transaction_id |
 
 </Endpoint>
@@ -36,19 +36,21 @@ curl "https://horizon.stellar.org/transactions/5ebd5c0af4385500b53dd63b0ef5f6e8f
 ```
 
 ```js
-var StellarSdk = require('stellar-sdk');
-var server = new StellarSdk.Server('https://horizon.stellar.org');
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon.stellar.org");
 
 server
-.transactions()
-.transaction('5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc')
-.call()
-.then(function(resp) {
-  console.log(resp)
-})
-.catch(function(err) {
-  console.error(err)
-})
+  .transactions()
+  .transaction(
+    "5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc",
+  )
+  .call()
+  .then(function (resp) {
+    console.log(resp);
+  })
+  .catch(function (err) {
+    console.error(err);
+  });
 ```
 
 </CodeExample>

--- a/content/docs/building-apps/basic-wallet.mdx
+++ b/content/docs/building-apps/basic-wallet.mdx
@@ -8,19 +8,37 @@ import { Alert } from "components/Alert";
 
 <Alert>
 
-In this tutorial, the goal is to get to a place where a user can create, store, and access their Stellar account using an intuitive pincode encryption method.  It assumes that you have already completed the [Project Setup section](./project-setup.mdx).
+In this tutorial, the goal is to get to a place where a user can create, store,
+and access their Stellar account using an intuitive pincode encryption method.
+It assumes that you have already completed the
+[Project Setup section](./project-setup.mdx).
 
 </Alert>
 
 [View the setup boilerplate code on GitHub][1]
 
 ## User Flow
-Because we've decided to build a non-custodial wallet, we don’t need to communicate with a server or database at all: everything can happen locally right on a user’s device.  We’ll be doing all our work inside of `src/components/wallet/`, so head over there now.  We’re going to use the `StellarSdk.Keypair.random()` from the StellarSdk to generate a new valid Stellar keypair.  That's the easy part.  The hard work will be storing that vital information in a secure yet accessible manner.
 
-The user flow we're building will work like this: Click “Create Account” → UI modal popup asking for a pincode → Enter pincode, click “OK” → App encrypts a new Stellar keypair secret key with pincode → App saves encrypted secret to `localStorage`. On page reload, we’ll fetch the `publicKey` to “login” the user, but for any protected action such as “Copy Secret”, the modal will pop back up asking for the original pincode.
+Because we've decided to build a non-custodial wallet, we don’t need to
+communicate with a server or database at all: everything can happen locally
+right on a user’s device. We’ll be doing all our work inside of
+`src/components/wallet/`, so head over there now. We’re going to use the
+`StellarSdk.Keypair.random()` from the StellarSdk to generate a new valid
+Stellar keypair. That's the easy part. The hard work will be storing that vital
+information in a secure yet accessible manner.
+
+The user flow we're building will work like this: Click “Create Account” → UI
+modal popup asking for a pincode → Enter pincode, click “OK” → App encrypts a
+new Stellar keypair secret key with pincode → App saves encrypted secret to
+`localStorage`. On page reload, we’ll fetch the `publicKey` to “login” the user,
+but for any protected action such as “Copy Secret”, the modal will pop back up
+asking for the original pincode.
 
 ## Create a Popup Modal
-To start, let's look at at the popup modal. We’ll be mimicking the browser’s `prompt` functionality with our own new, more powerful component. First things first we should generate a new component:
+
+To start, let's look at at the popup modal. We’ll be mimicking the browser’s
+`prompt` functionality with our own new, more powerful component. First things
+first we should generate a new component:
 
 <CodeExample>
 
@@ -30,12 +48,14 @@ npm run generate
 
 </CodeExample>
 
-Call it `stellar-prompt`, and deselect both test files leaving only the styling. Once you have that, open `src/components/prompt/` and rename the `.css` file to `.scss`. Fill that style file with this:
+Call it `stellar-prompt`, and deselect both test files leaving only the styling.
+Once you have that, open `src/components/prompt/` and rename the `.css` file to
+`.scss`. Fill that style file with this:
 
 <CodeExample>
 
 ```scss
-@import '../../global/style.scss';
+@import "../../global/style.scss";
 
 :host {
   display: block;
@@ -98,12 +118,12 @@ Call it `stellar-prompt`, and deselect both test files leaving only the styling.
       color: blue;
     }
     &:after {
-      content: '◀';
+      content: "◀";
       top: calc(50% - 5px);
       transform: translate(0, -50%) rotate(90deg);
     }
     &:before {
-      content: '▶';
+      content: "▶";
       top: calc(50% + 5px);
       transform: translate(0, -50%) rotate(90deg);
     }
@@ -136,91 +156,83 @@ Replace the `prompt.tsx` contents with this.
 <CodeExample>
 
 ```tsx
-import {
-  Component,
-  Prop,
-  Element,
-  Watch,
-  h,
-  State
-} from '@stencil/core'
-import { defer as loDefer } from 'lodash-es'
+import { Component, Prop, Element, Watch, h, State } from "@stencil/core";
+import { defer as loDefer } from "lodash-es";
 
 export interface Prompter {
-  show: boolean
-  message?: string
-  placeholder?: string
-  options?: Array<any>
-  resolve?: Function
-  reject?: Function
+  show: boolean;
+  message?: string;
+  placeholder?: string;
+  options?: Array<any>;
+  resolve?: Function;
+  reject?: Function;
 }
 
 @Component({
-  tag: 'stellar-prompt',
-  styleUrl: 'prompt.scss',
-  shadow: true
+  tag: "stellar-prompt",
+  styleUrl: "prompt.scss",
+  shadow: true,
 })
 export class Prompt {
-  @Element() private element: HTMLElement
+  @Element() private element: HTMLElement;
 
-  @Prop({mutable: true}) prompter: Prompter
+  @Prop({ mutable: true }) prompter: Prompter;
 
-  @State() private input: string
+  @State() private input: string;
 
-  @Watch('prompter')
+  @Watch("prompter")
   watchHandler(newValue: Prompter, oldValue: Prompter) {
-    if (newValue.show === oldValue.show)
-      return
+    if (newValue.show === oldValue.show) return;
 
     if (newValue.show) {
-      this.input = null
+      this.input = null;
 
       if (newValue.options)
-        this.input = this.input || `${newValue.options[0].code}:${newValue.options[0].issuer}`
+        this.input =
+          this.input ||
+          `${newValue.options[0].code}:${newValue.options[0].issuer}`;
       else
-        loDefer(() => this.element.shadowRoot.querySelector('input').focus())
-    }
-
-    else {
-      this.prompter.message = null
-      this.prompter.placeholder = null
-      this.prompter.options = null
+        loDefer(() => this.element.shadowRoot.querySelector("input").focus());
+    } else {
+      this.prompter.message = null;
+      this.prompter.placeholder = null;
+      this.prompter.options = null;
     }
   }
 
   componentDidLoad() {
-    addEventListener('keyup', (e: KeyboardEvent) => {
+    addEventListener("keyup", (e: KeyboardEvent) => {
       if (this.prompter.show)
         e.keyCode === 13
-        ? this.submit(e)
-        : e.keyCode === 27
-        ? this.cancel(e)
-        : null
-    })
+          ? this.submit(e)
+          : e.keyCode === 27
+          ? this.cancel(e)
+          : null;
+    });
   }
 
   cancel(e: Event) {
-    e.preventDefault()
+    e.preventDefault();
 
     this.prompter = {
       ...this.prompter,
-      show: false
-    }
-    this.prompter.reject(null)
+      show: false,
+    };
+    this.prompter.reject(null);
   }
 
   submit(e: Event) {
-    e.preventDefault()
+    e.preventDefault();
 
     this.prompter = {
       ...this.prompter,
-      show: false
-    }
-    this.prompter.resolve(this.input)
+      show: false,
+    };
+    this.prompter.resolve(this.input);
   }
 
   update(e) {
-    this.input = e.target.value.toUpperCase()
+    this.input = e.target.value.toUpperCase();
   }
 
   render() {
@@ -229,40 +241,56 @@ export class Prompt {
         <div class="prompt">
           {this.prompter.message ? <p>{this.prompter.message}</p> : null}
 
-          {
-            this.prompter.options
-            ? <div class="select-wrapper">
-                <select
-                  onInput={(e) => this.update(e)}
-                > {this.prompter.options.map((option) =>
-                    <option
-                      value={`${option.code}:${option.issuer}`}
-                      selected={this.input === `${option.code}:${option.issuer}`}
-                    >{option.code}</option>
-                  )}
-                </select>
-              </div>
-            : <input type="text"
-                placeholder={this.prompter.placeholder}
-                value={this.input}
-                onInput={(e) => this.update(e)}
-              ></input>
-          }
+          {this.prompter.options ? (
+            <div class="select-wrapper">
+              <select onInput={(e) => this.update(e)}>
+                {" "}
+                {this.prompter.options.map((option) => (
+                  <option
+                    value={`${option.code}:${option.issuer}`}
+                    selected={this.input === `${option.code}:${option.issuer}`}
+                  >
+                    {option.code}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            <input
+              type="text"
+              placeholder={this.prompter.placeholder}
+              value={this.input}
+              onInput={(e) => this.update(e)}
+            ></input>
+          )}
 
           <div class="actions">
-            <button class="cancel" type="button" onClick={(e) => this.cancel(e)}>Cancel</button>
-            <button class="submit" type="button" onClick={(e) => this.submit(e)}>OK</button>
+            <button
+              class="cancel"
+              type="button"
+              onClick={(e) => this.cancel(e)}
+            >
+              Cancel
+            </button>
+            <button
+              class="submit"
+              type="button"
+              onClick={(e) => this.submit(e)}
+            >
+              OK
+            </button>
           </div>
         </div>
       </div>
-    ) : null
+    ) : null;
   }
 }
 ```
 
 </CodeExample>
 
-One of the first things you’ll notice is the use of `lodash-es`.  Let’s make sure we’ve got that imported before moving forward:
+One of the first things you’ll notice is the use of `lodash-es`. Let’s make sure
+we’ve got that imported before moving forward:
 
 <CodeExample>
 
@@ -272,109 +300,115 @@ npm i -D lodash-es
 
 </CodeExample>
 
-There’s a lot going on in this file, but since this isn’t a Stencil tutorial we’ll skip the details.  What this allows us to do it to use a `<stellar-prompt prompter={this.prompter} />` component elsewhere in our project. It's worth noting the variables available to us in the `prompter` property.
+There’s a lot going on in this file, but since this isn’t a Stencil tutorial
+we’ll skip the details. What this allows us to do it to use a
+`<stellar-prompt prompter={this.prompter} />` component elsewhere in our
+project. It's worth noting the variables available to us in the `prompter`
+property.
 
 <CodeExample>
 
 ```ts
 export interface Prompter {
-  show: boolean
-  message?: string
-  placeholder?: string
-  options?: Array<any>
-  resolve?: Function
-  reject?: Function
+  show: boolean;
+  message?: string;
+  placeholder?: string;
+  options?: Array<any>;
+  resolve?: Function;
+  reject?: Function;
 }
 ```
 
 </CodeExample>
 
-The values we’ll be making most use of are those first three: `show`, `message` and `placeholder`. The last two—`resolve` and `reject`—are for promisifying the prompt so we can await a response before continuing with further logic. 
-Don't worry: that statement will make more sense in a moment once we include this component in `src/components/wallet/`. Speaking of, let’s swing over to that component now.
+The values we’ll be making most use of are those first three: `show`, `message`
+and `placeholder`. The last two—`resolve` and `reject`—are for promisifying the
+prompt so we can await a response before continuing with further logic. Don't
+worry: that statement will make more sense in a moment once we include this
+component in `src/components/wallet/`. Speaking of, let’s swing over to that
+component now.
 
-We’ve got a lot of work to do in here so I’ll just paste the code in all its glory and we’ll walk through it block by block:
+We’ve got a lot of work to do in here so I’ll just paste the code in all its
+glory and we’ll walk through it block by block:
 
 <CodeExample>
 
 ```ts
-import {
-  Component,
-  State
-} from '@stencil/core'
+import { Component, State } from "@stencil/core";
 
-import componentWillLoad from './events/componentWillLoad'
-import render from './events/render'
+import componentWillLoad from "./events/componentWillLoad";
+import render from "./events/render";
 
-import createAccount from './methods/createAccount'
-import copyAddress from './methods/copyAddress'
-import copySecret from './methods/copySecret'
-import signOut from './methods/signOut'
-import setPrompt from './methods/setPrompt'
+import createAccount from "./methods/createAccount";
+import copyAddress from "./methods/copyAddress";
+import copySecret from "./methods/copySecret";
+import signOut from "./methods/signOut";
+import setPrompt from "./methods/setPrompt";
 
-import { Prompter } from '@prompt/prompt'
+import { Prompter } from "@prompt/prompt";
 
 interface StellarAccount {
-  publicKey: string,
-  keystore: string,
+  publicKey: string;
+  keystore: string;
 }
 
 @Component({
-  tag: 'stellar-wallet',
-  styleUrl: 'wallet.scss',
-  shadow: true
+  tag: "stellar-wallet",
+  styleUrl: "wallet.scss",
+  shadow: true,
 })
 export class Wallet {
-  @State() account: StellarAccount
-  @State() prompter: Prompter = {show: false}
-  @State() error: any = null
+  @State() account: StellarAccount;
+  @State() prompter: Prompter = { show: false };
+  @State() error: any = null;
 
   // Component events
   componentWillLoad() {}
   render() {}
 
   // Stellar methods
-  createAccount = createAccount
-  copyAddress = copyAddress
-  copySecret = copySecret
-  signOut = signOut
+  createAccount = createAccount;
+  copyAddress = copyAddress;
+  copySecret = copySecret;
+  signOut = signOut;
 
   // Misc methods
-  setPrompt = setPrompt
+  setPrompt = setPrompt;
 }
 
-Wallet.prototype.componentWillLoad = componentWillLoad
-Wallet.prototype.render = render
+Wallet.prototype.componentWillLoad = componentWillLoad;
+Wallet.prototype.render = render;
 ```
 
 </CodeExample>
 
-They say the beginning is a good place to start.  Let’s do that:
+They say the beginning is a good place to start. Let’s do that:
 
 <CodeExample>
 
 ```js
-import {
-  Component,
-  State
-} from '@stencil/core'
+import { Component, State } from "@stencil/core";
 
-import componentWillLoad from './events/componentWillLoad'
-import render from './events/render'
+import componentWillLoad from "./events/componentWillLoad";
+import render from "./events/render";
 
-import createAccount from './methods/createAccount'
-import copyAddress from './methods/copyAddress'
-import copySecret from './methods/copySecret'
-import signOut from './methods/signOut'
-import setPrompt from './methods/setPrompt'
+import createAccount from "./methods/createAccount";
+import copyAddress from "./methods/copyAddress";
+import copySecret from "./methods/copySecret";
+import signOut from "./methods/signOut";
+import setPrompt from "./methods/setPrompt";
 
-import { Prompter } from '@prompt/prompt'
+import { Prompter } from "@prompt/prompt";
 ```
 
 </CodeExample>
 
 Just one import from a library we should already have installed.
 
-The other relative path imports are all the *events* and *methods* we’ll create here in a moment. For now, just generate all those files in their appropriate directories. Ensure your console is at the root of the `stellar-wallet` project before running this string of commands:
+The other relative path imports are all the _events_ and _methods_ we’ll create
+here in a moment. For now, just generate all those files in their appropriate
+directories. Ensure your console is at the root of the `stellar-wallet` project
+before running this string of commands:
 
 <CodeExample>
 
@@ -386,19 +420,23 @@ touch src/components/wallet/methods/{createAccount,copyAddress,copySecret,signOu
 
 </CodeExample>
 
-Next we have this funky line which may seem like an npm team import, but is actually a fancy typescript module alias path.
+Next we have this funky line which may seem like an npm team import, but is
+actually a fancy typescript module alias path.
 
 <CodeExample>
 
 ```ts
-import { Prompter } from '@prompt/prompt'
+import { Prompter } from "@prompt/prompt";
 ```
 
 </CodeExample>
 
-This allows us to avoid long error prone `../../../` paths and just use `@{alias}/{path?}/{module}`. In order to get this past both the linter and compiler we’ll need to modify a couple files.
+This allows us to avoid long error prone `../../../` paths and just use
+`@{alias}/{path?}/{module}`. In order to get this past both the linter and
+compiler we’ll need to modify a couple files.
 
-First, modify the `tsconfig.json` file to include these values in the `compilerOptions` object.
+First, modify the `tsconfig.json` file to include these values in the
+`compilerOptions` object.
 
 <CodeExample>
 
@@ -418,7 +456,8 @@ First, modify the `tsconfig.json` file to include these values in the `compilerO
 
 </CodeExample>
 
-Next,modify the `package.json` file to include a `_moduleAliases` key at the root of the object.
+Next,modify the `package.json` file to include a `_moduleAliases` key at the
+root of the object.
 
 <CodeExample>
 
@@ -434,7 +473,8 @@ Next,modify the `package.json` file to include a `_moduleAliases` key at the roo
 
 </CodeExample>
 
-Finally, install the `module-alias` package and add it to the top of the `src/index.ts` file.
+Finally, install the `module-alias` package and add it to the top of the
+`src/index.ts` file.
 
 <CodeExample>
 
@@ -447,13 +487,14 @@ npm i -D module-alias
 <CodeExample>
 
 ```ts
-import 'module-alias/register'
-export * from './components'
+import "module-alias/register";
+export * from "./components";
 ```
 
 </CodeExample>
 
-Cool! With any luck we should be able to use these slick alias imports for the prompt and services directories now.
+Cool! With any luck we should be able to use these slick alias imports for the
+prompt and services directories now.
 
 ## Create Stellar Account Class
 
@@ -461,14 +502,17 @@ Cool! With any luck we should be able to use these slick alias imports for the p
 
 ```ts
 interface StellarAccount {
-  publicKey: string,
-  keystore: string,
+  publicKey: string;
+  keystore: string;
 }
 ```
 
 </CodeExample>
 
-`interface` is just the TypeScript way of setting up a tidy typed class. `StellarAccount` will be our account class.  It includes the `publicKey` for easy reference later in Horizon or Astrograph calls and the Top Secret `keystore` key containing the encrypted account secret cipher.
+`interface` is just the TypeScript way of setting up a tidy typed class.
+`StellarAccount` will be our account class. It includes the `publicKey` for easy
+reference later in Horizon or Astrograph calls and the Top Secret `keystore` key
+containing the encrypted account secret cipher.
 
 <CodeExample>
 
@@ -489,45 +533,57 @@ export class Wallet {
 
 </CodeExample>
 
-Pretty standard boring bits, setting up the `@Component` with its defining values and initializing with some `@State` and `@Prop` data. You can see we’re setting up an `account` state with our `StellarAccount` class as well as a `prompter` state with that `Prompter` class from the `stellar-prompt` we imported earlier. We’re initializing that `prompter` state with a `show` value of `false` so the prompt modal rendereth not initially.
+Pretty standard boring bits, setting up the `@Component` with its defining
+values and initializing with some `@State` and `@Prop` data. You can see we’re
+setting up an `account` state with our `StellarAccount` class as well as a
+`prompter` state with that `Prompter` class from the `stellar-prompt` we
+imported earlier. We’re initializing that `prompter` state with a `show` value
+of `false` so the prompt modal rendereth not initially.
 
-Everything after this is the assignment of our imported events and methods from up above. Let’s begin with the `./events/componentWillLoad.ts`
+Everything after this is the assignment of our imported events and methods from
+up above. Let’s begin with the `./events/componentWillLoad.ts`
 
 <CodeExample>
 
 ```js
-import { handleError } from '@services/error'
-import { get } from '@services/storage'
+import { handleError } from "@services/error";
+import { get } from "@services/storage";
 
 export default async function componentWillLoad() {
   try {
-    let keystore = await get('keyStore')
+    let keystore = await get("keyStore");
 
-    this.error = null
+    this.error = null;
 
     if (keystore) {
-      keystore = atob(keystore)
+      keystore = atob(keystore);
 
-      const { publicKey } = JSON.parse(atob(JSON.parse(keystore).adata))
+      const { publicKey } = JSON.parse(atob(JSON.parse(keystore).adata));
 
       this.account = {
         publicKey,
-        keystore
-      }
+        keystore,
+      };
     }
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-`componentWillLoad` is the Stencil way of pre-filling the state and prop values before actually rendering the component. In our case we’ll use this method to populate the `account` `@State` with the saved storage `keyStore` value if there is one. At first there won’t be, so we’ll come back to this once we’ve actually gone over how to create and save accounts. For now just know it’s here, and since you’re smart, I imagine you can already kind of see how it works.
+`componentWillLoad` is the Stencil way of pre-filling the state and prop values
+before actually rendering the component. In our case we’ll use this method to
+populate the `account` `@State` with the saved storage `keyStore` value if there
+is one. At first there won’t be, so we’ll come back to this once we’ve actually
+gone over how to create and save accounts. For now just know it’s here, and
+since you’re smart, I imagine you can already kind of see how it works.
 
-“But wait!” you say, “What are the `@services/error` and `@services/storage` packages?” Fine, yes, we should go over those. Remember the module alias stuff from earlier? Well one was for `@prompt` and the other was for `@services`. Go ahead and create these two files and add them to the `src/services` directory.
+“But wait!” you say, “What are the `@services/error` and `@services/storage`
+packages?” Fine, yes, we should go over those. Remember the module alias stuff
+from earlier? Well one was for `@prompt` and the other was for `@services`. Go
+ahead and create these two files and add them to the `src/services` directory.
 
 <CodeExample>
 
@@ -543,41 +599,43 @@ touch src/services/{error,storage}.ts
 <CodeExample>
 
 ```ts
-import { get as loGet } from 'lodash-es'
+import { get as loGet } from "lodash-es";
 
 export function handleError(err: any) {
-  return loGet(err, 'response.data', loGet(err, 'message', err))
+  return loGet(err, "response.data", loGet(err, "message", err));
 }
 ```
 
 </CodeExample>
 
-Nothing fancy, just a clean little error handler we’!ll make use of later when processing API requests.
+Nothing fancy, just a clean little error handler we’!ll make use of later when
+processing API requests.
 
 ## Set Up Key Storage
+
 Next is `storage.ts`.
 
 <CodeExample>
 
 ```js
-import { Plugins } from '@capacitor/core'
+import { Plugins } from "@capacitor/core";
 
-const { Storage } = Plugins
+const { Storage } = Plugins;
 
 export async function set(key: string, value: any): Promise<void> {
   await Storage.set({
     key,
-    value
-  })
+    value,
+  });
 }
 
 export async function get(key: string): Promise<any> {
-  const item = await Storage.get({ key })
-  return item.value
+  const item = await Storage.get({ key });
+  return item.value;
 }
 
 export async function remove(key: string): Promise<void> {
-  await Storage.remove({ key })
+  await Storage.remove({ key });
 }
 ```
 
@@ -620,91 +678,127 @@ https://capacitor.ionicframework.com/docs/basics/workflow
 
 </CodeExample>
 
-We’re not really making full use of [ Capacitor ][2], but it is an amazing service so be sure and check it out! For now we just need it to make storing and retrieving our data a bit more stable.
+We’re not really making full use of [ Capacitor ][2], but it is an amazing
+service so be sure and check it out! For now we just need it to make storing and
+retrieving our data a bit more stable.
 
-This storage service is simply a key setter and getter helper for storing and retrieving data. We’ll use this for any persistent data we want to store.  For now, that's our Stellar account data.
+This storage service is simply a key setter and getter helper for storing and
+retrieving data. We’ll use this for any persistent data we want to store. For
+now, that's our Stellar account data.
 
 ## Set Up Event Handling
-That’s everything we need for the `componentWillLoad` event. On to the `./events/render.tsx` file.
+
+That’s everything we need for the `componentWillLoad` event. On to the
+`./events/render.tsx` file.
 
 <CodeExample>
 
 ```tsx
-import { h } from '@stencil/core'
+import { h } from "@stencil/core";
 
 export default function render() {
   return [
     <stellar-prompt prompter={this.prompter} />,
-    this.account
-    ? [
-      <div class="account-key">
-        <p>{this.account.publicKey}</p>
-        <button class="small" type="button" onClick={(e) => this.copyAddress(e)}>Copy Address</button>
-        <button class="small" type="button" onClick={(e) => this.copySecret(e)}>Copy Secret</button>
-      </div>,
-    ]
-    : <button type="button" onClick={(e) => this.createAccount(e)}>Create Account</button>,
+    this.account ? (
+      [
+        <div class="account-key">
+          <p>{this.account.publicKey}</p>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copyAddress(e)}
+          >
+            Copy Address
+          </button>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copySecret(e)}
+          >
+            Copy Secret
+          </button>
+        </div>,
+      ]
+    ) : (
+      <button type="button" onClick={(e) => this.createAccount(e)}>
+        Create Account
+      </button>
+    ),
 
-    this.error ? <pre class="error">{JSON.stringify(this.error, null, 2)}</pre> : null,
-    this.account ? <button type="button" onClick={(e) => this.signOut(e)}>Sign Out</button> : null,
-  ]
+    this.error ? (
+      <pre class="error">{JSON.stringify(this.error, null, 2)}</pre>
+    ) : null,
+    this.account ? (
+      <button type="button" onClick={(e) => this.signOut(e)}>
+        Sign Out
+      </button>
+    ) : null,
+  ];
 }
 ```
 
 </CodeExample>
 
-It looks messy, but it’s actually a pretty simple `.tsx` file rendering out our DOM based off a series of conditional values. You can see we’re including the  `stellar-prompt` component, and setting the prompter prop to our `this.prompter` state. We then have a ternary operation toggling between a Create Account button and a basic account UI. If `this.account` has a truthy value, we’ll print out the account’s `publicKey` along with some interaction buttons. If `this.account` is falsey, we’ll print out a singular Create Account button connected to, you guessed it, the `createAccount` method. After that logic, we print out an error if there is one, and finally a Sign Out button if there’s an account to sign out of. Those are the two `Wallet` `@Component` events.
+It looks messy, but it’s actually a pretty simple `.tsx` file rendering out our
+DOM based off a series of conditional values. You can see we’re including the
+`stellar-prompt` component, and setting the prompter prop to our `this.prompter`
+state. We then have a ternary operation toggling between a Create Account button
+and a basic account UI. If `this.account` has a truthy value, we’ll print out
+the account’s `publicKey` along with some interaction buttons. If `this.account`
+is falsey, we’ll print out a singular Create Account button connected to, you
+guessed it, the `createAccount` method. After that logic, we print out an error
+if there is one, and finally a Sign Out button if there’s an account to sign out
+of. Those are the two `Wallet` `@Component` events.
 
 ## Create Methods
-Let’s look at the methods now beginning with the `./methods/createAccount.ts` file.
+
+Let’s look at the methods now beginning with the `./methods/createAccount.ts`
+file.
 
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
-import { Keypair } from 'stellar-sdk'
+import sjcl from "@tinyanvil/sjcl";
+import { Keypair } from "stellar-sdk";
 
-import { handleError } from '@services/error'
-import { set } from '@services/storage'
+import { handleError } from "@services/error";
+import { set } from "@services/storage";
 
 export default async function createAccount(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    const pincode_1 = await this.setPrompt('Enter a keystore pincode')
-    const pincode_2 = await this.setPrompt('Enter keystore pincode again')
+    const pincode_1 = await this.setPrompt("Enter a keystore pincode");
+    const pincode_2 = await this.setPrompt("Enter keystore pincode again");
 
-    if (
-      !pincode_1
-      || !pincode_2
-      || pincode_1 !== pincode_2
-    ) throw 'Invalid pincode'
+    if (!pincode_1 || !pincode_2 || pincode_1 !== pincode_2)
+      throw "Invalid pincode";
 
-    this.error = null
+    this.error = null;
 
-    const keypair = Keypair.random()
+    const keypair = Keypair.random();
 
     this.account = {
       publicKey: keypair.publicKey(),
       keystore: sjcl.encrypt(pincode_1, keypair.secret(), {
         adata: JSON.stringify({
-          publicKey: keypair.publicKey()
-        })
-      })
-    }
+          publicKey: keypair.publicKey(),
+        }),
+      }),
+    };
 
-    await set('keyStore', btoa(this.account.keystore))
-  }
-
-  catch(err) {
-    this.error = handleError(err)
+    await set("keyStore", btoa(this.account.keystore));
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-Aha! Finally something interesting. This method forms the meat of our component. Before we dive into it, though let’s install the missing `@tinyanvil/sjcl` package.
+Aha! Finally something interesting. This method forms the meat of our component.
+Before we dive into it, though let’s install the missing `@tinyanvil/sjcl`
+package.
 
 <CodeExample>
 
@@ -715,27 +809,40 @@ npm i -D @tinyanvil/sjcl
 </CodeExample>
 
 ## Create an Account
-Essentially all we’re doing is making a request to create an account, which triggers the Prompt modal to ask for a pincode.  That pincode will be used in the `sjcl.encrypt` method to encrypt the secret key from the `Keypair.random()` method. We set the `this.account` with the `publicKey`, which encrypted the `keystore` cipher, and now we're storing that cipher in base64 format in `localStorage` via our `set('keyStore')` method for easy retrieval when the browser reloads. We could also encode that cipher into a QR code or a link to share with other devices. Since it requires the pincode that encrypted cipher, it's as secure as the pincode you encrypt it with.
+
+Essentially all we’re doing is making a request to create an account, which
+triggers the Prompt modal to ask for a pincode. That pincode will be used in the
+`sjcl.encrypt` method to encrypt the secret key from the `Keypair.random()`
+method. We set the `this.account` with the `publicKey`, which encrypted the
+`keystore` cipher, and now we're storing that cipher in base64 format in
+`localStorage` via our `set('keyStore')` method for easy retrieval when the
+browser reloads. We could also encode that cipher into a QR code or a link to
+share with other devices. Since it requires the pincode that encrypted cipher,
+it's as secure as the pincode you encrypt it with.
 
 ## Copy Address
-Now that we’ve created an account, there are three more actions we'll enable: `copyAddress`, `copySecret`, and `signOut`.
+
+Now that we’ve created an account, there are three more actions we'll enable:
+`copyAddress`, `copySecret`, and `signOut`.
 
 First `./methods/copyAddress.ts`
 
 <CodeExample>
 
 ```ts
-import copy from 'copy-to-clipboard'
+import copy from "copy-to-clipboard";
 
 export default async function copyAddress(e: Event) {
-  e.preventDefault()
-  copy(this.account.publicKey)
+  e.preventDefault();
+  copy(this.account.publicKey);
 }
 ```
 
 </CodeExample>
 
-Well there you go, the easiest code you’ll see all day. Just `copy` the `publicKey` from the `this.account` object to the clipboard. Before we jump though don’t forget to install that `copy-to-clipboard` package.
+Well there you go, the easiest code you’ll see all day. Just `copy` the
+`publicKey` from the `this.account` object to the clipboard. Before we jump
+though don’t forget to install that `copy-to-clipboard` package.
 
 <CodeExample>
 
@@ -746,79 +853,84 @@ npm i -D copy-to-clipboard
 </CodeExample>
 
 ## Copy Secret
+
 Next `./methods/copySecret.ts`
 
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
-import copy from 'copy-to-clipboard'
+import sjcl from "@tinyanvil/sjcl";
+import copy from "copy-to-clipboard";
 
-import { handleError } from '@services/error'
+import { handleError } from "@services/error";
 
 export default async function copySecret(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    const pincode = await this.setPrompt('Enter your keystore pincode')
+    const pincode = await this.setPrompt("Enter your keystore pincode");
 
-    if (!pincode)
-      return
+    if (!pincode) return;
 
-    this.error = null
+    this.error = null;
 
-    const secret = sjcl.decrypt(pincode, this.account.keystore)
-    copy(secret)
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+    const secret = sjcl.decrypt(pincode, this.account.keystore);
+    copy(secret);
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-You may not actually include this in your production wallet, but for now it's a simple demonstration of how to programmatically gain access to the secret key at a later date for making payments, creating trustlines, etc. It’s essentially the `createAccount` in reverse: it asks for the pincode to decrypt the keystore which, once decrypted, we `copy` into the clipboard.
+You may not actually include this in your production wallet, but for now it's a
+simple demonstration of how to programmatically gain access to the secret key at
+a later date for making payments, creating trustlines, etc. It’s essentially the
+`createAccount` in reverse: it asks for the pincode to decrypt the keystore
+which, once decrypted, we `copy` into the clipboard.
 
 ## Sign Out
+
 Finally `./methods/signOut.ts`
 
 <CodeExample>
 
 ```ts
-import { remove } from '@services/storage'
-import { handleError } from '@services/error'
+import { remove } from "@services/storage";
+import { handleError } from "@services/error";
 
 export default async function signOut(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    const confirmNuke = await this.setPrompt('Are you sure? This will nuke your account', 'Enter NUKE to confirm')
+    const confirmNuke = await this.setPrompt(
+      "Are you sure? This will nuke your account",
+      "Enter NUKE to confirm",
+    );
 
-    if (
-      !confirm
-      || !/nuke/gi.test(confirmNuke)
-    ) return
+    if (!confirm || !/nuke/gi.test(confirmNuke)) return;
 
-    this.error = null
+    this.error = null;
 
-    await remove('keyStore')
-    location.reload()
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+    await remove("keyStore");
+    location.reload();
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-It’s important to allow users to nuke their account, but we need to be careful to confirm that action with our faithful `setPrompt`. Once they opt to “NUKE” the account we can remove the `keyStore` and reload the app.
+It’s important to allow users to nuke their account, but we need to be careful
+to confirm that action with our faithful `setPrompt`. Once they opt to “NUKE”
+the account we can remove the `keyStore` and reload the app.
 
 ## Set Prompt
-Speaking of `setPrompt` the last method in our `wallet.ts` file is `./methods/setPrompt.ts`.
+
+Speaking of `setPrompt` the last method in our `wallet.ts` file is
+`./methods/setPrompt.ts`.
 
 <CodeExample>
 
@@ -826,31 +938,36 @@ Speaking of `setPrompt` the last method in our `wallet.ts` file is `./methods/se
 export default function setPrompt(
   message: string,
   placeholder?: string,
-  options?: Array<any>
+  options?: Array<any>,
 ): Promise<string> {
   this.prompter = {
     ...this.prompter,
     show: true,
     message,
     placeholder,
-    options
-  }
+    options,
+  };
 
   return new Promise((resolve, reject) => {
-    this.prompter.resolve = resolve
-    this.prompter.reject = reject
-  })
+    this.prompter.resolve = resolve;
+    this.prompter.reject = reject;
+  });
 }
 ```
 
 </CodeExample>
 
-In `setPrompt`, we see how the prompt state is set, and how the Promise is set up to allow us to wait on the prompt whenever we call this method. It’s actually pretty slick, and it might be worth looking back at the `src/components/prompt/prompt.tsx` to see how the `resolve` and `reject` functions get called. It’s not central to our wallet creation, but it’s a pretty handy little component that will serve us well in the future as we continue to request input from the user.
+In `setPrompt`, we see how the prompt state is set, and how the Promise is set
+up to allow us to wait on the prompt whenever we call this method. It’s actually
+pretty slick, and it might be worth looking back at the
+`src/components/prompt/prompt.tsx` to see how the `resolve` and `reject`
+functions get called. It’s not central to our wallet creation, but it’s a pretty
+handy little component that will serve us well in the future as we continue to
+request input from the user.
 
-That’s it folks! Restart the server with `npm start` and you’ve got a perfectly legitimate, minimal Stellar wallet key creation and storage Web Component! It's a solid foundation for a non-custodial wallet that relies on a simple pincode. 
+That’s it folks! Restart the server with `npm start` and you’ve got a perfectly
+legitimate, minimal Stellar wallet key creation and storage Web Component! It's
+a solid foundation for a non-custodial wallet that relies on a simple pincode.
 
-
-[1]:	https://github.com/stellar/stellar-demo-wallet/tree/setup
-[2]:	https://capacitor.ionicframework.com/ "Capacitor"
-
-
+[1]: https://github.com/stellar/stellar-demo-wallet/tree/setup
+[2]: https://capacitor.ionicframework.com/ "Capacitor"

--- a/content/docs/building-apps/connect-to-anchors/deposit-anchored-assets.mdx
+++ b/content/docs/building-apps/connect-to-anchors/deposit-anchored-assets.mdx
@@ -3,156 +3,181 @@ title: Deposit anchored assets
 order: 20
 ---
 
-
 import { CodeExample } from "components/CodeExample";
 import { Alert } from "components/Alert";
 
 <Alert>
 
-This section of the tutorial takes the [basic wallet](../basic-wallet.mdx) with [trustlines](../custom-assets.mdx) and [anchor connections](./setup-for-anchored-assets.mdx) enabled and adds the ability to initiate in-app deposits with an Anchor.  If you have all that ready, and the stellar.toml file is loaded into a `@Prop` on your component, you’re ready to begin the initial deposit of their asset into our wallet. 
+This section of the tutorial takes the [basic wallet](../basic-wallet.mdx) with
+[trustlines](../custom-assets.mdx) and
+[anchor connections](./setup-for-anchored-assets.mdx) enabled and adds the
+ability to initiate in-app deposits with an Anchor. If you have all that ready,
+and the stellar.toml file is loaded into a `@Prop` on your component, you’re
+ready to begin the initial deposit of their asset into our wallet.
 
 </Alert>
 
 ## Create Deposit Method
+
 Let’s create `./methods/depositAsset.ts`.
 
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
-import {
-  Transaction,
-  Keypair,
-} from 'stellar-sdk'
-import axios from 'axios'
+import sjcl from "@tinyanvil/sjcl";
+import { Transaction, Keypair } from "stellar-sdk";
+import axios from "axios";
 import {
   get as loGet,
   each as loEach,
   findIndex as loFindIndex,
-} from 'lodash-es'
+} from "lodash-es";
 
-import { handleError } from '@services/error'
+import { handleError } from "@services/error";
 
 export default async function depositAsset(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    let currency = await this.setPrompt('Select the currency you\'d like to deposit', null, this.toml.CURRENCIES)
-        currency = currency.split(':')
+    let currency = await this.setPrompt(
+      "Select the currency you'd like to deposit",
+      null,
+      this.toml.CURRENCIES,
+    );
+    currency = currency.split(":");
 
-    const pincode = await this.setPrompt('Enter your keystore pincode')
+    const pincode = await this.setPrompt("Enter your keystore pincode");
 
-    if (!pincode)
-        return
+    if (!pincode) return;
 
-    const balances = loGet(this.account, 'state.balances')
+    const balances = loGet(this.account, "state.balances");
     const hasCurrency = loFindIndex(balances, {
       asset_code: currency[0],
-      asset_issuer: currency[1]
-    })
+      asset_issuer: currency[1],
+    });
 
     if (hasCurrency === -1)
-      await this.trustAsset(null, currency[0], currency[1], pincode)
+      await this.trustAsset(null, currency[0], currency[1], pincode);
 
-    const info = await axios.get(`${this.toml.TRANSFER_SERVER}/info`)
-    .then(({data}) => data)
+    const info = await axios
+      .get(`${this.toml.TRANSFER_SERVER}/info`)
+      .then(({ data }) => data);
 
-    console.log(info)
+    console.log(info);
 
-    const auth = await axios.get(`${this.toml.WEB_AUTH_ENDPOINT}`, {
-      params: {
-        account: this.account.publicKey
-      }
-    })
-    .then(async ({data}) => {
-      const transaction: any = new Transaction(data.transaction, data.network_passphrase)
+    const auth = await axios
+      .get(`${this.toml.WEB_AUTH_ENDPOINT}`, {
+        params: {
+          account: this.account.publicKey,
+        },
+      })
+      .then(async ({ data }) => {
+        const transaction: any = new Transaction(
+          data.transaction,
+          data.network_passphrase,
+        );
 
-      this.error = null
-      this.loading = {...this.loading, deposit: true}
+        this.error = null;
+        this.loading = { ...this.loading, deposit: true };
 
-      const keypair = Keypair.fromSecret(
-        sjcl.decrypt(pincode, this.account.keystore)
+        const keypair = Keypair.fromSecret(
+          sjcl.decrypt(pincode, this.account.keystore),
+        );
+
+        transaction.sign(keypair);
+        return transaction.toXDR();
+      })
+      .then((transaction) =>
+        axios.post(
+          `${this.toml.WEB_AUTH_ENDPOINT}`,
+          { transaction },
+          { headers: { "Content-Type": "application/json" } },
+        ),
       )
+      .then(({ data: { token } }) => token);
 
-      transaction.sign(keypair)
-      return transaction.toXDR()
-    })
-    .then((transaction) => axios.post(`${this.toml.WEB_AUTH_ENDPOINT}`, {transaction}, {headers: {'Content-Type': 'application/json'}}))
-    .then(({data: {token}}) => token)
+    console.log(auth);
 
-    console.log(auth)
+    const formData = new FormData();
 
-    const formData = new FormData()
-
-    loEach({
-      asset_code: currency[0],
-      account: this.account.publicKey,
-      lang: 'en'
-    }, (value, key) => formData.append(key, value))
-
-    const interactive = await axios.post(`${this.toml.TRANSFER_SERVER}/transactions/deposit/interactive`, formData, {
-      headers: {
-        'Authorization': `Bearer ${auth}`,
-        'Content-Type': 'multipart/form-data'
-      }
-    }).then(({data}) => data)
-
-    console.log(interactive)
-
-    const transactions = await axios.get(`${this.toml.TRANSFER_SERVER}/transactions`, {
-      params: {
+    loEach(
+      {
         asset_code: currency[0],
-        limit: 1,
-        kind: 'deposit',
+        account: this.account.publicKey,
+        lang: "en",
       },
-      headers: {
-        'Authorization': `Bearer ${auth}`
-      }
-    })
-    .then(({data: {transactions}}) => transactions)
+      (value, key) => formData.append(key, value),
+    );
 
-    console.log(transactions)
+    const interactive = await axios
+      .post(
+        `${this.toml.TRANSFER_SERVER}/transactions/deposit/interactive`,
+        formData,
+        {
+          headers: {
+            Authorization: `Bearer ${auth}`,
+            "Content-Type": "multipart/form-data",
+          },
+        },
+      )
+      .then(({ data }) => data);
 
-    const urlBuilder = new URL(interactive.url)
-          urlBuilder.searchParams.set('callback', 'postMessage')
-    const popup = open(urlBuilder.toString(), 'popup', 'width=500,height=800')
+    console.log(interactive);
+
+    const transactions = await axios
+      .get(`${this.toml.TRANSFER_SERVER}/transactions`, {
+        params: {
+          asset_code: currency[0],
+          limit: 1,
+          kind: "deposit",
+        },
+        headers: {
+          Authorization: `Bearer ${auth}`,
+        },
+      })
+      .then(({ data: { transactions } }) => transactions);
+
+    console.log(transactions);
+
+    const urlBuilder = new URL(interactive.url);
+    urlBuilder.searchParams.set("callback", "postMessage");
+    const popup = open(urlBuilder.toString(), "popup", "width=500,height=800");
 
     if (!popup) {
-      this.loading = {...this.loading, deposit: false}
-      throw 'Popups are blocked. You\'ll need to enable popups for this demo to work'
+      this.loading = { ...this.loading, deposit: false };
+      throw "Popups are blocked. You'll need to enable popups for this demo to work";
     }
 
-    window.onmessage = ({data: {transaction}}) => {
-      console.log(transaction.status, transaction)
+    window.onmessage = ({ data: { transaction } }) => {
+      console.log(transaction.status, transaction);
 
-      if (transaction.status === 'completed') {
-        this.updateAccount()
-        this.loading = {...this.loading, deposit: false}
-      }
-
-      else {
+      if (transaction.status === "completed") {
+        this.updateAccount();
+        this.loading = { ...this.loading, deposit: false };
+      } else {
         setTimeout(() => {
-          const urlBuilder = new URL(transaction.more_info_url)
-                urlBuilder.searchParams.set('callback', 'postMessage')
+          const urlBuilder = new URL(transaction.more_info_url);
+          urlBuilder.searchParams.set("callback", "postMessage");
 
-          popup.location.replace(urlBuilder.toString())
-        }, 1000)
+          popup.location.replace(urlBuilder.toString());
+        }, 1000);
       }
-    }
-  }
-
-  catch (err) {
-    this.loading = {...this.loading, deposit: false}
-    this.error = handleError(err)
+    };
+  } catch (err) {
+    this.loading = { ...this.loading, deposit: false };
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-It’s a lot of code, but keep in mind this is everything we need to completely interoperate with financial infrastructure foreign to the Stellar ecosystem, which is a big ask and in \~130 lines of code.  It’s a modern day miracle!
+It’s a lot of code, but keep in mind this is everything we need to completely
+interoperate with financial infrastructure foreign to the Stellar ecosystem,
+which is a big ask and in \~130 lines of code. It’s a modern day miracle!
 
 ## Currency Code and Issuer Prompt
+
 First things first install the missing `axios` package.
 
 <CodeExample>
@@ -163,7 +188,8 @@ npm i -D axios
 
 </CodeExample>
 
-We’ll skip the rest of the top import stuff as you’re well aware of what that is, and we’ve installed and walked through anything noteworthy here already.
+We’ll skip the rest of the top import stuff as you’re well aware of what that
+is, and we’ve installed and walked through anything noteworthy here already.
 
 <CodeExample>
 
@@ -187,99 +213,156 @@ export default async function depositAsset(e: Event) {
 
 </CodeExample>
 
-Only thing here we haven’t seen before is the prompt selection of the currency code and issuer we’d like to deposit. To get this, we send the `this.setPrompt` a final options array argument, in this case the values from `this.toml.CURRENCIES`. This will open the prompt with a select\<\>options input field rather than a text input field.
+Only thing here we haven’t seen before is the prompt selection of the currency
+code and issuer we’d like to deposit. To get this, we send the `this.setPrompt`
+a final options array argument, in this case the values from
+`this.toml.CURRENCIES`. This will open the prompt with a select\<\>options input
+field rather than a text input field.
 
 ![][image-1]
 
-That selection will come back as a string in the form of `{code}:{issuer}` so we split that by the `:` so we’ll have a nice tidy array of `[{code}, {issuer}]` to use later.
+That selection will come back as a string in the form of `{code}:{issuer}` so we
+split that by the `:` so we’ll have a nice tidy array of `[{code}, {issuer}]` to
+use later.
 
 ## Check Trustline
+
 <CodeExample>
 
 ```ts
-const balances = loGet(this.account, 'state.balances')
+const balances = loGet(this.account, "state.balances");
 const hasCurrency = loFindIndex(balances, {
   asset_code: currency[0],
-  asset_issuer: currency[1]
-})
+  asset_issuer: currency[1],
+});
 
 if (hasCurrency === -1)
-  await this.trustAsset(null, currency[0], currency[1], pincode)
+  await this.trustAsset(null, currency[0], currency[1], pincode);
 ```
 
 </CodeExample>
 
-Once we’ve got the currency we’re dealing with we need to check if we have a trustline for that asset setup for our account. The anchor won’t be able to deposit their token into our account if we don’t have a trustline set for it first. So we get the balance from the `this.account.state` and then inspect the `balances` to see if that currency exists. If it doesn’t we trigger the `this.trustAsset` method with the arguments set to automatically add that trustline to our account.
+Once we’ve got the currency we’re dealing with we need to check if we have a
+trustline for that asset setup for our account. The anchor won’t be able to
+deposit their token into our account if we don’t have a trustline set for it
+first. So we get the balance from the `this.account.state` and then inspect the
+`balances` to see if that currency exists. If it doesn’t we trigger the
+`this.trustAsset` method with the arguments set to automatically add that
+trustline to our account.
 
 ## Get Info
+
 <CodeExample>
 
 ```ts
-const info = await axios.get(`${this.toml.TRANSFER_SERVER}/info`)
-.then(({data}) => data)
+const info = await axios
+  .get(`${this.toml.TRANSFER_SERVER}/info`)
+  .then(({ data }) => data);
 
-console.log(info)
+console.log(info);
 ```
 
 </CodeExample>
 
-Once our account is setup, it’s time to start asking the Anchor some questions about itself and the features it supports. We get at that info by calling a GET on the `TRANSFER_SERVER/info` url from the anchor’s TOML file. We won’t make use of any of this data right now, but this is where you'd find fee and feature information which to display in you UI for your wallet user to review.
+Once our account is setup, it’s time to start asking the Anchor some questions
+about itself and the features it supports. We get at that info by calling a GET
+on the `TRANSFER_SERVER/info` url from the anchor’s TOML file. We won’t make use
+of any of this data right now, but this is where you'd find fee and feature
+information which to display in you UI for your wallet user to review.
 
 ## Create Authenticated User Session
+
 <CodeExample>
 
 ```ts
-const auth = await axios.get(`${this.toml.WEB_AUTH_ENDPOINT}`, {
-  params: {
-    account: this.account.publicKey
-  }
-})
-.then(async ({data: {transaction, network_passphrase}}) => {
-  const txn: any = new Transaction(transaction, network_passphrase)
+const auth = await axios
+  .get(`${this.toml.WEB_AUTH_ENDPOINT}`, {
+    params: {
+      account: this.account.publicKey,
+    },
+  })
+  .then(async ({ data: { transaction, network_passphrase } }) => {
+    const txn: any = new Transaction(transaction, network_passphrase);
 
-  this.error = null
-  this.loading = {...this.loading, withdraw: true}
+    this.error = null;
+    this.loading = { ...this.loading, withdraw: true };
 
-  txn.sign(keypair)
-  return txn.toXDR()
-})
-.then((transaction) => axios.post(`${this.toml.WEB_AUTH_ENDPOINT}`, {transaction}, {headers: {'Content-Type': 'application/json'}}))
-.then(({data: {token}}) => token)
+    txn.sign(keypair);
+    return txn.toXDR();
+  })
+  .then((transaction) =>
+    axios.post(
+      `${this.toml.WEB_AUTH_ENDPOINT}`,
+      { transaction },
+      { headers: { "Content-Type": "application/json" } },
+    ),
+  )
+  .then(({ data: { token } }) => token);
 
-console.log(auth)
+console.log(auth);
 ```
 
 </CodeExample>
 
-This call is actually a part of [SEP-0010](link), which allows us to verify ownership of a user's public key so the Anchor knows the deposit request is coming from a valid entity. You don’t want someone else issuing deposit requests on your account, so to prove you control the Stellar account request the deposit, you sign a dummy authentication transaction and send it to the Anchor's web auth server.  The server responds with a JWT token, which will be used to verify all further API calls to the anchor.  For more info on how this works, check out the user authetication from an [Anchor's point of view](link).
+This call is actually a part of [SEP-0010](link), which allows us to verify
+ownership of a user's public key so the Anchor knows the deposit request is
+coming from a valid entity. You don’t want someone else issuing deposit requests
+on your account, so to prove you control the Stellar account request the
+deposit, you sign a dummy authentication transaction and send it to the Anchor's
+web auth server. The server responds with a JWT token, which will be used to
+verify all further API calls to the anchor. For more info on how this works,
+check out the user authetication from an [Anchor's point of view](link).
 
-The endpoint for creating an authenticated user session is specified the `WEB_AUTH_ENDPOINT` on an Anchor's stellar.toml file. The first thing our wallet does is make a GET request with a public `account` param which will send back an unsigned Stellar transaction for that account that has in invalide sequence number, so it doesn't actually *do* anything when submitted to the network. In response you’ll sign that transaction on behalf of the user and POST it back. If the signature checks out, the success response will contain an Authorization Bearer header JWT which you’ll want to store and use for all future interactions with the Anchor.
+The endpoint for creating an authenticated user session is specified the
+`WEB_AUTH_ENDPOINT` on an Anchor's stellar.toml file. The first thing our wallet
+does is make a GET request with a public `account` param which will send back an
+unsigned Stellar transaction for that account that has in invalide sequence
+number, so it doesn't actually _do_ anything when submitted to the network. In
+response you’ll sign that transaction on behalf of the user and POST it back. If
+the signature checks out, the success response will contain an Authorization
+Bearer header JWT which you’ll want to store and use for all future interactions
+with the Anchor.
 
 ## Initiate Deposit
+
 <CodeExample>
 
 ```ts
-const formData = new FormData()
+const formData = new FormData();
 
-loEach({
-  asset_code: currency[0],
-  account: this.account.publicKey,
-  lang: 'en'
-}, (value, key) => formData.append(key, value))
+loEach(
+  {
+    asset_code: currency[0],
+    account: this.account.publicKey,
+    lang: "en",
+  },
+  (value, key) => formData.append(key, value),
+);
 
-const interactive = await axios.post(`${this.toml.TRANSFER_SERVER}/transactions/withdraw/interactive`, formData, {
-  headers: {
-    'Authorization': `Bearer ${auth}`,
-    'Content-Type': 'multipart/form-data'
-  }
-}).then(({data}) => data)
+const interactive = await axios
+  .post(
+    `${this.toml.TRANSFER_SERVER}/transactions/withdraw/interactive`,
+    formData,
+    {
+      headers: {
+        Authorization: `Bearer ${auth}`,
+        "Content-Type": "multipart/form-data",
+      },
+    },
+  )
+  .then(({ data }) => data);
 
-console.log(interactive)
+console.log(interactive);
 ```
 
 </CodeExample>
 
-This call is our first little bit of magic. Once we setup our `multipart/form-data` entry values we can POST them to the `${this.toml.TRANSFER_SERVER}/transactions/withdraw/interactive` endpoint along with our `auth` Authorization Bearer `auth` token we acquired earlier. The response to this call will contain a special url that allows a usder to interact directly with the Anchor to provide the data required for a deposit.
+This call is our first little bit of magic. Once we setup our
+`multipart/form-data` entry values we can POST them to the
+`${this.toml.TRANSFER_SERVER}/transactions/withdraw/interactive` endpoint along
+with our `auth` Authorization Bearer `auth` token we acquired earlier. The
+response to this call will contain a special url that allows a usder to interact
+directly with the Anchor to provide the data required for a deposit.
 
 <CodeExample>
 
@@ -293,25 +376,29 @@ This call is our first little bit of magic. Once we setup our `multipart/form-da
 
 </CodeExample>
 
-In a moment we’ll open that `url` in an iframe, popup, or new tab. Once we’ve sent that request, there will be a pending transaction request we can inspect at the `${this.toml.TRANSFER_SERVER}/transactions` route.
+In a moment we’ll open that `url` in an iframe, popup, or new tab. Once we’ve
+sent that request, there will be a pending transaction request we can inspect at
+the `${this.toml.TRANSFER_SERVER}/transactions` route.
 
 ## Check Transaction Status
+
 <CodeExample>
 
 ```ts
-const transactions = await axios.get(`${this.toml.TRANSFER_SERVER}/transactions`, {
-  params: {
-    asset_code: currency[0],
-    limit: 1,
-    kind: 'deposit',
-  },
-  headers: {
-    'Authorization': `Bearer ${auth}`
-  }
-})
-.then(({data: {transactions}}) => transactions)
+const transactions = await axios
+  .get(`${this.toml.TRANSFER_SERVER}/transactions`, {
+    params: {
+      asset_code: currency[0],
+      limit: 1,
+      kind: "deposit",
+    },
+    headers: {
+      Authorization: `Bearer ${auth}`,
+    },
+  })
+  .then(({ data: { transactions } }) => transactions);
 
-console.log(transactions)
+console.log(transactions);
 ```
 
 </CodeExample>
@@ -349,27 +436,38 @@ This request should return the deposit status for the request we just made.
 
 </CodeExample>
 
-Once we’re certain we’ve got a `"status": "incomplete",` which is the correct response since we haven't served the user the URL that allows them to initiate a deposit, we know everything's working, so we can go back to the `interactive.url` route and open that to begin filling out the deposit requirements.
+Once we’re certain we’ve got a `"status": "incomplete",` which is the correct
+response since we haven't served the user the URL that allows them to initiate a
+deposit, we know everything's working, so we can go back to the
+`interactive.url` route and open that to begin filling out the deposit
+requirements.
 
 ## Serve the Anchor Webapp
+
 <CodeExample>
 
 ```ts
-    const urlBuilder = new URL(interactive.url)
-          urlBuilder.searchParams.set('callback', 'postMessage')
-    const popup = open(urlBuilder.toString(), 'popup', 'width=500,height=800')
+const urlBuilder = new URL(interactive.url);
+urlBuilder.searchParams.set("callback", "postMessage");
+const popup = open(urlBuilder.toString(), "popup", "width=500,height=800");
 
-    if (!popup) {
-      this.loading = {...this.loading, deposit: false}
-      throw 'Popups are blocked. You\'ll need to enable popups for this demo to work'
-    }
+if (!popup) {
+  this.loading = { ...this.loading, deposit: false };
+  throw "Popups are blocked. You'll need to enable popups for this demo to work";
+}
 ```
 
 </CodeExample>
 
-We’ll opt for a popup. When you first open that url, it’s likely the anchor will ask for some level of KYC data from the user: name, email, address, verification docs like bank statements, passport, or license, etc. The SDF demo server we're using — which is hooked up to the testnet — will ask for name and email. 
+We’ll opt for a popup. When you first open that url, it’s likely the anchor will
+ask for some level of KYC data from the user: name, email, address, verification
+docs like bank statements, passport, or license, etc. The SDF demo server we're
+using — which is hooked up to the testnet — will ask for name and email.
 
-After passing that screen your user enters the amount of an asset they'd like to deposit on the next screen. If, for instance, a user enters $500, once that deposit clears — and on this demo it clears automatically — the Anchor will credit the user's wallet with 500 of the token **less any fees**. In our case, the user ends up with 498.95: 1.05 is taken out in fees for a $500 deposit.
+After passing that screen your user enters the amount of an asset they'd like to
+deposit on the next screen. If, for instance, a user enters
+$500, once that deposit clears — and on this demo it clears automatically — the Anchor will credit the user's wallet with 500 of the token **less any fees**. In our case, the user ends up with 498.95: 1.05 is taken out in fees for a $500
+deposit.
 
 If popups are disabled, we should kill the loader and show that error in the UI.
 
@@ -405,12 +503,24 @@ If popups are disabled, we should kill the loader and show that error in the UI.
 </CodeExample>
 
 ## Check Deposit Status
-SEP-0024 allows specifies two methods for further communication between the anchor window and the wallet: a POST JSON for when you have a server, message and postMessage for when you have a client-side service. We don’t have a server, so we opt for the `urlBuilder.searchParams.set('callback', 'postMessage')`. With that set, we can setup a window `'message'` event listener which will fire whenever the anchor popup window sends a `postMessage` to our popup `window`. From there we just listen to the popup message until `transaction.status` equals `'completed'`.  At that point our deposit has succeeded, and we can `this.updateAccount()` and kill the loader. If the transaction is still in a pending status we’ll wait 1 second before reloading the anchor popup window and checking again.
 
-If at any point during this flow there’s an error we should catch that, kill the loader, and display the error to the user.
+SEP-0024 allows specifies two methods for further communication between the
+anchor window and the wallet: a POST JSON for when you have a server, message
+and postMessage for when you have a client-side service. We don’t have a server,
+so we opt for the `urlBuilder.searchParams.set('callback', 'postMessage')`. With
+that set, we can setup a window `'message'` event listener which will fire
+whenever the anchor popup window sends a `postMessage` to our popup `window`.
+From there we just listen to the popup message until `transaction.status` equals
+`'completed'`. At that point our deposit has succeeded, and we can
+`this.updateAccount()` and kill the loader. If the transaction is still in a
+pending status we’ll wait 1 second before reloading the anchor popup window and
+checking again.
 
-Whew!
-\*wipes sweat from brow then hands on sleeves
-Nice work! “Just like that” we’ve deposited an anchored asset into our wallet! We can now make payments with that asset to anyone else who has a trustline enabled for this asset.
+If at any point during this flow there’s an error we should catch that, kill the
+loader, and display the error to the user.
 
-[image-1]:	https://tyler.link/y419zR+
+Whew! \*wipes sweat from brow then hands on sleeves Nice work! “Just like that”
+we’ve deposited an anchored asset into our wallet! We can now make payments with
+that asset to anyone else who has a trustline enabled for this asset.
+
+[image-1]: https://tyler.link/y419zR+

--- a/content/docs/building-apps/connect-to-anchors/index.mdx
+++ b/content/docs/building-apps/connect-to-anchors/index.mdx
@@ -2,12 +2,36 @@
 title: Interoperability Basics
 order: 0
 ---
-Stellar makes it easy to issue assets and to connect them to existing banking rails so that users can move value onto — and off of — the network.  The services that create those connections are called **anchors**, and you can read all about how they work and what they do in [Enable Deposit and Withdrawal](../../enabling-deposit-and-withdrawal/index.mdx).  
 
-Most Anchors set up infrastructure to enable wallets to offer in-app deposits and withdrawals by following best practices specified in Stellar Ecosystem Proposals.  SEPs are publicly created, open-source documents that live in a [Github repository](https://github.com/stellar/stellar-protocol/tree/master/ecosystem#stellar-ecosystem-proposals-seps).  They define how different institutions (such as asset issuers, wallets, exchanges, and service providers) should interact and interoperate.  If you're building an app, you can implement the client side of some key SEPs and immediately give your users access to a whole world of local fiat currencies  
+Stellar makes it easy to issue assets and to connect them to existing banking
+rails so that users can move value onto — and off of — the network. The services
+that create those connections are called **anchors**, and you can read all about
+how they work and what they do in
+[Enable Deposit and Withdrawal](../../enabling-deposit-and-withdrawal/index.mdx).
 
-This part of the tutorial will focus on the Interactive Anchor/Wallet Asset Transfer Server SEP (aka SEP-24), which defines the specs for deposit and withdrawal implementations. It's focused on the client side of interactive user flows — meaning flows where users interact with an Anchor-hosted interface rendered inside a wallet — and by the end, you should have an implemenation which can be re-purposed to work with any SEP-supporting Anchor.
+Most Anchors set up infrastructure to enable wallets to offer in-app deposits
+and withdrawals by following best practices specified in Stellar Ecosystem
+Proposals. SEPs are publicly created, open-source documents that live in a
+[Github repository](https://github.com/stellar/stellar-protocol/tree/master/ecosystem#stellar-ecosystem-proposals-seps).
+They define how different institutions (such as asset issuers, wallets,
+exchanges, and service providers) should interact and interoperate. If you're
+building an app, you can implement the client side of some key SEPs and
+immediately give your users access to a whole world of local fiat currencies
 
-When you implement SEP-0024, users can tokenize their grocery-buying dollars, pesos, or naira, use them on the Stellar network and, when they're ready, redeem them for cash in hand or money in the bank — and they can do it all from the comfort of your app.
+This part of the tutorial will focus on the Interactive Anchor/Wallet Asset
+Transfer Server SEP (aka SEP-24), which defines the specs for deposit and
+withdrawal implementations. It's focused on the client side of interactive user
+flows — meaning flows where users interact with an Anchor-hosted interface
+rendered inside a wallet — and by the end, you should have an implemenation
+which can be re-purposed to work with any SEP-supporting Anchor.
 
-Most Anchors offer fiat-backed assets, and SEP-24 is set up to allow them to handle various KYC and AML requirements. But SEP-24 allows for the deposit and withdraw of cryptocurrencies like BTC, ETH, and ERC20 tokens like USDT. If the financial landscape is a bunch of lakes, SEP-0024 is a series of rivers by which you move your currency canoe in and out of the Stellar lake.
+When you implement SEP-0024, users can tokenize their grocery-buying dollars,
+pesos, or naira, use them on the Stellar network and, when they're ready, redeem
+them for cash in hand or money in the bank — and they can do it all from the
+comfort of your app.
+
+Most Anchors offer fiat-backed assets, and SEP-24 is set up to allow them to
+handle various KYC and AML requirements. But SEP-24 allows for the deposit and
+withdraw of cryptocurrencies like BTC, ETH, and ERC20 tokens like USDT. If the
+financial landscape is a bunch of lakes, SEP-0024 is a series of rivers by which
+you move your currency canoe in and out of the Stellar lake.

--- a/content/docs/building-apps/connect-to-anchors/setup-for-anchored-assets.mdx
+++ b/content/docs/building-apps/connect-to-anchors/setup-for-anchored-assets.mdx
@@ -5,100 +5,108 @@ order: 10
 
 import { CodeExample } from "components/CodeExample";
 
-So how do we make use of SEP-0024 to allow deposits and withdrawals of anchored assets? First let’s boot up our project:
+So how do we make use of SEP-0024 to allow deposits and withdrawals of anchored
+assets? First let’s boot up our project:
 
 [View trustline boilerplate code on GitHub][1]
 
-Next, let's think about our goals. What we’re trying to do is communicate with Anchors to get information about the assets they honor, and about the requirements and steps necessary to initiate a deposit or withdrawal on behalf of a user. When a user deposits with an Anchor — by sending dollars to their bank account via ACH, for example — the Anchor will credit their Stellar account with the equivalent amount of tokens.  The user can then hold, transfer, or trade those tokens just like any other Stellar asset.  When a user withdraws those tokens — generally by making a payment back to the Anchor's Stellar account — the Anchor redeems them for cash in hand or money in the bank. If you’re still a little lost it will all hopefully become clear as we get coding.
+Next, let's think about our goals. What we’re trying to do is communicate with
+Anchors to get information about the assets they honor, and about the
+requirements and steps necessary to initiate a deposit or withdrawal on behalf
+of a user. When a user deposits with an Anchor — by sending dollars to their
+bank account via ACH, for example — the Anchor will credit their Stellar account
+with the equivalent amount of tokens. The user can then hold, transfer, or trade
+those tokens just like any other Stellar asset. When a user withdraws those
+tokens — generally by making a payment back to the Anchor's Stellar account —
+the Anchor redeems them for cash in hand or money in the bank. If you’re still a
+little lost it will all hopefully become clear as we get coding.
 
-This tutorial will consist of a few minor `./events/` updates and two new `./methods/`. Let’s start with the updates first. We actually need to update the core `wallet.ts` component.
+This tutorial will consist of a few minor `./events/` updates and two new
+`./methods/`. Let’s start with the updates first. We actually need to update the
+core `wallet.ts` component.
 
 ## Update Wallet Component
+
 <CodeExample>
 
 ```ts
-import {
-  Component,
-  State,
-  Prop
-} from '@stencil/core'
-import {
-  Server,
-  ServerApi,
-} from 'stellar-sdk'
+import { Component, State, Prop } from "@stencil/core";
+import { Server, ServerApi } from "stellar-sdk";
 
-import componentWillLoad from './events/componentWillLoad' // UPDATE
-import render from './events/render' // UPDATE
+import componentWillLoad from "./events/componentWillLoad"; // UPDATE
+import render from "./events/render"; // UPDATE
 
-import createAccount from './methods/createAccount'
-import updateAccount from './methods/updateAccount'
-import depositAsset from './methods/depositAsset' // NEW
-import withdrawAsset from './methods/withdrawAsset' // NEW
-import trustAsset from './methods/trustAsset'
-import makePayment from './methods/makePayment'
-import copyAddress from './methods/copyAddress'
-import copySecret from './methods/copySecret'
-import signOut from './methods/signOut'
-import setPrompt from './methods/setPrompt'
+import createAccount from "./methods/createAccount";
+import updateAccount from "./methods/updateAccount";
+import depositAsset from "./methods/depositAsset"; // NEW
+import withdrawAsset from "./methods/withdrawAsset"; // NEW
+import trustAsset from "./methods/trustAsset";
+import makePayment from "./methods/makePayment";
+import copyAddress from "./methods/copyAddress";
+import copySecret from "./methods/copySecret";
+import signOut from "./methods/signOut";
+import setPrompt from "./methods/setPrompt";
 
-import { Prompter } from '@prompt/prompt'
+import { Prompter } from "@prompt/prompt";
 
 interface StellarAccount {
-  publicKey: string,
-  keystore: string,
-  state?: ServerApi.AccountRecord,
+  publicKey: string;
+  keystore: string;
+  state?: ServerApi.AccountRecord;
 }
 
 interface Loading {
-  fund?: boolean,
-  pay?: boolean,
-  trust?: boolean,
-  update?: boolean,
-  deposit?: boolean, // NEW
-  withdraw?: boolean // NEW
+  fund?: boolean;
+  pay?: boolean;
+  trust?: boolean;
+  update?: boolean;
+  deposit?: boolean; // NEW
+  withdraw?: boolean; // NEW
 }
 
 @Component({
-  tag: 'stellar-wallet',
-  styleUrl: 'wallet.scss',
-  shadow: true
+  tag: "stellar-wallet",
+  styleUrl: "wallet.scss",
+  shadow: true,
 })
 export class Wallet {
-  @State() account: StellarAccount
-  @State() prompter: Prompter = {show: false}
-  @State() loading: Loading = {}
-  @State() error: any = null
+  @State() account: StellarAccount;
+  @State() prompter: Prompter = { show: false };
+  @State() loading: Loading = {};
+  @State() error: any = null;
 
-  @Prop() server: Server
-  @Prop() homeDomain: String // NEW
-  @Prop() toml: Object // NEW
+  @Prop() server: Server;
+  @Prop() homeDomain: String; // NEW
+  @Prop() toml: Object; // NEW
 
   // Component events
   componentWillLoad() {}
   render() {}
 
   // Stellar methods
-  createAccount = createAccount
-  updateAccount = updateAccount
-  depositAsset = depositAsset // NEW
-  withdrawAsset = withdrawAsset // NEW
-  trustAsset = trustAsset
-  makePayment = makePayment
-  copyAddress = copyAddress
-  copySecret = copySecret
-  signOut = signOut
+  createAccount = createAccount;
+  updateAccount = updateAccount;
+  depositAsset = depositAsset; // NEW
+  withdrawAsset = withdrawAsset; // NEW
+  trustAsset = trustAsset;
+  makePayment = makePayment;
+  copyAddress = copyAddress;
+  copySecret = copySecret;
+  signOut = signOut;
 
   // Misc methods
-  setPrompt = setPrompt
+  setPrompt = setPrompt;
 }
 
-Wallet.prototype.componentWillLoad = componentWillLoad
-Wallet.prototype.render = render
+Wallet.prototype.componentWillLoad = componentWillLoad;
+Wallet.prototype.render = render;
 ```
 
 </CodeExample>
 
-You can see from the `// NEW` and `// UPDATE` comments what we are adding and updating. Nothing worth noting here other than near the bottom two new `@Prop`’s.
+You can see from the `// NEW` and `// UPDATE` comments what we are adding and
+updating. Nothing worth noting here other than near the bottom two new
+`@Prop`’s.
 
 <CodeExample>
 
@@ -109,52 +117,117 @@ You can see from the `// NEW` and `// UPDATE` comments what we are adding and up
 
 </CodeExample>
 
-We’ll talk more about home domain’s and stellar.toml files in a moment, but take special note of these as they will play a critical roll in connecting tp the world outside of Stellar.
+We’ll talk more about home domain’s and stellar.toml files in a moment, but take
+special note of these as they will play a critical roll in connecting tp the
+world outside of Stellar.
 
 ## Add Deposit and Withdraw Buttons
-Next let’s add a couple buttons for deposit and withdraw to the `./events/render.tsx`.
+
+Next let’s add a couple buttons for deposit and withdraw to the
+`./events/render.tsx`.
 
 <CodeExample>
 
 ```tsx
-import { h } from '@stencil/core'
-import { has as loHas } from 'lodash-es'
+import { h } from "@stencil/core";
+import { has as loHas } from "lodash-es";
 
 export default function render() {
   return [
     <stellar-prompt prompter={this.prompter} />,
 
+    this.account ? (
+      [
+        <div class="account-key">
+          <p>{this.account.publicKey}</p>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copyAddress(e)}
+          >
+            Copy Address
+          </button>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copySecret(e)}
+          >
+            Copy Secret
+          </button>
+        </div>,
+
+        <button
+          class={this.loading.deposit ? "loading" : null}
+          type="button"
+          onClick={(e) => this.depositAsset(e)}
+        >
+          {this.loading.deposit ? <stellar-loader /> : null} Deposit Asset
+        </button>,
+        <button
+          class={this.loading.withdraw ? "loading" : null}
+          type="button"
+          onClick={(e) => this.withdrawAsset(e)}
+        >
+          {this.loading.withdraw ? <stellar-loader /> : null} Withdraw Asset
+        </button>,
+
+        <button
+          class={this.loading.trust ? "loading" : null}
+          type="button"
+          onClick={(e) => this.trustAsset(e)}
+        >
+          {this.loading.trust ? <stellar-loader /> : null} Trust Asset
+        </button>,
+        <button
+          class={this.loading.pay ? "loading" : null}
+          type="button"
+          onClick={(e) => this.makePayment(e)}
+        >
+          {this.loading.pay ? <stellar-loader /> : null} Make Payment
+        </button>,
+      ]
+    ) : (
+      <button
+        class={this.loading.fund ? "loading" : null}
+        type="button"
+        onClick={(e) => this.createAccount(e)}
+      >
+        {this.loading.fund ? <stellar-loader /> : null} Create Account
+      </button>
+    ),
+
+    this.error ? (
+      <pre class="error">{JSON.stringify(this.error, null, 2)}</pre>
+    ) : null,
+
+    loHas(this.account, "state") ? (
+      <pre class="account-state">
+        {JSON.stringify(this.account.state, null, 2)}
+      </pre>
+    ) : null,
+
     this.account
-    ? [
-      <div class="account-key">
-        <p>{this.account.publicKey}</p>
-        <button class="small" type="button" onClick={(e) => this.copyAddress(e)}>Copy Address</button>
-        <button class="small" type="button" onClick={(e) => this.copySecret(e)}>Copy Secret</button>
-      </div>,
-
-      <button class={this.loading.deposit ? 'loading' : null} type="button" onClick={(e) => this.depositAsset(e)}>{this.loading.deposit ? <stellar-loader /> : null} Deposit Asset</button>,
-      <button class={this.loading.withdraw ? 'loading' : null} type="button" onClick={(e) => this.withdrawAsset(e)}>{this.loading.withdraw ? <stellar-loader /> : null} Withdraw Asset</button>,
-
-      <button class={this.loading.trust ? 'loading' : null} type="button" onClick={(e) => this.trustAsset(e)}>{this.loading.trust ? <stellar-loader /> : null} Trust Asset</button>,
-      <button class={this.loading.pay ? 'loading' : null} type="button" onClick={(e) => this.makePayment(e)}>{this.loading.pay ? <stellar-loader /> : null} Make Payment</button>,
-    ]
-    : <button class={this.loading.fund ? 'loading' : null} type="button" onClick={(e) => this.createAccount(e)}>{this.loading.fund ? <stellar-loader /> : null} Create Account</button>,
-
-    this.error ? <pre class="error">{JSON.stringify(this.error, null, 2)}</pre> : null,
-
-    loHas(this.account, 'state') ? <pre class="account-state">{JSON.stringify(this.account.state, null, 2)}</pre> : null,
-
-    this.account ? [
-      <button class={this.loading.update ? 'loading' : null} type="button" onClick={(e) => this.updateAccount(e)}>{this.loading.update ? <stellar-loader /> : null} Update Account</button>,
-      <button type="button" onClick={(e) => this.signOut(e)}>Sign Out</button>,
-    ] : null,
-  ]
+      ? [
+          <button
+            class={this.loading.update ? "loading" : null}
+            type="button"
+            onClick={(e) => this.updateAccount(e)}
+          >
+            {this.loading.update ? <stellar-loader /> : null} Update Account
+          </button>,
+          <button type="button" onClick={(e) => this.signOut(e)}>
+            Sign Out
+          </button>,
+        ]
+      : null,
+  ];
 }
 ```
 
 </CodeExample>
 
-This is the same as what we did in the previous tutorial except that we're adding two buttons.
+This is the same as what we did in the previous tutorial except that we're
+adding two buttons.
 
 <CodeExample>
 
@@ -165,66 +238,84 @@ This is the same as what we did in the previous tutorial except that we're addin
 
 </CodeExample>
 
-“Deposit Asset” and “Withdraw Asset” connect to the `this.depositAsset` and `this.withdrawAsset` methods respectively. We’ll create those methods momentarily.
+“Deposit Asset” and “Withdraw Asset” connect to the `this.depositAsset` and
+`this.withdrawAsset` methods respectively. We’ll create those methods
+momentarily.
 
-Before that though let’s make a change to the `./events/componentWillLoad.ts` file.
+Before that though let’s make a change to the `./events/componentWillLoad.ts`
+file.
 
 ## Update Components
+
 <CodeExample>
 
 ```ts
-import { Server, StellarTomlResolver } from 'stellar-sdk'
-import { handleError } from '@services/error'
-import { get } from '@services/storage'
+import { Server, StellarTomlResolver } from "stellar-sdk";
+import { handleError } from "@services/error";
+import { get } from "@services/storage";
 
 export default async function componentWillLoad() {
   try {
-    let keystore = await get('keyStore')
+    let keystore = await get("keyStore");
 
-    this.error = null
-    this.server = new Server('https://horizon-testnet.stellar.org')
-    this.homeDomain = 'stellar-anchor-server.herokuapp.com'
-    this.toml = await StellarTomlResolver.resolve(this.homeDomain)
+    this.error = null;
+    this.server = new Server("https://horizon-testnet.stellar.org");
+    this.homeDomain = "stellar-anchor-server.herokuapp.com";
+    this.toml = await StellarTomlResolver.resolve(this.homeDomain);
 
     if (keystore) {
-      keystore = atob(keystore)
+      keystore = atob(keystore);
 
-      const { publicKey } = JSON.parse(atob(JSON.parse(keystore).adata))
+      const { publicKey } = JSON.parse(atob(JSON.parse(keystore).adata));
 
       this.account = {
         publicKey,
-        keystore
-      }
+        keystore,
+      };
 
-      this.updateAccount()
+      this.updateAccount();
     }
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-Here, the only changes we're making are to include of the `StellarTomlResolver` from the `stellar-sdk` package and to set the values for `this.homeDomain` and `this.toml`.
+Here, the only changes we're making are to include of the `StellarTomlResolver`
+from the `stellar-sdk` package and to set the values for `this.homeDomain` and
+`this.toml`.
 
 <CodeExample>
 
 ```ts
-this.homeDomain = 'stellar-anchor-server.herokuapp.com'
-this.toml = await StellarTomlResolver.resolve(this.homeDomain)
+this.homeDomain = "stellar-anchor-server.herokuapp.com";
+this.toml = await StellarTomlResolver.resolve(this.homeDomain);
 ```
 
 </CodeExample>
 
 ## About stellar.toml Files
-You know what, let’s just go ahead and cover stellar.toml files. A `stellar.toml` file is a static resource that organizations building on Stellar publish on their home domain at `https://{homeDomain}/.well-known/stellar.toml`.  By linking their home domain to a Stellar account using a `set_options` operation, they create a verifiable connection from that account to the information published there.  To find out everything you'd ever want to know about stellar.toml files, check out [SEP-1], which is the complete stellar.toml specification.  
 
-Stellar.toml files contain all sorts of information about an organization, the assets they offer, and the integrations they support.  Wallets can look at an account, find the home domain, and crawl a stellar.toml to find out pretty much everything they need to know about an Anchor, and that's exactly what the Stellar SDK `StellarTomlResolver.resolve` method does: it pulls in a stellar.toml and parses it. 
+You know what, let’s just go ahead and cover stellar.toml files. A
+`stellar.toml` file is a static resource that organizations building on Stellar
+publish on their home domain at `https://{homeDomain}/.well-known/stellar.toml`.
+By linking their home domain to a Stellar account using a `set_options`
+operation, they create a verifiable connection from that account to the
+information published there. To find out everything you'd ever want to know
+about stellar.toml files, check out [SEP-1], which is the complete stellar.toml
+specification.
 
-Let's look at some concrete examples: here’s [StellarX.com’s stellar.toml file][2].
+Stellar.toml files contain all sorts of information about an organization, the
+assets they offer, and the integrations they support. Wallets can look at an
+account, find the home domain, and crawl a stellar.toml to find out pretty much
+everything they need to know about an Anchor, and that's exactly what the
+Stellar SDK `StellarTomlResolver.resolve` method does: it pulls in a
+stellar.toml and parses it.
+
+Let's look at some concrete examples: here’s [StellarX.com’s stellar.toml
+file][2].
 
 <CodeExample>
 
@@ -288,15 +379,27 @@ image="https://www.anchorusd.com/img/usdx.png"
 
 </CodeExample>
 
-You can see the data provided by these companies that identifies who they are, what they do, and what services they provide. In this tutorial, we’re interested in the `[[CURRENCIES]]` they issue as that’s what we’re trying to get ahold of.  We’re also looking for the `TRANSFER_SERVER` keyword, which indicates that an Anchor supports SEP-24, and the `WEB_AUTH_ENDPOINT`, which allows a wallet to set up an authenticated user session. Any time you find these three fields, and you’ve found an Anchor you can interoperate with.
+You can see the data provided by these companies that identifies who they are,
+what they do, and what services they provide. In this tutorial, we’re interested
+in the `[[CURRENCIES]]` they issue as that’s what we’re trying to get ahold of.
+We’re also looking for the `TRANSFER_SERVER` keyword, which indicates that an
+Anchor supports SEP-24, and the `WEB_AUTH_ENDPOINT`, which allows a wallet to
+set up an authenticated user session. Any time you find these three fields, and
+you’ve found an Anchor you can interoperate with.
 
-Once we’ve found an Anchor that supports deposit and withdrawal, we can begin the process of connecting with them from our wallet. This tutorial builds on the testnet, so from we’ll be use an SDF testing anchor server located at `stellar-anchor-server.herokuapp.com` You can [view the TOML file for this entity][5] here.
+Once we’ve found an Anchor that supports deposit and withdrawal, we can begin
+the process of connecting with them from our wallet. This tutorial builds on the
+testnet, so from we’ll be use an SDF testing anchor server located at
+`stellar-anchor-server.herokuapp.com` You can [view the TOML file for this
+entity][5] here.
 
-
-[1]:	https://github.com/stellar/stellar-demo-wallet/tree/trustline
-[2]:	https://www.stellarx.com/.well-known/stellar.toml
-[3]:	https://www.anchorusd.com/.well-known/stellar.toml
-[4]:	https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
-[5]:	https://stellar-anchor-server.herokuapp.com/.well-known/stellar.toml
-[6]:	/4%20SEP-0024%20%E2%80%93%20Make%20Use%20of%20Anchors/1%20SEP-0024%20Explained.md
-[7]:	/4%20SEP-0024%20%E2%80%93%20Make%20Use%20of%20Anchors/3%20Deposit%20Anchored%20Assets.md
+[1]: https://github.com/stellar/stellar-demo-wallet/tree/trustline
+[2]: https://www.stellarx.com/.well-known/stellar.toml
+[3]: https://www.anchorusd.com/.well-known/stellar.toml
+[4]:
+  https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+[5]: https://stellar-anchor-server.herokuapp.com/.well-known/stellar.toml
+[6]:
+  /4%20SEP-0024%20%E2%80%93%20Make%20Use%20of%20Anchors/1%20SEP-0024%20Explained.md
+[7]:
+  /4%20SEP-0024%20%E2%80%93%20Make%20Use%20of%20Anchors/3%20Deposit%20Anchored%20Assets.md

--- a/content/docs/building-apps/connect-to-anchors/withdraw-anchored-assets.mdx
+++ b/content/docs/building-apps/connect-to-anchors/withdraw-anchored-assets.mdx
@@ -8,19 +8,29 @@ import { Alert } from "components/Alert";
 
 <Alert>
 
-At this point, you should have a [basic wallet](../basic-wallet.mdx) that can handle [custom assets](../custom-assets.mdx), and you should have [enabled deposits](./deposit-anchored-assets.mdx) and used the SDF-maintained testnet [Anchor Reference Implementation](link) to get some test tokens into your wallet.  After you’ve had some fun with your new asset, it's time to learn to perform this process in reverse, and that's what we'll do here: set your wallet up to handle withdrawals.
+At this point, you should have a [basic wallet](../basic-wallet.mdx) that can
+handle [custom assets](../custom-assets.mdx), and you should have
+[enabled deposits](./deposit-anchored-assets.mdx) and used the SDF-maintained
+testnet [Anchor Reference Implementation](link) to get some test tokens into
+your wallet. After you’ve had some fun with your new asset, it's time to learn
+to perform this process in reverse, and that's what we'll do here: set your
+wallet up to handle withdrawals.
 
 </Alert>
 
-In a live situation, this is the step when a user takes a Stellar-based token and redeems it with an Anchor for the underlying asset it represents.  It's how they'd move money off the network and back into their bank account, for instance. 
+In a live situation, this is the step when a user takes a Stellar-based token
+and redeems it with an Anchor for the underlying asset it represents. It's how
+they'd move money off the network and back into their bank account, for
+instance.
 
 ## Create Withdraw Method
+
 To start, create `./methods/withdrawAsset.ts` and pop this in.
 
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
+import sjcl from "@tinyanvil/sjcl";
 import {
   Transaction,
   Keypair,
@@ -31,181 +41,204 @@ import {
   Operation,
   Asset,
   Memo,
-  MemoHash
-} from 'stellar-sdk'
+  MemoHash,
+} from "stellar-sdk";
 
-import axios from 'axios'
+import axios from "axios";
 import {
   get as loGet,
   each as loEach,
   findIndex as loFindIndex,
-} from 'lodash-es'
+} from "lodash-es";
 
-import { handleError } from '@services/error'
+import { handleError } from "@services/error";
 
 export default async function withdrawAsset(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    let currency = await this.setPrompt('Select the currency you\'d like to withdraw', null, this.toml.CURRENCIES)
-        currency = currency.split(':')
+    let currency = await this.setPrompt(
+      "Select the currency you'd like to withdraw",
+      null,
+      this.toml.CURRENCIES,
+    );
+    currency = currency.split(":");
 
-    const pincode = await this.setPrompt('Enter your keystore pincode')
+    const pincode = await this.setPrompt("Enter your keystore pincode");
 
-    if (!pincode)
-      return
+    if (!pincode) return;
 
     const keypair = Keypair.fromSecret(
-      sjcl.decrypt(pincode, this.account.keystore)
-    )
+      sjcl.decrypt(pincode, this.account.keystore),
+    );
 
-    const balances = loGet(this.account, 'state.balances')
+    const balances = loGet(this.account, "state.balances");
     const hasCurrency = loFindIndex(balances, {
       asset_code: currency[0],
-      asset_issuer: currency[1]
-    })
+      asset_issuer: currency[1],
+    });
 
     if (hasCurrency === -1)
-      await this.trustAsset(null, currency[0], currency[1], pincode)
+      await this.trustAsset(null, currency[0], currency[1], pincode);
 
-    const info = await axios.get(`${this.toml.TRANSFER_SERVER}/info`)
-    .then(({data}) => data)
+    const info = await axios
+      .get(`${this.toml.TRANSFER_SERVER}/info`)
+      .then(({ data }) => data);
 
-    console.log(info)
+    console.log(info);
 
-    const auth = await axios.get(`${this.toml.WEB_AUTH_ENDPOINT}`, {
-      params: {
-        account: this.account.publicKey
-      }
-    })
-    .then(async ({data: {transaction, network_passphrase}}) => {
-      const txn: any = new Transaction(transaction, network_passphrase)
+    const auth = await axios
+      .get(`${this.toml.WEB_AUTH_ENDPOINT}`, {
+        params: {
+          account: this.account.publicKey,
+        },
+      })
+      .then(async ({ data: { transaction, network_passphrase } }) => {
+        const txn: any = new Transaction(transaction, network_passphrase);
 
-      this.error = null
-      this.loading = {...this.loading, withdraw: true}
+        this.error = null;
+        this.loading = { ...this.loading, withdraw: true };
 
-      txn.sign(keypair)
-      return txn.toXDR()
-    })
-    .then((transaction) => axios.post(`${this.toml.WEB_AUTH_ENDPOINT}`, {transaction}, {headers: {'Content-Type': 'application/json'}}))
-    .then(({data: {token}}) => token)
+        txn.sign(keypair);
+        return txn.toXDR();
+      })
+      .then((transaction) =>
+        axios.post(
+          `${this.toml.WEB_AUTH_ENDPOINT}`,
+          { transaction },
+          { headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .then(({ data: { token } }) => token);
 
-    console.log(auth)
+    console.log(auth);
 
-    const formData = new FormData()
+    const formData = new FormData();
 
-    loEach({
-      asset_code: currency[0],
-      account: this.account.publicKey,
-      lang: 'en'
-    }, (value, key) => formData.append(key, value))
-
-    const interactive = await axios.post(`${this.toml.TRANSFER_SERVER}/transactions/withdraw/interactive`, formData, {
-      headers: {
-        'Authorization': `Bearer ${auth}`,
-        'Content-Type': 'multipart/form-data'
-      }
-    }).then(({data}) => data)
-
-    console.log(interactive)
-
-    const transactions = await axios.get(`${this.toml.TRANSFER_SERVER}/transactions`, {
-      params: {
+    loEach(
+      {
         asset_code: currency[0],
-        limit: 1,
-        kind: 'withdrawal',
+        account: this.account.publicKey,
+        lang: "en",
       },
-      headers: {
-        'Authorization': `Bearer ${auth}`
-      }
-    })
-    .then(({data: {transactions}}) => transactions)
+      (value, key) => formData.append(key, value),
+    );
 
-    console.log(transactions)
+    const interactive = await axios
+      .post(
+        `${this.toml.TRANSFER_SERVER}/transactions/withdraw/interactive`,
+        formData,
+        {
+          headers: {
+            Authorization: `Bearer ${auth}`,
+            "Content-Type": "multipart/form-data",
+          },
+        },
+      )
+      .then(({ data }) => data);
 
-    const urlBuilder = new URL(interactive.url)
-          urlBuilder.searchParams.set('callback', 'postMessage')
-    const popup = open(urlBuilder.toString(), 'popup', 'width=500,height=800')
+    console.log(interactive);
+
+    const transactions = await axios
+      .get(`${this.toml.TRANSFER_SERVER}/transactions`, {
+        params: {
+          asset_code: currency[0],
+          limit: 1,
+          kind: "withdrawal",
+        },
+        headers: {
+          Authorization: `Bearer ${auth}`,
+        },
+      })
+      .then(({ data: { transactions } }) => transactions);
+
+    console.log(transactions);
+
+    const urlBuilder = new URL(interactive.url);
+    urlBuilder.searchParams.set("callback", "postMessage");
+    const popup = open(urlBuilder.toString(), "popup", "width=500,height=800");
 
     if (!popup) {
-      this.loading = {...this.loading, withdraw: false}
-      throw 'Popups are blocked. You\'ll need to enable popups for this demo to work'
+      this.loading = { ...this.loading, withdraw: false };
+      throw "Popups are blocked. You'll need to enable popups for this demo to work";
     }
 
     await new Promise((resolve, reject) => {
-      let submittedTxn
+      let submittedTxn;
 
-      window.onmessage = ({data: {transaction}}) => {
-        console.log(transaction.status, transaction)
+      window.onmessage = ({ data: { transaction } }) => {
+        console.log(transaction.status, transaction);
 
-        if (transaction.status === 'completed') {
-          this.updateAccount()
-          this.loading = {...this.loading, withdraw: false}
-          resolve()
-        }
-
-        else if (
-          !submittedTxn
-          && transaction.status === 'pending_user_transfer_start'
+        if (transaction.status === "completed") {
+          this.updateAccount();
+          this.loading = { ...this.loading, withdraw: false };
+          resolve();
+        } else if (
+          !submittedTxn &&
+          transaction.status === "pending_user_transfer_start"
         ) {
           this.server
-          .accounts()
-          .accountId(keypair.publicKey())
-          .call()
-          .then(({sequence}) => {
-            const account = new Account(keypair.publicKey(), sequence)
-            const txn = new TransactionBuilder(account, {
-              fee: BASE_FEE,
-              networkPassphrase: Networks.TESTNET
+            .accounts()
+            .accountId(keypair.publicKey())
+            .call()
+            .then(({ sequence }) => {
+              const account = new Account(keypair.publicKey(), sequence);
+              const txn = new TransactionBuilder(account, {
+                fee: BASE_FEE,
+                networkPassphrase: Networks.TESTNET,
+              })
+                .addOperation(
+                  Operation.payment({
+                    destination: transaction.withdraw_anchor_account,
+                    asset: new Asset(currency[0], currency[1]),
+                    amount: transaction.amount_in,
+                  }),
+                )
+                .addMemo(new Memo(MemoHash, transaction.withdraw_memo))
+                .setTimeout(0)
+                .build();
+
+              txn.sign(keypair);
+              return this.server.submitTransaction(txn);
             })
-            .addOperation(Operation.payment({
-              destination: transaction.withdraw_anchor_account,
-              asset: new Asset(currency[0], currency[1]),
-              amount: transaction.amount_in
-            }))
-            .addMemo(new Memo(MemoHash, transaction.withdraw_memo))
-            .setTimeout(0)
-            .build()
+            .then((res) => {
+              console.log(res);
+              submittedTxn = res;
 
-            txn.sign(keypair)
-            return this.server.submitTransaction(txn)
-          })
-          .then((res) => {
-            console.log(res)
-            submittedTxn = res
+              const urlBuilder = new URL(transaction.more_info_url);
+              urlBuilder.searchParams.set("callback", "postMessage");
 
-            const urlBuilder = new URL(transaction.more_info_url)
-                  urlBuilder.searchParams.set('callback', 'postMessage')
-
-            popup.location.replace(urlBuilder.toString())
-          })
-          .catch((err) => reject(err))
-        }
-
-        else {
+              popup.location.replace(urlBuilder.toString());
+            })
+            .catch((err) => reject(err));
+        } else {
           setTimeout(() => {
-            const urlBuilder = new URL(transaction.more_info_url)
-                  urlBuilder.searchParams.set('callback', 'postMessage')
+            const urlBuilder = new URL(transaction.more_info_url);
+            urlBuilder.searchParams.set("callback", "postMessage");
 
-            popup.location.replace(urlBuilder.toString())
-          }, 1000)
+            popup.location.replace(urlBuilder.toString());
+          }, 1000);
         }
-      }
-    })
-  }
-
-  catch (err) {
-    this.loading = {...this.loading, withdraw: false}
-    this.error = handleError(err)
+      };
+    });
+  } catch (err) {
+    this.loading = { ...this.loading, withdraw: false };
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-We’ll actually skip everything except the stuff that is significantly different than the [deposit flow](./deposit-anchored-assets.mdx).  The main difference between the two is who submits the Stellar transaction: in the deposit flow the anchor is sends the wallet a Stellar asset; in the withdraw flow the wallet sends the asset to the anchor.  So for the witdraw flow, we’ll need to build and submit a payment transaction.
+We’ll actually skip everything except the stuff that is significantly different
+than the [deposit flow](./deposit-anchored-assets.mdx). The main difference
+between the two is who submits the Stellar transaction: in the deposit flow the
+anchor is sends the wallet a Stellar asset; in the withdraw flow the wallet
+sends the asset to the anchor. So for the witdraw flow, we’ll need to build and
+submit a payment transaction.
 
 ## Create and Submit Payment Transaction
+
 <CodeExample>
 
 ```ts
@@ -224,7 +257,11 @@ We’ll actually skip everything except the stuff that is significantly differen
 
 </CodeExample>
 
-First thing we’ll see is the use of a Promise. This allows us to respond to any errors in the transaction we’re about to build and submit. Inside the promise we have three if statement blocks.  The first `if` statement is a response to a status of success, which is where we'll end up once the withdraw has registered and everything is hunky dory.
+First thing we’ll see is the use of a Promise. This allows us to respond to any
+errors in the transaction we’re about to build and submit. Inside the promise we
+have three if statement blocks. The first `if` statement is a response to a
+status of success, which is where we'll end up once the withdraw has registered
+and everything is hunky dory.
 
 <CodeExample>
 
@@ -270,8 +307,18 @@ First thing we’ll see is the use of a Promise. This allows us to respond to an
 
 </CodeExample>
 
-Otherwise if the transaction status is `pending_user_transfer_start` and we haven’t yet submitted a transaction to the Anchor, we attempt that. We load up the user's account to get the next valid sequence number, and build a Stellar [transaction](../../glossary/transactions.mdx) consisting of a [payment operation](../../glossary/operations.mdx
-) with all the details from the transaction object that the anchor is expecting. Once we have a valid transaction built, we’ll sign it with the keypair, submit the transaction to the network, and wait for a response. If the transaction is successful, we save that value to `submittedTxn` and reload the anchor popup to observe the pending status. Make sure to set the `submittedTxn` to a truthy value or else you run the risk of submitting the transaction multiple times, as the anchor may take a moment to realize you’ve successfully submitted a transaction to them.
+Otherwise if the transaction status is `pending_user_transfer_start` and we
+haven’t yet submitted a transaction to the Anchor, we attempt that. We load up
+the user's account to get the next valid sequence number, and build a Stellar
+[transaction](../../glossary/transactions.mdx) consisting of a
+[payment operation](../../glossary/operations.mdx) with all the details from the
+transaction object that the anchor is expecting. Once we have a valid
+transaction built, we’ll sign it with the keypair, submit the transaction to the
+network, and wait for a response. If the transaction is successful, we save that
+value to `submittedTxn` and reload the anchor popup to observe the pending
+status. Make sure to set the `submittedTxn` to a truthy value or else you run
+the risk of submitting the transaction multiple times, as the anchor may take a
+moment to realize you’ve successfully submitted a transaction to them.
 
 <CodeExample>
 
@@ -297,15 +344,14 @@ Otherwise if the transaction status is `pending_user_transfer_start` and we have
 
 </CodeExample>
 
-The last if block is that if all else fails just keep reloading the anchor popup every second until we get a `'completed'` status.
+The last if block is that if all else fails just keep reloading the anchor popup
+every second until we get a `'completed'` status.
 
 Finally catch and respond to any errors.
 
-With this method saved and the server reloaded we have a fully functional SEP-0024 compliant wallet! Noice!
+With this method saved and the server reloaded we have a fully functional
+SEP-0024 compliant wallet! Noice!
 
 [View this code on GitHub][1]
 
-
-
-[1]:	https://github.com/stellar/stellar-demo-wallet/tree/sep24
-
+[1]: https://github.com/stellar/stellar-demo-wallet/tree/sep24

--- a/content/docs/building-apps/custom-assets.mdx
+++ b/content/docs/building-apps/custom-assets.mdx
@@ -8,66 +8,131 @@ import { Alert } from "components/Alert";
 
 <Alert>
 
-In this section of the tutorial, we'll add the ability to hold and transfer custom assets to the basic wallet we built in previous sections.  It asssumes that you've already completed [Build a Basic Wallet](./basic-wallet.mdx) and [Make XLM Payments](./xlm-payments.mdx).
+In this section of the tutorial, we'll add the ability to hold and transfer
+custom assets to the basic wallet we built in previous sections. It asssumes
+that you've already completed [Build a Basic Wallet](./basic-wallet.mdx) and
+[Make XLM Payments](./xlm-payments.mdx).
 
 </Alert>
 
 [View pay boilerplate code on GitHub][1]
 
 ## What's a Custom Asset?
-Stellar allows anyone to easily issue an asset, and all assets can be held, transferred, and traded just like XLM, the network token.  Every asset *other* than XLM exists on the network in the form of trustlines: an asset holder explicitly agrees to allow a balance of a specific token issued by a specific issuing account by creating a persistent ledger entry tied to the holding account.  You can find out more in the guide to [creating custom assets](../issuing-assets/index.mdx).
 
-Each trustline increases the user's [base reserve](../glossary/minimum-balance.mdx) by 0.5 XLM, and in this tutorial, we'll go over how to set up your wallet to create trustlines and manage the base reserve on behalf of a user. 
+Stellar allows anyone to easily issue an asset, and all assets can be held,
+transferred, and traded just like XLM, the network token. Every asset _other_
+than XLM exists on the network in the form of trustlines: an asset holder
+explicitly agrees to allow a balance of a specific token issued by a specific
+issuing account by creating a persistent ledger entry tied to the holding
+account. You can find out more in the guide to
+[creating custom assets](../issuing-assets/index.mdx).
 
+Each trustline increases the user's
+[base reserve](../glossary/minimum-balance.mdx) by 0.5 XLM, and in this
+tutorial, we'll go over how to set up your wallet to create trustlines and
+manage the base reserve on behalf of a user.
 
 ## Add Trustlines Button
-To enable custom asset handling, we need to modify three files and create one new one. Let’s start with our modifications. First up the `./events/render.tsx` file. We need to add a button for creating these new trustlines!
+
+To enable custom asset handling, we need to modify three files and create one
+new one. Let’s start with our modifications. First up the `./events/render.tsx`
+file. We need to add a button for creating these new trustlines!
 
 <CodeExample>
 
 ```tsx
-import { h } from '@stencil/core'
-import { has as loHas } from 'lodash-es'
+import { h } from "@stencil/core";
+import { has as loHas } from "lodash-es";
 
 export default function render() {
   return [
     <stellar-prompt prompter={this.prompter} />,
 
+    this.account ? (
+      [
+        <div class="account-key">
+          <p>{this.account.publicKey}</p>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copyAddress(e)}
+          >
+            Copy Address
+          </button>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copySecret(e)}
+          >
+            Copy Secret
+          </button>
+        </div>,
+
+        <button
+          class={this.loading.trust ? "loading" : null}
+          type="button"
+          onClick={(e) => this.trustAsset(e)}
+        >
+          {this.loading.trust ? <stellar-loader /> : null} Trust Asset
+        </button>,
+        <button
+          class={this.loading.pay ? "loading" : null}
+          type="button"
+          onClick={(e) => this.makePayment(e)}
+        >
+          {this.loading.pay ? <stellar-loader /> : null} Make Payment
+        </button>,
+      ]
+    ) : (
+      <button
+        class={this.loading.fund ? "loading" : null}
+        type="button"
+        onClick={(e) => this.createAccount(e)}
+      >
+        {this.loading.fund ? <stellar-loader /> : null} Create Account
+      </button>
+    ),
+
+    this.error ? (
+      <pre class="error">{JSON.stringify(this.error, null, 2)}</pre>
+    ) : null,
+
+    loHas(this.account, "state") ? (
+      <pre class="account-state">
+        {JSON.stringify(this.account.state, null, 2)}
+      </pre>
+    ) : null,
+
     this.account
-    ? [
-      <div class="account-key">
-        <p>{this.account.publicKey}</p>
-        <button class="small" type="button" onClick={(e) => this.copyAddress(e)}>Copy Address</button>
-        <button class="small" type="button" onClick={(e) => this.copySecret(e)}>Copy Secret</button>
-      </div>,
-
-      <button class={this.loading.trust ? 'loading' : null} type="button" onClick={(e) => this.trustAsset(e)}>{this.loading.trust ? <stellar-loader /> : null} Trust Asset</button>,
-      <button class={this.loading.pay ? 'loading' : null} type="button" onClick={(e) => this.makePayment(e)}>{this.loading.pay ? <stellar-loader /> : null} Make Payment</button>,
-    ]
-    : <button class={this.loading.fund ? 'loading' : null} type="button" onClick={(e) => this.createAccount(e)}>{this.loading.fund ? <stellar-loader /> : null} Create Account</button>,
-
-    this.error ? <pre class="error">{JSON.stringify(this.error, null, 2)}</pre> : null,
-
-    loHas(this.account, 'state') ? <pre class="account-state">{JSON.stringify(this.account.state, null, 2)}</pre> : null,
-
-    this.account ? [
-      <button class={this.loading.update ? 'loading' : null} type="button" onClick={(e) => this.updateAccount(e)}>{this.loading.update ? <stellar-loader /> : null} Update Account</button>,
-      <button type="button" onClick={(e) => this.signOut(e)}>Sign Out</button>,
-    ] : null,
-  ]
+      ? [
+          <button
+            class={this.loading.update ? "loading" : null}
+            type="button"
+            onClick={(e) => this.updateAccount(e)}
+          >
+            {this.loading.update ? <stellar-loader /> : null} Update Account
+          </button>,
+          <button type="button" onClick={(e) => this.signOut(e)}>
+            Sign Out
+          </button>,
+        ]
+      : null,
+  ];
 }
 ```
 
 </CodeExample>
 
-If you look closely you’ll spot the Trust Asset button right below our `account-key` div. Nothing funky here, just a button that triggers `this.trustAsset` method which we’ll add in a moment.
+If you look closely you’ll spot the Trust Asset button right below our
+`account-key` div. Nothing funky here, just a button that triggers
+`this.trustAsset` method which we’ll add in a moment.
 
 Next up, let’s update the `./methods/makePayment.ts` file.
 
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
+import sjcl from "@tinyanvil/sjcl";
 import {
   Keypair,
   Account,
@@ -75,125 +140,135 @@ import {
   BASE_FEE,
   Networks,
   Operation,
-  Asset
-} from 'stellar-sdk'
-import { has as loHas } from 'lodash-es'
+  Asset,
+} from "stellar-sdk";
+import { has as loHas } from "lodash-es";
 
-import { handleError } from '@services/error'
+import { handleError } from "@services/error";
 
 export default async function makePayment(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    let instructions = await this.setPrompt('{Amount} {Asset} {Destination}')
-        instructions = instructions.split(' ')
+    let instructions = await this.setPrompt("{Amount} {Asset} {Destination}");
+    instructions = instructions.split(" ");
 
     if (!/xlm/gi.test(instructions[1]))
-      instructions[3] = await this.setPrompt(`Who issues the ${instructions[1]} asset?`, 'Enter ME to refer to yourself')
+      instructions[3] = await this.setPrompt(
+        `Who issues the ${instructions[1]} asset?`,
+        "Enter ME to refer to yourself",
+      );
 
-    const pincode = await this.setPrompt('Enter your keystore pincode')
+    const pincode = await this.setPrompt("Enter your keystore pincode");
 
-    if (
-      !instructions
-      || !pincode
-    ) return
+    if (!instructions || !pincode) return;
 
     const keypair = Keypair.fromSecret(
-      sjcl.decrypt(pincode, this.account.keystore)
-    )
+      sjcl.decrypt(pincode, this.account.keystore),
+    );
 
-    if (/me/gi.test(instructions[3]))
-      instructions[3] = keypair.publicKey()
+    if (/me/gi.test(instructions[3])) instructions[3] = keypair.publicKey();
 
-    this.error = null
-    this.loading = {...this.loading, pay: true}
+    this.error = null;
+    this.loading = { ...this.loading, pay: true };
 
     await this.server
-    .accounts()
-    .accountId(keypair.publicKey())
-    .call()
-    .then(({sequence}) => {
-      const account = new Account(keypair.publicKey(), sequence)
-      const transaction = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: Networks.TESTNET
-      })
-      .addOperation(Operation.payment({
-        destination: instructions[2],
-        asset: instructions[3] ? new Asset(instructions[1], instructions[3]) : Asset.native(),
-        amount: instructions[0]
-      }))
-      .setTimeout(0)
-      .build()
-
-      transaction.sign(keypair)
-      return this.server.submitTransaction(transaction)
-      .catch((err) => {
-        if ( // Paying an account which doesn't exist, create it instead
-          loHas(err, 'response.data.extras.result_codes.operations')
-          && err.response.data.status === 400
-          && err.response.data.extras.result_codes.operations.indexOf('op_no_destination') !== -1
-          && !instructions[3]
-        ) {
-          const transaction = new TransactionBuilder(account, {
-            fee: BASE_FEE,
-            networkPassphrase: Networks.TESTNET
-          })
-          .addOperation(Operation.createAccount({
-            destination: instructions[2],
-            startingBalance: instructions[0]
-          }))
+      .accounts()
+      .accountId(keypair.publicKey())
+      .call()
+      .then(({ sequence }) => {
+        const account = new Account(keypair.publicKey(), sequence);
+        const transaction = new TransactionBuilder(account, {
+          fee: BASE_FEE,
+          networkPassphrase: Networks.TESTNET,
+        })
+          .addOperation(
+            Operation.payment({
+              destination: instructions[2],
+              asset: instructions[3]
+                ? new Asset(instructions[1], instructions[3])
+                : Asset.native(),
+              amount: instructions[0],
+            }),
+          )
           .setTimeout(0)
-          .build()
+          .build();
 
-          transaction.sign(keypair)
-          return this.server.submitTransaction(transaction)
-        }
+        transaction.sign(keypair);
+        return this.server.submitTransaction(transaction).catch((err) => {
+          if (
+            // Paying an account which doesn't exist, create it instead
+            loHas(err, "response.data.extras.result_codes.operations") &&
+            err.response.data.status === 400 &&
+            err.response.data.extras.result_codes.operations.indexOf(
+              "op_no_destination",
+            ) !== -1 &&
+            !instructions[3]
+          ) {
+            const transaction = new TransactionBuilder(account, {
+              fee: BASE_FEE,
+              networkPassphrase: Networks.TESTNET,
+            })
+              .addOperation(
+                Operation.createAccount({
+                  destination: instructions[2],
+                  startingBalance: instructions[0],
+                }),
+              )
+              .setTimeout(0)
+              .build();
 
-        else throw err
+            transaction.sign(keypair);
+            return this.server.submitTransaction(transaction);
+          } else throw err;
+        });
       })
-    })
-    .then((res) => console.log(res))
-    .finally(() => {
-      this.loading = {...this.loading, pay: false}
-      this.updateAccount()
-    })
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+      .then((res) => console.log(res))
+      .finally(() => {
+        this.loading = { ...this.loading, pay: false };
+        this.updateAccount();
+      });
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-This is a big file was covered in great detail in the [Make XLM Payments](link) tutorial, so we’ll just focus on the changes we need to make to support custom asset payments.
+This is a big file was covered in great detail in the [Make XLM Payments](link)
+tutorial, so we’ll just focus on the changes we need to make to support custom
+asset payments.
 
 <CodeExample>
 
 ```ts
-let instructions = await this.setPrompt('{Amount} {Asset} {Destination}')
-    instructions = instructions.split(' ')
+let instructions = await this.setPrompt("{Amount} {Asset} {Destination}");
+instructions = instructions.split(" ");
 
 if (!/xlm/gi.test(instructions[1]))
-  instructions[3] = await this.setPrompt(`Who issues the ${instructions[1]} asset?`, 'Enter ME to refer to yourself')
+  instructions[3] = await this.setPrompt(
+    `Who issues the ${instructions[1]} asset?`,
+    "Enter ME to refer to yourself",
+  );
 ```
 
 </CodeExample>
 
-This change allows us to indicate a specific asset code we’d like use to make a payment and triggers an additional prompt to set the issuer for that asset if it’s not the native XLM.
+This change allows us to indicate a specific asset code we’d like use to make a
+payment and triggers an additional prompt to set the issuer for that asset if
+it’s not the native XLM.
 
 <CodeExample>
 
 ```ts
-if (/me/gi.test(instructions[3]))
-  instructions[3] = keypair.publicKey()
+if (/me/gi.test(instructions[3])) instructions[3] = keypair.publicKey();
 ```
 
 </CodeExample>
 
-This is just a nifty little helper shortcut to allow us to use the `ME` “issuer” to swap with our actual account publicKey. Niceties make the world go ‘round.
+This is just a nifty little helper shortcut to allow us to use the `ME` “issuer”
+to swap with our actual account publicKey. Niceties make the world go ‘round.
 
 <CodeExample>
 
@@ -203,87 +278,87 @@ asset: instructions[3] ? new Asset(instructions[1], instructions[3]) : Asset.nat
 
 </CodeExample>
 
-The final noteworthy change is a ternary operation that switches our payment asset between the native XLM and a custom asset based off of responses to our prompt. Essentially, if `instructions[3]` exists — meaning there is an issuer — use that issuer and custom token as the asset for the payment. Otherwise, just use the native `Asset`.
+The final noteworthy change is a ternary operation that switches our payment
+asset between the native XLM and a custom asset based off of responses to our
+prompt. Essentially, if `instructions[3]` exists — meaning there is an issuer —
+use that issuer and custom token as the asset for the payment. Otherwise, just
+use the native `Asset`.
 
-The final changes are in the `wallet.ts` itself and tie together all the other updates as well as pull in the new `trustAsset` method.
+The final changes are in the `wallet.ts` itself and tie together all the other
+updates as well as pull in the new `trustAsset` method.
 
 <CodeExample>
 
 ```ts
-import {
-  Component,
-  State,
-  Prop
-} from '@stencil/core'
-import {
-  Server,
-  ServerApi,
-} from 'stellar-sdk'
+import { Component, State, Prop } from "@stencil/core";
+import { Server, ServerApi } from "stellar-sdk";
 
-import componentWillLoad from './events/componentWillLoad'
-import render from './events/render'
+import componentWillLoad from "./events/componentWillLoad";
+import render from "./events/render";
 
-import createAccount from './methods/createAccount'
-import updateAccount from './methods/updateAccount'
-import trustAsset from './methods/trustAsset' // NEW
-import makePayment from './methods/makePayment' // UPDATE
-import copyAddress from './methods/copyAddress'
-import copySecret from './methods/copySecret'
-import signOut from './methods/signOut'
-import setPrompt from './methods/setPrompt'
+import createAccount from "./methods/createAccount";
+import updateAccount from "./methods/updateAccount";
+import trustAsset from "./methods/trustAsset"; // NEW
+import makePayment from "./methods/makePayment"; // UPDATE
+import copyAddress from "./methods/copyAddress";
+import copySecret from "./methods/copySecret";
+import signOut from "./methods/signOut";
+import setPrompt from "./methods/setPrompt";
 
-import { Prompter } from '@prompt/prompt'
+import { Prompter } from "@prompt/prompt";
 
 interface StellarAccount {
-  publicKey: string,
-  keystore: string,
-  state?: ServerApi.AccountRecord,
+  publicKey: string;
+  keystore: string;
+  state?: ServerApi.AccountRecord;
 }
 
-interface Loading { // UPDATE
-  fund?: boolean,
-  pay?: boolean,
-  trust?: boolean, // NEW
-  update?: boolean,
+interface Loading {
+  // UPDATE
+  fund?: boolean;
+  pay?: boolean;
+  trust?: boolean; // NEW
+  update?: boolean;
 }
 
 @Component({
-  tag: 'stellar-wallet',
-  styleUrl: 'wallet.scss',
-  shadow: true
+  tag: "stellar-wallet",
+  styleUrl: "wallet.scss",
+  shadow: true,
 })
 export class Wallet {
-  @State() account: StellarAccount
-  @State() prompter: Prompter = {show: false}
-  @State() loading: Loading = {}
-  @State() error: any = null
+  @State() account: StellarAccount;
+  @State() prompter: Prompter = { show: false };
+  @State() loading: Loading = {};
+  @State() error: any = null;
 
-  @Prop() server: Server
+  @Prop() server: Server;
 
   // Component events
   componentWillLoad() {}
   render() {}
 
   // Stellar methods
-  createAccount = createAccount
-  updateAccount = updateAccount
-  trustAsset = trustAsset // NEW
-  makePayment = makePayment // UPDATE
-  copyAddress = copyAddress
-  copySecret = copySecret
-  signOut = signOut
+  createAccount = createAccount;
+  updateAccount = updateAccount;
+  trustAsset = trustAsset; // NEW
+  makePayment = makePayment; // UPDATE
+  copyAddress = copyAddress;
+  copySecret = copySecret;
+  signOut = signOut;
 
   // Misc methods
-  setPrompt = setPrompt
+  setPrompt = setPrompt;
 }
 
-Wallet.prototype.componentWillLoad = componentWillLoad
-Wallet.prototype.render = render
+Wallet.prototype.componentWillLoad = componentWillLoad;
+Wallet.prototype.render = render;
 ```
 
 </CodeExample>
 
-Only thing worth seeing here besides the inclusion of the new `trustAsset` method is the addition of the `trust?: boolean,` in the `Loading` class.
+Only thing worth seeing here besides the inclusion of the new `trustAsset`
+method is the addition of the `trust?: boolean,` in the `Loading` class.
 
 ## Add Trustlines
 
@@ -292,7 +367,7 @@ Alright so, finally we get to the `./methods/trustAsset.ts` file!
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
+import sjcl from "@tinyanvil/sjcl";
 import {
   Keypair,
   Account,
@@ -300,81 +375,75 @@ import {
   BASE_FEE,
   Networks,
   Operation,
-  Asset
-} from 'stellar-sdk'
+  Asset,
+} from "stellar-sdk";
 
-import { handleError } from '@services/error'
+import { handleError } from "@services/error";
 
 export default async function trustAsset(
   e?: Event,
   asset?: string,
   issuer?: string,
-  pincode?: string
+  pincode?: string,
 ) {
   try {
-    if (e)
-      e.preventDefault()
+    if (e) e.preventDefault();
 
-    let instructions
+    let instructions;
 
-    if (
-      asset
-      && issuer
-    ) instructions = [asset, issuer]
-
+    if (asset && issuer) instructions = [asset, issuer];
     else {
-      instructions = await this.setPrompt('{Asset} {Issuer}')
-      instructions = instructions.split(' ')
+      instructions = await this.setPrompt("{Asset} {Issuer}");
+      instructions = instructions.split(" ");
     }
 
-    pincode = pincode || await this.setPrompt('Enter your keystore pincode')
+    pincode = pincode || (await this.setPrompt("Enter your keystore pincode"));
 
-    if (
-      !instructions
-      || !pincode
-    ) return
+    if (!instructions || !pincode) return;
 
     const keypair = Keypair.fromSecret(
-      sjcl.decrypt(pincode, this.account.keystore)
-    )
+      sjcl.decrypt(pincode, this.account.keystore),
+    );
 
-    this.error = null
-    this.loading = {...this.loading, trust: true}
+    this.error = null;
+    this.loading = { ...this.loading, trust: true };
 
-    await this.server.accounts()
-    .accountId(keypair.publicKey())
-    .call()
-    .then(({sequence}) => {
-      const account = new Account(keypair.publicKey(), sequence)
-      const transaction = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: Networks.TESTNET
+    await this.server
+      .accounts()
+      .accountId(keypair.publicKey())
+      .call()
+      .then(({ sequence }) => {
+        const account = new Account(keypair.publicKey(), sequence);
+        const transaction = new TransactionBuilder(account, {
+          fee: BASE_FEE,
+          networkPassphrase: Networks.TESTNET,
+        })
+          .addOperation(
+            Operation.changeTrust({
+              asset: new Asset(instructions[0], instructions[1]),
+            }),
+          )
+          .setTimeout(0)
+          .build();
+
+        transaction.sign(keypair);
+        return this.server.submitTransaction(transaction);
       })
-      .addOperation(Operation.changeTrust({
-        asset: new Asset(instructions[0], instructions[1])
-      }))
-      .setTimeout(0)
-      .build()
-
-      transaction.sign(keypair)
-      return this.server.submitTransaction(transaction)
-    })
-    .then((res) => console.log(res))
-    .finally(() => {
-      this.loading = {...this.loading, trust: false}
-      this.updateAccount()
-    })
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+      .then((res) => console.log(res))
+      .finally(() => {
+        this.loading = { ...this.loading, trust: false };
+        this.updateAccount();
+      });
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-This is similar to the `makePayment` method but there are a couple tiny tweaks worth noting:
+This is similar to the `makePayment` method but there are a couple tiny tweaks
+worth noting:
 
 <CodeExample>
 
@@ -406,13 +475,19 @@ export default async function trustAsset(
 
 </CodeExample>
 
-We’re allowing the inclusion of several arguments in this function, namely `asset`, `issuer`, and `pincode`. We won’t be making use of them here, but transparently creating trustlines from within other functions will prove useful later.
+We’re allowing the inclusion of several arguments in this function, namely
+`asset`, `issuer`, and `pincode`. We won’t be making use of them here, but
+transparently creating trustlines from within other functions will prove useful
+later.
 
-If we have any of those variables set, we can “preload” our interface a bit, and even bypass user input altogether if a pincode is provided. Again, not something we’ll make use of quite yet, but once we look into depositing and withdrawing assets from an Anchor or accepting incoming payments for which we don’t yet have a trustline this functionality will prove useful.
+If we have any of those variables set, we can “preload” our interface a bit, and
+even bypass user input altogether if a pincode is provided. Again, not something
+we’ll make use of quite yet, but once we look into depositing and withdrawing
+assets from an Anchor or accepting incoming payments for which we don’t yet have
+a trustline this functionality will prove useful.
 
-So there we have it! The ability to accept and pay with custom assets on Stellar!
+So there we have it! The ability to accept and pay with custom assets on
+Stellar!
 
-
-[1]:	https://github.com/stellar/stellar-demo-wallet/tree/pay
-[3]:	https://github.com/stellar/stellar-demo-wallet/tree/trustline
-
+[1]: https://github.com/stellar/stellar-demo-wallet/tree/pay
+[3]: https://github.com/stellar/stellar-demo-wallet/tree/trustline

--- a/content/docs/building-apps/index.mdx
+++ b/content/docs/building-apps/index.mdx
@@ -3,23 +3,67 @@ title: Overview
 order: 0
 ---
 
-Stellar is a self-serve distributed ledger that you can use as a backend to power all kinds of apps and services.  It has built-in logic for creating accounts, signing transactions, and tracking balances, and anyone can use it to issue, store, transfer, and trade assets.  Since many of those assets connect to real-world currencies, and since there are open protocols for integrating deposit and withdrawal of those assets, a Stellar-based app can take advantage of real banking rails and connect to real money.  
+Stellar is a self-serve distributed ledger that you can use as a backend to
+power all kinds of apps and services. It has built-in logic for creating
+accounts, signing transactions, and tracking balances, and anyone can use it to
+issue, store, transfer, and trade assets. Since many of those assets connect to
+real-world currencies, and since there are open protocols for integrating
+deposit and withdrawal of those assets, a Stellar-based app can take advantage
+of real banking rails and connect to real money.
 
-Currently, developers use Stellar to power cross-border payment apps, currency exchanges, micropayment services, and platforms for in-game purchases, but what you build — and how you build it — is up to you.  At its core, though, any app built on Stellar relies on the same basic functions: key storage, account creation, transaction signing, and queries to the Stellar database.  To make things easy, and to stick with common parlance, we’ll call the part of an app that implements those core functions a *wallet*.  This section of the docs will walk you through the process of building one.  
+Currently, developers use Stellar to power cross-border payment apps, currency
+exchanges, micropayment services, and platforms for in-game purchases, but what
+you build — and how you build it — is up to you. At its core, though, any app
+built on Stellar relies on the same basic functions: key storage, account
+creation, transaction signing, and queries to the Stellar database. To make
+things easy, and to stick with common parlance, we’ll call the part of an app
+that implements those core functions a _wallet_. This section of the docs will
+walk you through the process of building one.
 
-Stellar wallets can do more than store and move assets, and they don't have to be the end product for your users. They can be front and center in an application, or function invisibly in the background without revealing anything about Stellar to the end user.  However you decide to surface the UI of the wallet, there are several basic considerations and common implementations, and the goal of this section of the docs is to cover those by showing you how to build a basic wallet UI.
+Stellar wallets can do more than store and move assets, and they don't have to
+be the end product for your users. They can be front and center in an
+application, or function invisibly in the background without revealing anything
+about Stellar to the end user. However you decide to surface the UI of the
+wallet, there are several basic considerations and common implementations, and
+the goal of this section of the docs is to cover those by showing you how to
+build a basic wallet UI.
 
-It’s a step-by-step tutorial explaining how to construct a robust Stellar wallet following best practices.  If you follow it to the end, you'll have a fully functional Stellar interface, and a strong framework for continued development of your own use case.
+It’s a step-by-step tutorial explaining how to construct a robust Stellar wallet
+following best practices. If you follow it to the end, you'll have a fully
+functional Stellar interface, and a strong framework for continued development
+of your own use case.
 
 ## What’s in a Wallet?
-Unlike real-world wallets, which hold real-world cash, Stellar wallets don’t hold digital cash.  Not directly.  Rather, they allow users to view the history and current state of the Stellar ledger, and to sign and submit transactions.  Accounts, balances, and offers to buy and sell assets are kept on the ledger itself, which is shared by all the nodes that make up the network.  A wallet may store references or caches to the Stellar database, but the actual record and the value it tracks are on chain.
 
-What does this mean for the wallet we’re about to build? Good question. It means the wallet acts as a visual and interactive layer on top of Stellar rather than as an extension or storage mechanism. Our conversation moving forward will revolve around accessing Stellar and surfacing data in the network rather than "running" Stellar or storing something on our end.
+Unlike real-world wallets, which hold real-world cash, Stellar wallets don’t
+hold digital cash. Not directly. Rather, they allow users to view the history
+and current state of the Stellar ledger, and to sign and submit transactions.
+Accounts, balances, and offers to buy and sell assets are kept on the ledger
+itself, which is shared by all the nodes that make up the network. A wallet may
+store references or caches to the Stellar database, but the actual record and
+the value it tracks are on chain.
 
-A neat outflow of this is that most Stellar tools can operate almost entirely as client-side applications and services. There will certainly be server-side logic specific to your app, but the actual wallet interactions can operate openly on the client/browser.
+What does this mean for the wallet we’re about to build? Good question. It means
+the wallet acts as a visual and interactive layer on top of Stellar rather than
+as an extension or storage mechanism. Our conversation moving forward will
+revolve around accessing Stellar and surfacing data in the network rather than
+"running" Stellar or storing something on our end.
+
+A neat outflow of this is that most Stellar tools can operate almost entirely as
+client-side applications and services. There will certainly be server-side logic
+specific to your app, but the actual wallet interactions can operate openly on
+the client/browser.
 
 ## Securing Your Wallet
-Even though wallets can operate client-side, they deal with a user’s secret keys, which give direct access to their account, and to any value they hold in it.  That’s why it’s essential to require all web traffic to flow over strong TLS methods. Even when developing locally, use a self-signed localhost certificate to develop secure habits from the very beginning. 
-Stellar may be incredibly easy and intuitive, but it’s also powerful money-moving software.  Don’t skimp on security. Your future self and all your users thank you.  For more, check out our guide to [securing web-based products][1].
 
-[1]:	https://www.stellar.org/developers/guides/walkthroughs/securing-web-projects.html
+Even though wallets can operate client-side, they deal with a user’s secret
+keys, which give direct access to their account, and to any value they hold in
+it. That’s why it’s essential to require all web traffic to flow over strong TLS
+methods. Even when developing locally, use a self-signed localhost certificate
+to develop secure habits from the very beginning. Stellar may be incredibly easy
+and intuitive, but it’s also powerful money-moving software. Don’t skimp on
+security. Your future self and all your users thank you. For more, check out our
+guide to [securing web-based products][1].
+
+[1]:
+  https://www.stellar.org/developers/guides/walkthroughs/securing-web-projects.html

--- a/content/docs/building-apps/key-management.mdx
+++ b/content/docs/building-apps/key-management.mdx
@@ -3,23 +3,45 @@ title: Key Management Basics
 order: 30
 ---
 
-Step one for any app is to sort out user onboarding.  Since a Stellar wallet is an interface that gives a user access to an account stored on the ledger, and since that access is controlled by the account's secret key, the first thing you have to decide is how to handle a user's secret key, and how to append the Stellar account it unlocks to a user object.
+Step one for any app is to sort out user onboarding. Since a Stellar wallet is
+an interface that gives a user access to an account stored on the ledger, and
+since that access is controlled by the account's secret key, the first thing you
+have to decide is how to handle a user's secret key, and how to append the
+Stellar account it unlocks to a user object.
 
-The most important question: who will “own” the account? There are three possible answers:
+The most important question: who will “own” the account? There are three
+possible answers:
 
-1. You, the service provider, store the secret key and delegate usage rights to the user. This is a “custodial” service.
-2. They, the user, will store their own account credentials and permission your app to send requests or delegate transaction signing. This is a “non-custodial” service.
-3. A mixture of the two via multisig. This is especially useful for maintaining non-custodial status while still allowing for account recovery.
+1. You, the service provider, store the secret key and delegate usage rights to
+   the user. This is a “custodial” service.
+2. They, the user, will store their own account credentials and permission your
+   app to send requests or delegate transaction signing. This is a
+   “non-custodial” service.
+3. A mixture of the two via multisig. This is especially useful for maintaining
+   non-custodial status while still allowing for account recovery.
 
-Be very careful taking a custodial approach or using any mixture where you are storing user secrets. It’s easy to get wrong, and the consequences can be devastating.  For our purposes, we will assume choice #2.  This tutorial will show you hold to build a non-custodial service. 
+Be very careful taking a custodial approach or using any mixture where you are
+storing user secrets. It’s easy to get wrong, and the consequences can be
+devastating. For our purposes, we will assume choice #2. This tutorial will show
+you hold to build a non-custodial service.
 
-The non-custodial option poses some very real usability issues: your user has to securely store their own account credentials and safely navigate transaction signing on their end. There are ways to make that process more user-friendly, one of which is to create a keystore file guarded by a passphrase, and that's the approach we'll take in this tutorial.
+The non-custodial option poses some very real usability issues: your user has to
+securely store their own account credentials and safely navigate transaction
+signing on their end. There are ways to make that process more user-friendly,
+one of which is to create a keystore file guarded by a passphrase, and that's
+the approach we'll take in this tutorial.
 
-Creating a keystore file and storing it locally in the browser allows a user to import or export it into other systems, and  works pretty well as long as the user's passphrase is secure enough. We don't recommend this approach for high-security production applications, but it's the best way to get started, and for this tutorial, which lays out the foundation for a basic Stellar wallet, it’ll work just fine.
+Creating a keystore file and storing it locally in the browser allows a user to
+import or export it into other systems, and works pretty well as long as the
+user's passphrase is secure enough. We don't recommend this approach for
+high-security production applications, but it's the best way to get started, and
+for this tutorial, which lays out the foundation for a basic Stellar wallet,
+it’ll work just fine.
 
 ## Third-party Key Management Applications
 
-There are also several apps and services that specialize in adding additional security layers to users' accounts.  Check them out if you're interested:
+There are also several apps and services that specialize in adding additional
+security layers to users' accounts. Check them out if you're interested:
 
 - [Albedo][1]
 - [StellarAuth][2]
@@ -29,10 +51,10 @@ There are also several apps and services that specialize in adding additional se
 - [StellarGuard][6]
 - [LobstrVault][7]
 
-[1]:	https://albedo.link/
-[2]:	https://stellarauth.com/
-[3]:	https://stellar-authenticator.org/
-[4]:	https://www.ledger.com/
-[5]:	https://trezor.io/
-[6]:	https://stellarguard.me/
-[7]:	https://vault.lobstr.co/
+[1]: https://albedo.link/
+[2]: https://stellarauth.com/
+[3]: https://stellar-authenticator.org/
+[4]: https://www.ledger.com/
+[5]: https://trezor.io/
+[6]: https://stellarguard.me/
+[7]: https://vault.lobstr.co/

--- a/content/docs/building-apps/project-setup.mdx
+++ b/content/docs/building-apps/project-setup.mdx
@@ -5,9 +5,18 @@ order: 20
 
 import { CodeExample } from "components/CodeExample";
 
-Throughout this tutorial we'll be making use of a little toolchain called StencilJs. It takes the best of modern frontend frameworks and pares everything back to small, blazing fast, 100% standards-based Web Components that run in every browser. Don’t worry if you've never heard of it: it's just TS (JS), SCSS (CSS) and JSX (HTML). You should be able to follow along just fine if you've ever built something with modern web dev tools.
+Throughout this tutorial we'll be making use of a little toolchain called
+StencilJs. It takes the best of modern frontend frameworks and pares everything
+back to small, blazing fast, 100% standards-based Web Components that run in
+every browser. Don’t worry if you've never heard of it: it's just TS (JS), SCSS
+(CSS) and JSX (HTML). You should be able to follow along just fine if you've
+ever built something with modern web dev tools.
 
-We chose Stencil so you can learn by doing: it’s an easy way to create a web-based application, which means you can see the ins and outs of building a Stellar wallet start to finish.  Stellar also has a [suite of SDKs][1] in various programming languages, so if Javascript isn’t your thing, you can follow along, and recreate the steps below using one of them. 
+We chose Stencil so you can learn by doing: it’s an easy way to create a
+web-based application, which means you can see the ins and outs of building a
+Stellar wallet start to finish. Stellar also has a [suite of SDKs][1] in various
+programming languages, so if Javascript isn’t your thing, you can follow along,
+and recreate the steps below using one of them.
 
 To start the setup, open your terminal and initialize a new project.
 
@@ -19,7 +28,10 @@ npm init stencil
 
 </CodeExample>
 
-After running `init` you will be provided with a prompt to choose the type of project to start. While Stencil can be used to create entire apps, we’ll choose the component as we’ll just be dealing with modular components rather than building an entire application
+After running `init` you will be provided with a prompt to choose the type of
+project to start. While Stencil can be used to create entire apps, we’ll choose
+the component as we’ll just be dealing with modular components rather than
+building an entire application
 
 <CodeExample>
 
@@ -62,16 +74,22 @@ We’ll walk through the prompt, `cd` into the project and run `npm i ; npm star
 
    - https://github.com/ionic-team/stencil-component-starter
 
-  Happy coding! 
+  Happy coding!
 ```
 
 </CodeExample>
 
-Now that our project is initialized, let’s take a look at the directory structure and familiarize ourselves with where things are and what roles they play.
+Now that our project is initialized, let’s take a look at the directory
+structure and familiarize ourselves with where things are and what roles they
+play.
 
 ![][image-1]
 
-We’re mostly interested in the `src/` directory. The `dist/` and `www/` directories are outputs for compiled code. In the `src/components/` directory you’ll see a `my-component/` folder. We’re about to generate our own component, so go ahead and delete that folder. You can also nuke the `utils/` directory as we won’t be covering tests in this tutorial. Now run:
+We’re mostly interested in the `src/` directory. The `dist/` and `www/`
+directories are outputs for compiled code. In the `src/components/` directory
+you’ll see a `my-component/` folder. We’re about to generate our own component,
+so go ahead and delete that folder. You can also nuke the `utils/` directory as
+we won’t be covering tests in this tutorial. Now run:
 
 <CodeExample>
 
@@ -81,7 +99,10 @@ $ npm run generate
 
 </CodeExample>
 
-This will initialize a component generation script. Enter a name of `stellar-wallet`. Disable Spec Test and E2E Test as we’re not interested in those Stencil features today. Press Return and your component will generate and wire up.
+This will initialize a component generation script. Enter a name of
+`stellar-wallet`. Disable Spec Test and E2E Test as we’re not interested in
+those Stencil features today. Press Return and your component will generate and
+wire up.
 
 <CodeExample>
 
@@ -103,7 +124,9 @@ The following files have been generated:
 
 </CodeExample>
 
-Amazing! Just a few more setup bits and we can get coding. I don’t know about you but I prefer to style in SCSS rather than CSS so let’s get some modern CSS dev tools setup.
+Amazing! Just a few more setup bits and we can get coding. I don’t know about
+you but I prefer to style in SCSS rather than CSS so let’s get some modern CSS
+dev tools setup.
 
 <CodeExample>
 
@@ -113,61 +136,77 @@ npm i -D @stencil/postcss @stencil/sass autoprefixer @types/autoprefixer rollup-
 
 </CodeExample>
 
-Once those packages have successfully installed, hop over to the `stencil.config.ts` file at the root of the project and modify it to this:
+Once those packages have successfully installed, hop over to the
+`stencil.config.ts` file at the root of the project and modify it to this:
 
 <CodeExample>
 
 ```ts
-import { Config } from '@stencil/core'
-import { sass } from '@stencil/sass'
-import { postcss } from '@stencil/postcss'
-import autoprefixer from 'autoprefixer'
-import nodePolyfills from 'rollup-plugin-node-polyfills'
+import { Config } from "@stencil/core";
+import { sass } from "@stencil/sass";
+import { postcss } from "@stencil/postcss";
+import autoprefixer from "autoprefixer";
+import nodePolyfills from "rollup-plugin-node-polyfills";
 
 export const config: Config = {
-  namespace: 'stellar-wallet',
+  namespace: "stellar-wallet",
   outputTargets: [
     {
-      type: 'dist',
-      esmLoaderPath: '../loader'
+      type: "dist",
+      esmLoaderPath: "../loader",
     },
     {
-      type: 'docs-readme'
+      type: "docs-readme",
     },
     {
-      type: 'www',
-      serviceWorker: null // disable service workers
-    }
+      type: "www",
+      serviceWorker: null, // disable service workers
+    },
   ],
-  globalStyle: 'src/global/style.scss',
+  globalStyle: "src/global/style.scss",
   commonjs: {
     namedExports: {
-      'stellar-sdk': ['StrKey', 'xdr', 'Transaction', 'Keypair', 'Networks', 'Account', 'TransactionBuilder', 'BASE_FEE', 'Operation', 'Asset', 'Memo', 'MemoHash'],
-      '@stellar/wallet-sdk': ['KeyManager', 'KeyManagerPlugins', 'KeyType'],
+      "stellar-sdk": [
+        "StrKey",
+        "xdr",
+        "Transaction",
+        "Keypair",
+        "Networks",
+        "Account",
+        "TransactionBuilder",
+        "BASE_FEE",
+        "Operation",
+        "Asset",
+        "Memo",
+        "MemoHash",
+      ],
+      "@stellar/wallet-sdk": ["KeyManager", "KeyManagerPlugins", "KeyType"],
     },
   },
   plugins: [
     nodePolyfills(),
     sass(),
     postcss({
-      plugins: [autoprefixer()]
-    })
+      plugins: [autoprefixer()],
+    }),
   ],
   nodeResolve: {
     browser: true,
-    preferBuiltins: true
-  }
-}
+    preferBuiltins: true,
+  },
+};
 ```
 
 </CodeExample>
 
-With that file saved, pop over to the `src/components/wallet/` and rename the `wallet.css` to `wallet.scss`. While we’re here let’s go ahead and modify this new style file with some basic styling to put our project in a pretty place.
+With that file saved, pop over to the `src/components/wallet/` and rename the
+`wallet.css` to `wallet.scss`. While we’re here let’s go ahead and modify this
+new style file with some basic styling to put our project in a pretty place.
 
 <CodeExample>
 
 ```scss
-@import '../../global/style.scss';
+@import "../../global/style.scss";
 
 :host {
   display: block;
@@ -224,24 +263,94 @@ With that file saved, pop over to the `src/components/wallet/` and rename the `w
 
 </CodeExample>
 
-Before we update our `wallet.tsx` with this new stylesheet, note that we’re also importing a global stylesheet.  Go ahead and create that file at the root of the `src/` directory. So `src/global/style.scss`.
+Before we update our `wallet.tsx` with this new stylesheet, note that we’re also
+importing a global stylesheet. Go ahead and create that file at the root of the
+`src/` directory. So `src/global/style.scss`.
 
 <CodeExample>
 
 ```scss
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
   margin: 0;
   padding: 0;
   border: 0;
@@ -250,22 +359,35 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
   display: block;
 }
 body {
   line-height: 1;
 }
-ol, ul {
+ol,
+ul {
   list-style: none;
 }
-blockquote, q {
+blockquote,
+q {
   quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-  content: '';
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
   content: none;
 }
 table {
@@ -319,37 +441,38 @@ button {
 
 </CodeExample>
 
-Save those style files and update the `wallet.tsx` to point to our new styles like so:
+Save those style files and update the `wallet.tsx` to point to our new styles
+like so:
 
 <CodeExample>
 
 ```tsx
-import { Component, h } from '@stencil/core'
-import * as StellarSdk from 'stellar-sdk'
+import { Component, h } from "@stencil/core";
+import * as StellarSdk from "stellar-sdk";
 
 @Component({
-  tag: 'stellar-wallet',
-  styleUrl: 'wallet.scss',
-  shadow: true
+  tag: "stellar-wallet",
+  styleUrl: "wallet.scss",
+  shadow: true,
 })
 export class Wallet {
   render() {
     return [
       <h1>
-        {
-        !!StellarSdk
-        ? 'The StellarSdk is ready to rock 🤘'
-        : 'Uh oh, the StellarSdk is missing 😱'
-        }
-      </h1>
-    ]
+        {!!StellarSdk
+          ? "The StellarSdk is ready to rock 🤘"
+          : "Uh oh, the StellarSdk is missing 😱"}
+      </h1>,
+    ];
   }
 }
 ```
 
 </CodeExample>
 
-You’ll notice we also include a few extra setup lines to get the StellarSdk loaded in and ready to use. Let’s ensure all those dependencies are loaded and ready to rock.
+You’ll notice we also include a few extra setup lines to get the StellarSdk
+loaded in and ready to use. Let’s ensure all those dependencies are loaded and
+ready to rock.
 
 <CodeExample>
 
@@ -359,30 +482,34 @@ npm i -D stellar-sdk js-xdr
 
 </CodeExample>
 
-The last mod: point the `src/index.html` file to use this brand new component. Modify that file to match this.
+The last mod: point the `src/index.html` file to use this brand new component.
+Modify that file to match this.
 
 <CodeExample>
 
 ```html
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0" />
-  <title>Stellar Wallet</title>
-  <link rel="stylesheet" href="https://unpkg.com/reset-css/reset.css">
-  <script type="module" src="/build/stellar-wallet.esm.js"></script>
-  <script nomodule src="/build/stellar-wallet.js"></script>
-</head>
-<body>
-  <stellar-wallet />
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"
+    />
+    <title>Stellar Wallet</title>
+    <link rel="stylesheet" href="https://unpkg.com/reset-css/reset.css" />
+    <script type="module" src="/build/stellar-wallet.esm.js"></script>
+    <script nomodule src="/build/stellar-wallet.js"></script>
+  </head>
+  <body>
+    <stellar-wallet />
+  </body>
 </html>
 ```
 
 </CodeExample>
 
-You should be all set up now.  Restart the server and let’s get coding.
+You should be all set up now. Restart the server and let’s get coding.
 
 <CodeExample>
 
@@ -393,11 +520,8 @@ $ npm start
 
 </CodeExample>
 
-
 [View the full setup code on GitHub][2]
 
-[1]:	../software-and-sdks/index.mdx
-[2]:	https://github.com/stellar/stellar-demo-wallet/tree/setup
-
-[image-1]:	https://tyler.link/szLiPF+
-
+[1]: ../software-and-sdks/index.mdx
+[2]: https://github.com/stellar/stellar-demo-wallet/tree/setup
+[image-1]: https://tyler.link/szLiPF+

--- a/content/docs/building-apps/xlm-payments.mdx
+++ b/content/docs/building-apps/xlm-payments.mdx
@@ -8,17 +8,29 @@ import { Alert } from "components/Alert";
 
 <Alert>
 
-In this tutorial we’re going to modify our [base wallet app](./basic-wallet.mdx) to include functionality to send XLM to other Stellar accounts.
+In this tutorial we’re going to modify our [base wallet app](./basic-wallet.mdx)
+to include functionality to send XLM to other Stellar accounts.
 
 </Alert>
 
 [View keystore boilerplate code on GitHub][1]
 
-In the [Build a Basic Wallet section](./basic-wallet.mdx), we did the hard work of wiring up a secure client and rock-solid key creation and storage structure with a clear plan for key use and management.  Now that we have a method for creating an account — and for storing that account's secrets so they're safe and easy to use — we're ready to start making payments.  We'll start with XLM payments since they're a little simpler; in the [next sectiion](./custom-assets.mdx), we'll look at how to support payments for other assets.
+In the [Build a Basic Wallet section](./basic-wallet.mdx), we did the hard work
+of wiring up a secure client and rock-solid key creation and storage structure
+with a clear plan for key use and management. Now that we have a method for
+creating an account — and for storing that account's secrets so they're safe and
+easy to use — we're ready to start making payments. We'll start with XLM
+payments since they're a little simpler; in the
+[next sectiion](./custom-assets.mdx), we'll look at how to support payments for
+other assets.
 
-There isn’t too much that's new or complicated here: we'll be building on what we already have. Again, most of the work will be in `src/components/wallet/`; however, before we dive into that file let’s clean up our project just a touch and add some helpful polish. Namely a loader component.
+There isn’t too much that's new or complicated here: we'll be building on what
+we already have. Again, most of the work will be in `src/components/wallet/`;
+however, before we dive into that file let’s clean up our project just a touch
+and add some helpful polish. Namely a loader component.
 
 ## Add Loader Component
+
 Hopefully by now you’re familiar with how to generate new Stencil components.
 
 <CodeExample>
@@ -26,71 +38,63 @@ Hopefully by now you’re familiar with how to generate new Stencil components.
 ```bash
 npm run generate
 ```
+
 </CodeExample>
 
-
-We'll call the component `stellar-loader`, and deselect both test files leaving only the styling. Once you've done that, open `src/components/loader/` and rename the `.css` file to `.scss`. Then replace the `loader.tsx` contents with this:
+We'll call the component `stellar-loader`, and deselect both test files leaving
+only the styling. Once you've done that, open `src/components/loader/` and
+rename the `.css` file to `.scss`. Then replace the `loader.tsx` contents with
+this:
 
 <CodeExample>
 
 ```tsx
-import Combinatorics from 'js-combinatorics'
-import {
-  Component,
-  h,
-  State,
-  Prop
-} from '@stencil/core';
-import {
-  isEqual as loIsEqual,
-  sample as loSample
-} from 'lodash-es'
+import Combinatorics from "js-combinatorics";
+import { Component, h, State, Prop } from "@stencil/core";
+import { isEqual as loIsEqual, sample as loSample } from "lodash-es";
 
 @Component({
-  tag: 'stellar-loader',
-  styleUrl: 'loader.scss',
-  shadow: true
+  tag: "stellar-loader",
+  styleUrl: "loader.scss",
+  shadow: true,
 })
 export class Loader {
-  @State() chances: any = []
-  @State() chance: any = null
-  @Prop() interval: any
+  @State() chances: any = [];
+  @State() chance: any = null;
+  @Prop() interval: any;
 
   componentWillLoad() {
     return new Promise((resolve) => {
-      if (!this.chances.length)
-        this.generateChances(9)
+      if (!this.chances.length) this.generateChances(9);
 
       if (!this.interval)
-        this.interval = setInterval(() => this.getChance(), 100)
+        this.interval = setInterval(() => this.getChance(), 100);
 
-      resolve()
-    })
+      resolve();
+    });
   }
 
   generateChances(int: number) {
-    const baseN = Combinatorics.baseN([0, 1], int)
+    const baseN = Combinatorics.baseN([0, 1], int);
 
-    this.chances = baseN.toArray()
-    this.getChance()
+    this.chances = baseN.toArray();
+    this.getChance();
   }
   getChance() {
-    const chance = loSample(this.chances)
+    const chance = loSample(this.chances);
 
-    if (loIsEqual(chance, this.chance))
-      this.getChance()
-    else
-      this.chance = chance
+    if (loIsEqual(chance, this.chance)) this.getChance();
+    else this.chance = chance;
   }
 
   render() {
     return (
       <div class="loader">
-        {this.chance.map((int, i) =>
-          <div class={int ? 'on' : null} key={`${int}${i}`}></div>
-        )}
+        {this.chance.map((int, i) => (
+          <div class={int ? "on" : null} key={`${int}${i}`}></div>
+        ))}
       </div>
-    )
+    );
   }
 }
 ```
@@ -107,138 +111,133 @@ npm i -D js-combinatorics
 
 </CodeExample>
 
-It’s a fancy wackadoodle little component which at the end of the day just produces a little loader for use in our action buttons.
+It’s a fancy wackadoodle little component which at the end of the day just
+produces a little loader for use in our action buttons.
 
 ![][image-1]
 
 ## Import Methods
+
 We’re now ready to tackle the `src/components/wallet/wallet.ts` file.
 
 <CodeExample>
 
 ```ts
-import {
-  Component,
-  State,
-  Prop
-} from '@stencil/core'
-import {
-  Server,
-  ServerApi,
-} from 'stellar-sdk'
+import { Component, State, Prop } from "@stencil/core";
+import { Server, ServerApi } from "stellar-sdk";
 
-import componentWillLoad from './events/componentWillLoad'
-import render from './events/render'
+import componentWillLoad from "./events/componentWillLoad";
+import render from "./events/render";
 
-import createAccount from './methods/createAccount'
-import updateAccount from './methods/updateAccount'
-import makePayment from './methods/makePayment'
-import copyAddress from './methods/copyAddress'
-import copySecret from './methods/copySecret'
-import signOut from './methods/signOut'
-import setPrompt from './methods/setPrompt'
+import createAccount from "./methods/createAccount";
+import updateAccount from "./methods/updateAccount";
+import makePayment from "./methods/makePayment";
+import copyAddress from "./methods/copyAddress";
+import copySecret from "./methods/copySecret";
+import signOut from "./methods/signOut";
+import setPrompt from "./methods/setPrompt";
 
-import { Prompter } from '@prompt/prompt'
+import { Prompter } from "@prompt/prompt";
 
 interface StellarAccount {
-  publicKey: string,
-  keystore: string,
-  state?: ServerApi.AccountRecord,
+  publicKey: string;
+  keystore: string;
+  state?: ServerApi.AccountRecord;
 }
 
 interface Loading {
-  fund?: boolean,
-  pay?: boolean,
-  update?: boolean,
+  fund?: boolean;
+  pay?: boolean;
+  update?: boolean;
 }
 
 @Component({
-  tag: 'stellar-wallet',
-  styleUrl: 'wallet.scss',
-  shadow: true
+  tag: "stellar-wallet",
+  styleUrl: "wallet.scss",
+  shadow: true,
 })
 export class Wallet {
-  @State() account: StellarAccount
-  @State() prompter: Prompter = {show: false}
-  @State() loading: Loading = {}
-  @State() error: any = null
+  @State() account: StellarAccount;
+  @State() prompter: Prompter = { show: false };
+  @State() loading: Loading = {};
+  @State() error: any = null;
 
-  @Prop() server: Server
+  @Prop() server: Server;
 
   // Component events
   componentWillLoad() {}
   render() {}
 
   // Stellar methods
-  createAccount = createAccount
-  updateAccount = updateAccount
-  makePayment = makePayment
-  copyAddress = copyAddress
-  copySecret = copySecret
-  signOut = signOut
+  createAccount = createAccount;
+  updateAccount = updateAccount;
+  makePayment = makePayment;
+  copyAddress = copyAddress;
+  copySecret = copySecret;
+  signOut = signOut;
 
   // Misc methods
-  setPrompt = setPrompt
+  setPrompt = setPrompt;
 }
 
-Wallet.prototype.componentWillLoad = componentWillLoad
-Wallet.prototype.render = render
+Wallet.prototype.componentWillLoad = componentWillLoad;
+Wallet.prototype.render = render;
 ```
 
 </CodeExample>
 
-If you’ve followed other tutorials in this series much of this may be review, but we’ll just walk along this file and see exactly what’s going on.
+If you’ve followed other tutorials in this series much of this may be review,
+but we’ll just walk along this file and see exactly what’s going on.
 
 <CodeExample>
 
 ```ts
-import {
-  Component,
-  State,
-  Prop
-} from '@stencil/core'
-import {
-  Server,
-  ServerApi,
-} from 'stellar-sdk'
+import { Component, State, Prop } from "@stencil/core";
+import { Server, ServerApi } from "stellar-sdk";
 
-import componentWillLoad from './events/componentWillLoad' // UPDATE
-import render from './events/render' // UPDATE
+import componentWillLoad from "./events/componentWillLoad"; // UPDATE
+import render from "./events/render"; // UPDATE
 
-import createAccount from './methods/createAccount' // UPDATE
-import updateAccount from './methods/updateAccount' // NEW
-import makePayment from './methods/makePayment' // NEW
-import copyAddress from './methods/copyAddress'
-import copySecret from './methods/copySecret'
-import signOut from './methods/signOut'
-import setPrompt from './methods/setPrompt'
+import createAccount from "./methods/createAccount"; // UPDATE
+import updateAccount from "./methods/updateAccount"; // NEW
+import makePayment from "./methods/makePayment"; // NEW
+import copyAddress from "./methods/copyAddress";
+import copySecret from "./methods/copySecret";
+import signOut from "./methods/signOut";
+import setPrompt from "./methods/setPrompt";
 
-import { Prompter } from '@prompt/prompt'
+import { Prompter } from "@prompt/prompt";
 ```
 
 </CodeExample>
 
-Imports galore! Nothing really noteworthy here other than you’ll notice we’re importing `./methods/updateAccount` and `./methods/makePayment` methods which we’ll be creating soon. There are a number of updates in the other methods from previous tutorials, and we’ll walk through all of those in a moment as well.
+Imports galore! Nothing really noteworthy here other than you’ll notice we’re
+importing `./methods/updateAccount` and `./methods/makePayment` methods which
+we’ll be creating soon. There are a number of updates in the other methods from
+previous tutorials, and we’ll walk through all of those in a moment as well.
 
 <CodeExample>
 
 ```ts
-interface StellarAccount { // UPDATE
-  publicKey: string,
-  keystore: string,
-  state?: ServerApi.AccountRecord,
+interface StellarAccount {
+  // UPDATE
+  publicKey: string;
+  keystore: string;
+  state?: ServerApi.AccountRecord;
 }
 
-interface Loading { // NEW
-  fund?: boolean,
-  pay?: boolean,
-  update?: boolean,
+interface Loading {
+  // NEW
+  fund?: boolean;
+  pay?: boolean;
+  update?: boolean;
 }
 ```
 
 </CodeExample>
 
-Here we’re setting up two TypeScript classes: one for our account and the other for our loading states.
+Here we’re setting up two TypeScript classes: one for our account and the other
+for our loading states.
 
 <CodeExample>
 
@@ -262,139 +261,195 @@ export class Wallet {
 
 </CodeExample>
 
-Here we set up our `@State`’s, those dynamic properties with values that will change and alter the DOM of the component, and our `@Prop`, which in this case will hold a static reference to our Stellar server instance.
+Here we set up our `@State`’s, those dynamic properties with values that will
+change and alter the DOM of the component, and our `@Prop`, which in this case
+will hold a static reference to our Stellar server instance.
 
 ## Update Component Events
-Next let’s update our two component events `./events/componentWillLoad.ts` and `./events/render.tsx`:
+
+Next let’s update our two component events `./events/componentWillLoad.ts` and
+`./events/render.tsx`:
 
 <CodeExample>
 
 ```ts
-import { Server } from 'stellar-sdk'
-import { handleError } from '@services/error'
-import { get } from '@services/storage'
+import { Server } from "stellar-sdk";
+import { handleError } from "@services/error";
+import { get } from "@services/storage";
 
 export default async function componentWillLoad() {
   try {
-    let keystore = await get('keyStore')
+    let keystore = await get("keyStore");
 
-    this.error = null
-    this.server = new Server('https://horizon-testnet.stellar.org')
+    this.error = null;
+    this.server = new Server("https://horizon-testnet.stellar.org");
 
     if (keystore) {
-      keystore = atob(keystore)
+      keystore = atob(keystore);
 
-      const { publicKey } = JSON.parse(atob(JSON.parse(keystore).adata))
+      const { publicKey } = JSON.parse(atob(JSON.parse(keystore).adata));
 
       this.account = {
         publicKey,
-        keystore
-      }
+        keystore,
+      };
 
-      this.updateAccount()
+      this.updateAccount();
     }
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-In Stencil’s `componentWillLoad` method, we set up default values for the States and Props we initialized earlier. Most notably, we’re setting our server and account. You’ll notice we’re using the public `horizon-testnet` for now — we're just learning, and not ready to send live XLM — but in production you’d want to change this to the public `horizon` endpoint or, if you're running your own Horizon, to one of your own Horizon API endpoints. 
+In Stencil’s `componentWillLoad` method, we set up default values for the States
+and Props we initialized earlier. Most notably, we’re setting our server and
+account. You’ll notice we’re using the public `horizon-testnet` for now — we're
+just learning, and not ready to send live XLM — but in production you’d want to
+change this to the public `horizon` endpoint or, if you're running your own
+Horizon, to one of your own Horizon API endpoints.
 
-For the account we’re simply checking to see if a `keyStore` value has been stored, and if so we’re grabbing the public key and keystore from it and adding those to the account `@State`. The `state` value, which is optional, is not set here as we’ll need to run the method `updateAccount()` to find if the account exists, and if so what the state of that account looks like. We’ll get to that method shortly. For now let’s update our `render.tsx` method:
+For the account we’re simply checking to see if a `keyStore` value has been
+stored, and if so we’re grabbing the public key and keystore from it and adding
+those to the account `@State`. The `state` value, which is optional, is not set
+here as we’ll need to run the method `updateAccount()` to find if the account
+exists, and if so what the state of that account looks like. We’ll get to that
+method shortly. For now let’s update our `render.tsx` method:
 
 <CodeExample>
 
 ```tsx
-import { h } from '@stencil/core'
-import { has as loHas } from 'lodash-es'
+import { h } from "@stencil/core";
+import { has as loHas } from "lodash-es";
 
 export default function render() {
   return [
     <stellar-prompt prompter={this.prompter} />,
 
+    this.account ? (
+      [
+        <div class="account-key">
+          <p>{this.account.publicKey}</p>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copyAddress(e)}
+          >
+            Copy Address
+          </button>
+          <button
+            class="small"
+            type="button"
+            onClick={(e) => this.copySecret(e)}
+          >
+            Copy Secret
+          </button>
+        </div>,
+
+        <button
+          class={this.loading.pay ? "loading" : null}
+          type="button"
+          onClick={(e) => this.makePayment(e)}
+        >
+          {this.loading.pay ? <stellar-loader /> : null} Make Payment
+        </button>,
+      ]
+    ) : (
+      <button
+        class={this.loading.fund ? "loading" : null}
+        type="button"
+        onClick={(e) => this.createAccount(e)}
+      >
+        {this.loading.fund ? <stellar-loader /> : null} Create Account
+      </button>
+    ),
+
+    this.error ? (
+      <pre class="error">{JSON.stringify(this.error, null, 2)}</pre>
+    ) : null,
+
+    loHas(this.account, "state") ? (
+      <pre class="account-state">
+        {JSON.stringify(this.account.state, null, 2)}
+      </pre>
+    ) : null,
+
     this.account
-    ? [
-      <div class="account-key">
-        <p>{this.account.publicKey}</p>
-        <button class="small" type="button" onClick={(e) => this.copyAddress(e)}>Copy Address</button>
-        <button class="small" type="button" onClick={(e) => this.copySecret(e)}>Copy Secret</button>
-      </div>,
-
-      <button class={this.loading.pay ? 'loading' : null} type="button" onClick={(e) => this.makePayment(e)}>{this.loading.pay ? <stellar-loader /> : null} Make Payment</button>,
-    ]
-    : <button class={this.loading.fund ? 'loading' : null} type="button" onClick={(e) => this.createAccount(e)}>{this.loading.fund ? <stellar-loader /> : null} Create Account</button>,
-
-    this.error ? <pre class="error">{JSON.stringify(this.error, null, 2)}</pre> : null,
-
-    loHas(this.account, 'state') ? <pre class="account-state">{JSON.stringify(this.account.state, null, 2)}</pre> : null,
-
-    this.account ? [
-      <button class={this.loading.update ? 'loading' : null} type="button" onClick={(e) => this.updateAccount(e)}>{this.loading.update ? <stellar-loader /> : null} Update Account</button>,
-      <button type="button" onClick={(e) => this.signOut(e)}>Sign Out</button>,
-    ] : null,
-  ]
+      ? [
+          <button
+            class={this.loading.update ? "loading" : null}
+            type="button"
+            onClick={(e) => this.updateAccount(e)}
+          >
+            {this.loading.update ? <stellar-loader /> : null} Update Account
+          </button>,
+          <button type="button" onClick={(e) => this.signOut(e)}>
+            Sign Out
+          </button>,
+        ]
+      : null,
+  ];
 }
 ```
 
 </CodeExample>
 
-Yikers amirite!? Don’t worry though: it’s actually quite simple if you’ve spent any time with HTML in JS before. What we're looking at are a few ternary operators toggling the UI between different states based on the account status. Basically just a bunch of buttons wired up to their subsequent actions. Turns out creating those buttons is next on our to-do list!
+Yikers amirite!? Don’t worry though: it’s actually quite simple if you’ve spent
+any time with HTML in JS before. What we're looking at are a few ternary
+operators toggling the UI between different states based on the account status.
+Basically just a bunch of buttons wired up to their subsequent actions. Turns
+out creating those buttons is next on our to-do list!
 
 ## Create Buttons
-`updateAccount` and `makePayment` are new; `createAccount` will just need a few tweaks. Let’s start with that one.
+
+`updateAccount` and `makePayment` are new; `createAccount` will just need a few
+tweaks. Let’s start with that one.
 
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
-import axios from 'axios'
-import { Keypair } from 'stellar-sdk'
+import sjcl from "@tinyanvil/sjcl";
+import axios from "axios";
+import { Keypair } from "stellar-sdk";
 
-import { handleError } from '@services/error'
-import { set } from '@services/storage'
+import { handleError } from "@services/error";
+import { set } from "@services/storage";
 
 export default async function createAccount(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    const pincode_1 = await this.setPrompt('Enter a keystore pincode')
-    const pincode_2 = await this.setPrompt('Enter keystore pincode again')
+    const pincode_1 = await this.setPrompt("Enter a keystore pincode");
+    const pincode_2 = await this.setPrompt("Enter keystore pincode again");
 
-    if (
-      !pincode_1
-      || !pincode_2
-      || pincode_1 !== pincode_2
-    ) throw 'Invalid pincode'
+    if (!pincode_1 || !pincode_2 || pincode_1 !== pincode_2)
+      throw "Invalid pincode";
 
-    this.error = null
-    this.loading = {...this.loading, fund: true}
+    this.error = null;
+    this.loading = { ...this.loading, fund: true };
 
-    const keypair = Keypair.random()
+    const keypair = Keypair.random();
 
-    await axios(`https://friendbot.stellar.org?addr=${keypair.publicKey()}`)
-    .finally(() => this.loading = {...this.loading, fund: false})
+    await axios(
+      `https://friendbot.stellar.org?addr=${keypair.publicKey()}`,
+    ).finally(() => (this.loading = { ...this.loading, fund: false }));
 
     this.account = {
       publicKey: keypair.publicKey(),
       keystore: sjcl.encrypt(pincode_1, keypair.secret(), {
         adata: JSON.stringify({
-          publicKey: keypair.publicKey()
-        })
-      })
-    }
+          publicKey: keypair.publicKey(),
+        }),
+      }),
+    };
 
-    await set('keyStore', btoa(this.account.keystore))
+    await set("keyStore", btoa(this.account.keystore));
 
-    this.updateAccount()
-  }
-
-  catch(err) {
-    this.error = handleError(err)
+    this.updateAccount();
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
@@ -402,22 +457,31 @@ export default async function createAccount(e: Event) {
 </CodeExample>
 
 ## Fund Account Using Friendbot
-The only new thing we’re adding here — other than a loading state and an initial `this.updateAccount()` call at the end — is the call to [friendbot.stellar.org][2], which is a testnet tool that we can use to automatically fund our new testnet account with 10,000 XLM. Nice little shortcut to kickstart our development.
+
+The only new thing we’re adding here — other than a loading state and an initial
+`this.updateAccount()` call at the end — is the call to
+[friendbot.stellar.org][2], which is a testnet tool that we can use to
+automatically fund our new testnet account with 10,000 XLM. Nice little shortcut
+to kickstart our development.
 
 <CodeExample>
 
 ```ts
-await axios(`https://friendbot.stellar.org?addr=${keypair.publicKey()}`)
-.finally(() => this.loading = {...this.loading, fund: false})
+await axios(
+  `https://friendbot.stellar.org?addr=${keypair.publicKey()}`,
+).finally(() => (this.loading = { ...this.loading, fund: false }));
 ```
 
 </CodeExample>
 
-In production, you would have to find an actual source for funding the account.  Some wallets fund users' accounts for them; some require the user to supply the funds. 
+In production, you would have to find an actual source for funding the account.
+Some wallets fund users' accounts for them; some require the user to supply the
+funds.
 
-So that’s the updated `./methods/createAccount.ts` file. 
+So that’s the updated `./methods/createAccount.ts` file.
 
 ## Update Account Method
+
 Now let’s create two new files for updating the account and making XLM payments.
 
 <CodeExample>
@@ -433,70 +497,82 @@ Let’s start with the simpler one, `./methods/updateAccount.ts`
 <CodeExample>
 
 ```ts
-import {
-  omit as loOmit,
-  map as loMap
-} from 'lodash-es'
+import { omit as loOmit, map as loMap } from "lodash-es";
 
-import { handleError } from '@services/error'
+import { handleError } from "@services/error";
 
 export default async function updateAccount(e?: Event) {
   try {
-    if (e) e.preventDefault()
+    if (e) e.preventDefault();
 
-    this.error = null
-    this.loading = {...this.loading, update: true}
+    this.error = null;
+    this.loading = { ...this.loading, update: true };
 
     await this.server
-    .accounts()
-    .accountId(this.account.publicKey)
-    .call()
-    .then((account) => {
-      account.balances = loMap(account.balances, (balance) => loOmit(balance, [
-        'limit',
-        'buying_liabilities',
-        'selling_liabilities',
-        'is_authorized',
-        'last_modified_ledger',
-        balance.asset_type !== 'native' ? 'asset_type' : null
-      ]))
+      .accounts()
+      .accountId(this.account.publicKey)
+      .call()
+      .then((account) => {
+        account.balances = loMap(account.balances, (balance) =>
+          loOmit(balance, [
+            "limit",
+            "buying_liabilities",
+            "selling_liabilities",
+            "is_authorized",
+            "last_modified_ledger",
+            balance.asset_type !== "native" ? "asset_type" : null,
+          ]),
+        );
 
-      this.account = {...this.account, state: loOmit(account, [
-        'id',
-        '_links',
-        'sequence',
-        'subentry_count',
-        'last_modified_ledger',
-        'flags',
-        'thresholds',
-        'account_id',
-        'signers',
-        'paging_token',
-        'data_attr'
-      ])}
-    })
-    .finally(() => this.loading = {...this.loading, update: false})
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+        this.account = {
+          ...this.account,
+          state: loOmit(account, [
+            "id",
+            "_links",
+            "sequence",
+            "subentry_count",
+            "last_modified_ledger",
+            "flags",
+            "thresholds",
+            "account_id",
+            "signers",
+            "paging_token",
+            "data_attr",
+          ]),
+        };
+      })
+      .finally(() => (this.loading = { ...this.loading, update: false }));
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-All we’re doing here is looking up the state of the Stellar account on the ledger and saving it to the `this.account.state`. You’ll also notice we’re omitting several fields from the account and balances for easier readability. You may choose to save these and selectively display the values you care about, but in our example we’re just displaying the raw JSON, so cleaning things up a little is the right move. 
+All we’re doing here is looking up the state of the Stellar account on the
+ledger and saving it to the `this.account.state`. You’ll also notice we’re
+omitting several fields from the account and balances for easier readability.
+You may choose to save these and selectively display the values you care about,
+but in our example we’re just displaying the raw JSON, so cleaning things up a
+little is the right move.
 
-`this.account = {...this.account, state: loOmit(account, ['id', ...])}` may feel odd, but it’s just the Stencil way of updating a state’s object key to trigger a re-render of the DOM. You’ll notice `this.loading` follows the same pattern. We’ll make use of this data further down in the `render` method, but for now just know this is how we would grab ahold of the account to get the latest state.
+`this.account = {...this.account, state: loOmit(account, ['id', ...])}` may feel
+odd, but it’s just the Stencil way of updating a state’s object key to trigger a
+re-render of the DOM. You’ll notice `this.loading` follows the same pattern.
+We’ll make use of this data further down in the `render` method, but for now
+just know this is how we would grab ahold of the account to get the latest
+state.
 
 ## Make Payment Method
-Next let’s break down the main subject method for this tutorial, `./methods/makePayment.ts`:
+
+Next let’s break down the main subject method for this tutorial,
+`./methods/makePayment.ts`:
 
 <CodeExample>
 
 ```ts
-import sjcl from '@tinyanvil/sjcl'
+import sjcl from "@tinyanvil/sjcl";
 import {
   Keypair,
   Account,
@@ -504,93 +580,93 @@ import {
   BASE_FEE,
   Networks,
   Operation,
-  Asset
-} from 'stellar-sdk'
-import { has as loHas } from 'lodash-es'
+  Asset,
+} from "stellar-sdk";
+import { has as loHas } from "lodash-es";
 
-import { handleError } from '@services/error'
+import { handleError } from "@services/error";
 
 export default async function makePayment(e: Event) {
   try {
-    e.preventDefault()
+    e.preventDefault();
 
-    let instructions = await this.setPrompt('{Amount} {Destination}')
-        instructions = instructions.split(' ')
+    let instructions = await this.setPrompt("{Amount} {Destination}");
+    instructions = instructions.split(" ");
 
-    const pincode = await this.setPrompt('Enter your keystore pincode')
+    const pincode = await this.setPrompt("Enter your keystore pincode");
 
-    if (
-      !instructions
-      || !pincode
-    ) return
+    if (!instructions || !pincode) return;
 
     const keypair = Keypair.fromSecret(
-      sjcl.decrypt(pincode, this.account.keystore)
-    )
+      sjcl.decrypt(pincode, this.account.keystore),
+    );
 
-    this.error = null
-    this.loading = {...this.loading, pay: true}
+    this.error = null;
+    this.loading = { ...this.loading, pay: true };
 
     await this.server
-    .accounts()
-    .accountId(keypair.publicKey())
-    .call()
-    .then(({sequence}) => {
-      const account = new Account(keypair.publicKey(), sequence)
-      const transaction = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: Networks.TESTNET
-      })
-      .addOperation(Operation.payment({
-        destination: instructions[1],
-        asset: Asset.native(),
-        amount: instructions[0]
-      }))
-      .setTimeout(0)
-      .build()
-
-      transaction.sign(keypair)
-      return this.server.submitTransaction(transaction)
-      .catch((err) => {
-        if ( // Paying an account which doesn't exist, create it instead
-          loHas(err, 'response.data.extras.result_codes.operations')
-          && err.response.data.status === 400
-          && err.response.data.extras.result_codes.operations.indexOf('op_no_destination') !== -1
-        ) {
-          const transaction = new TransactionBuilder(account, {
-            fee: BASE_FEE,
-            networkPassphrase: Networks.TESTNET
-          })
-          .addOperation(Operation.createAccount({
-            destination: instructions[1],
-            startingBalance: instructions[0]
-          }))
+      .accounts()
+      .accountId(keypair.publicKey())
+      .call()
+      .then(({ sequence }) => {
+        const account = new Account(keypair.publicKey(), sequence);
+        const transaction = new TransactionBuilder(account, {
+          fee: BASE_FEE,
+          networkPassphrase: Networks.TESTNET,
+        })
+          .addOperation(
+            Operation.payment({
+              destination: instructions[1],
+              asset: Asset.native(),
+              amount: instructions[0],
+            }),
+          )
           .setTimeout(0)
-          .build()
+          .build();
 
-          transaction.sign(keypair)
-          return this.server.submitTransaction(transaction)
-        }
+        transaction.sign(keypair);
+        return this.server.submitTransaction(transaction).catch((err) => {
+          if (
+            // Paying an account which doesn't exist, create it instead
+            loHas(err, "response.data.extras.result_codes.operations") &&
+            err.response.data.status === 400 &&
+            err.response.data.extras.result_codes.operations.indexOf(
+              "op_no_destination",
+            ) !== -1
+          ) {
+            const transaction = new TransactionBuilder(account, {
+              fee: BASE_FEE,
+              networkPassphrase: Networks.TESTNET,
+            })
+              .addOperation(
+                Operation.createAccount({
+                  destination: instructions[1],
+                  startingBalance: instructions[0],
+                }),
+              )
+              .setTimeout(0)
+              .build();
 
-        else throw err
+            transaction.sign(keypair);
+            return this.server.submitTransaction(transaction);
+          } else throw err;
+        });
       })
-    })
-    .then((res) => console.log(res))
-    .finally(() => {
-      this.loading = {...this.loading, pay: false}
-      this.updateAccount()
-    })
-  }
-
-  catch (err) {
-    this.error = handleError(err)
+      .then((res) => console.log(res))
+      .finally(() => {
+        this.loading = { ...this.loading, pay: false };
+        this.updateAccount();
+      });
+  } catch (err) {
+    this.error = handleError(err);
   }
 }
 ```
 
 </CodeExample>
 
-This method is quite massive, so let’s break it down further so it's easier to understand exactly what is going on.
+This method is quite massive, so let’s break it down further so it's easier to
+understand exactly what is going on.
 
 <CodeExample>
 
@@ -612,22 +688,26 @@ export default async function makePayment(e: Event) {
 
 </CodeExample>
 
-We’re going to need a couple pieces of info from the user: the amount of XLM to send, what address to send it to, and the pincode for unlocking the keystore file. We request those asynchronously and cancel out of the method if they aren’t provided.
+We’re going to need a couple pieces of info from the user: the amount of XLM to
+send, what address to send it to, and the pincode for unlocking the keystore
+file. We request those asynchronously and cancel out of the method if they
+aren’t provided.
 
 <CodeExample>
 
 ```ts
-  const keypair = Keypair.fromSecret(
-    sjcl.decrypt(pincode, this.account.keystore)
-  )
+const keypair = Keypair.fromSecret(
+  sjcl.decrypt(pincode, this.account.keystore),
+);
 
-  this.error = null
-  this.loading = {...this.loading, pay: true}
+this.error = null;
+this.loading = { ...this.loading, pay: true };
 ```
 
 </CodeExample>
 
-Next we unpack the keystore with the pincode, reset any existing errors, and trigger the `pay` loading boolean:
+Next we unpack the keystore with the pincode, reset any existing errors, and
+trigger the `pay` loading boolean:
 
 <CodeExample>
 
@@ -656,7 +736,11 @@ Next we unpack the keystore with the pincode, reset any existing errors, and tri
 
 </CodeExample>
 
-From there we call the keypair account to retrieve its current sequence number so we can prepare a transaction with a payment operation. We set the destination and amount using the instructions from the prompt we collected and split earlier. Finally, we build, sign, and submit that transaction to the Stellar Horizon API server.
+From there we call the keypair account to retrieve its current sequence number
+so we can prepare a transaction with a payment operation. We set the destination
+and amount using the instructions from the prompt we collected and split
+earlier. Finally, we build, sign, and submit that transaction to the Stellar
+Horizon API server.
 
 <CodeExample>
 
@@ -688,7 +772,10 @@ From there we call the keypair account to retrieve its current sequence number s
 
 </CodeExample>
 
-If the account we want to send XLM is unfunded (and therefore doesn't yet exist on the ledger), we'll get back `op_no_destination`.  This `catch` handles that issue by trying again with a `createAccount` operation. For any other issues we just pass the error on unmodified.
+If the account we want to send XLM is unfunded (and therefore doesn't yet exist
+on the ledger), we'll get back `op_no_destination`. This `catch` handles that
+issue by trying again with a `createAccount` operation. For any other issues we
+just pass the error on unmodified.
 
 <CodeExample>
 
@@ -709,14 +796,16 @@ If the account we want to send XLM is unfunded (and therefore doesn't yet exist 
 
 </CodeExample>
 
-Finally, we log any success transaction, kill the loader, and `updateAccount` to reflect the new balance in our account after successfully sending XLM. We also have our `catch` block that passes to the `handleError` service.  We will render that in a nice error block in the UI.
+Finally, we log any success transaction, kill the loader, and `updateAccount` to
+reflect the new balance in our account after successfully sending XLM. We also
+have our `catch` block that passes to the `handleError` service. We will render
+that in a nice error block in the UI.
 
-There we go! That wasn’t so bad right? Pretty simple, and yet from this tutorial we have the power to hold and observe balances, and to make payments using the power of the Stellar ledger. Amazing!
+There we go! That wasn’t so bad right? Pretty simple, and yet from this tutorial
+we have the power to hold and observe balances, and to make payments using the
+power of the Stellar ledger. Amazing!
 
-
-[1]:	https://github.com/stellar/stellar-demo-wallet/tree/keystore
-[2]:	https://friendbot.stellar.org/
-[3]:	https://github.com/stellar/stellar-demo-wallet/tree/pay
-
-
-[image-1]:	https://tyler.link/pM4Z2R+
+[1]: https://github.com/stellar/stellar-demo-wallet/tree/keystore
+[2]: https://friendbot.stellar.org/
+[3]: https://github.com/stellar/stellar-demo-wallet/tree/pay
+[image-1]: https://tyler.link/pM4Z2R+

--- a/content/docs/enabling-deposit-and-withdrawal/index.mdx
+++ b/content/docs/enabling-deposit-and-withdrawal/index.mdx
@@ -3,41 +3,95 @@ title: Overview
 order: 10
 ---
 
-One of the main use cases for Stellar is the tokenization of fiat currency to optimize processes like cross-border payments, and this section of the docs details the technical and operational steps necessary to set up a service that does that.  
+One of the main use cases for Stellar is the tokenization of fiat currency to
+optimize processes like cross-border payments, and this section of the docs
+details the technical and operational steps necessary to set up a service that
+does that.
 
-This section doesn't cover the basic steps for issuing an asset on the network — you can find those [here](../issuing-assets/index.mdx) — rather, it explains how developers can *connect* the Stellar Network to their country's banking system and regulatory processes such as [KYC](https://en.wikipedia.org/wiki/Know_your_customer) and [AML](https://en.wikipedia.org/wiki/Money_laundering#Anti-money_laundering) by setting up a webapp and specific endpoints that allow users to make deposits and withdrawals.  It will walk through the flow, features, and protocol specifications for integrating with wallets and other clients, and offer examples and tools to make the process easier to implement and test.  
+This section doesn't cover the basic steps for issuing an asset on the network —
+you can find those [here](../issuing-assets/index.mdx) — rather, it explains how
+developers can _connect_ the Stellar Network to their country's banking system
+and regulatory processes such as
+[KYC](https://en.wikipedia.org/wiki/Know_your_customer) and
+[AML](https://en.wikipedia.org/wiki/Money_laundering#Anti-money_laundering) by
+setting up a webapp and specific endpoints that allow users to make deposits and
+withdrawals. It will walk through the flow, features, and protocol
+specifications for integrating with wallets and other clients, and offer
+examples and tools to make the process easier to implement and test.
 
-We will go over SDF's [Reference Implementations](./reference-implementations.mdx) and all three stages of the development process:
+We will go over SDF's
+[Reference Implementations](./reference-implementations.mdx) and all three
+stages of the development process:
 
 1. [Setting up a test server](./setting-up-test-server.mdx)
 1. [Setting up a production server](./setting-up-production-server.mdx)
 1. [Launch](./launch.mdx)
 
-
-
 ## The basic customer flow
 
-*Stellar Anchors* are the on/off ramps of the Stellar network: they accept deposits of fiat currencies (such USD, CNY, and BRL) via existing rails (such as bank deposits or cash-in points), and send a user the  equivalent digital tokens representing those deposits on the Stellar network.  On the flipside, they allow holders to redeem those tokens for the real-world assets they represent.  To read more about the kinds of things you can do with digital fiat currency, check out [this explainer](https://www.stellar.org/learn/the-power-of-stellar).
+_Stellar Anchors_ are the on/off ramps of the Stellar network: they accept
+deposits of fiat currencies (such USD, CNY, and BRL) via existing rails (such as
+bank deposits or cash-in points), and send a user the equivalent digital tokens
+representing those deposits on the Stellar network. On the flipside, they allow
+holders to redeem those tokens for the real-world assets they represent. To read
+more about the kinds of things you can do with digital fiat currency, check out
+[this explainer](https://www.stellar.org/learn/the-power-of-stellar).
 
-Stellar Anchors can issue their own assets (in which case, they earn the title *Issuing Anchors*), or they can honor assets that already exist on the network.  So if you want to build an on/off ramp for Stellar, you can consult the [Issue Assets](../issuing-assets/index.mdx) section and issue your own token to offer customers *or* you can find another organization that issues a Stellar-network asset and arrange to broker their token.   
+Stellar Anchors can issue their own assets (in which case, they earn the title
+_Issuing Anchors_), or they can honor assets that already exist on the network.
+So if you want to build an on/off ramp for Stellar, you can consult the
+[Issue Assets](../issuing-assets/index.mdx) section and issue your own token to
+offer customers _or_ you can find another organization that issues a
+Stellar-network asset and arrange to broker their token.
 
 The complete customer flow from deposit to withdrawal goes something like this:
 
 1. Customer goes through KYC
 1. Deposits real fiat currency (e.g. sends a bank transfer)
-1. Receives the digital asset on the Stellar network from the asset distributer and/or issuer
-1. Uses the digital asset on the Stellar network (for remittance, payments, trading, store of value, etc)
-1. Redeems the digital asset by returning it to the issuer on the Stellar network
-1. Receives real fiat currency in return (e.g. receives a bank transfer) 
+1. Receives the digital asset on the Stellar network from the asset distributer
+   and/or issuer
+1. Uses the digital asset on the Stellar network (for remittance, payments,
+   trading, store of value, etc)
+1. Redeems the digital asset by returning it to the issuer on the Stellar
+   network
+1. Receives real fiat currency in return (e.g. receives a bank transfer)
 
 ## Interoperability and Stellar Ecosystem Proposals
 
-Since customers generally use wallets to hold their Stellar tokens, and since there are a lot of wallets to choose from, a crucial step in enabling that customer flow and making a fiat-backed token widely accessible is to set up infrastructure that enables wallets to offer in-app deposits and withdrawals, and to follow best practices when doing to allow any wallet to easily find and interact with it.
+Since customers generally use wallets to hold their Stellar tokens, and since
+there are a lot of wallets to choose from, a crucial step in enabling that
+customer flow and making a fiat-backed token widely accessible is to set up
+infrastructure that enables wallets to offer in-app deposits and withdrawals,
+and to follow best practices when doing to allow any wallet to easily find and
+interact with it.
 
-Those best practices are specified in Stellar Ecosystem Proposals (SEPs), which are publicly created, open-source documents that live in a [Github repository](https://github.com/stellar/stellar-protocol/tree/master/ecosystem#stellar-ecosystem-proposals-seps).  They define how different institutions (such as asset issuers, wallets, exchanges, and service providers) should interact and interoperate. 
+Those best practices are specified in Stellar Ecosystem Proposals (SEPs), which
+are publicly created, open-source documents that live in a
+[Github repository](https://github.com/stellar/stellar-protocol/tree/master/ecosystem#stellar-ecosystem-proposals-seps).
+They define how different institutions (such as asset issuers, wallets,
+exchanges, and service providers) should interact and interoperate.
 
-There are many use cases covered by the existing SEPs — including regulated assets ([SEP-8](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md)) and federated user identification ([SEP-2](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0002.md)) — and new SEPs are proposed and discussed on Github all the time.  We encourage you to participate in those discussions and help build new standards that will make the financial services easier and more accessible.
+There are many use cases covered by the existing SEPs — including regulated
+assets
+([SEP-8](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md))
+and federated user identification
+([SEP-2](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0002.md))
+— and new SEPs are proposed and discussed on Github all the time. We encourage
+you to participate in those discussions and help build new standards that will
+make the financial services easier and more accessible.
 
-This guide will focus on the **Interactive Anchor/Wallet Asset Transfer Server** SEP (aka [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md)), since it defines the specs for deposit and withdrawal implementations. SEP-24 is focused on *interactive user flows*, meaning flows where users interact with an Anchor-hosted interface rendered inside a wallet. 
+This guide will focus on the **Interactive Anchor/Wallet Asset Transfer Server**
+SEP (aka
+[SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md)),
+since it defines the specs for deposit and withdrawal implementations. SEP-24 is
+focused on _interactive user flows_, meaning flows where users interact with an
+Anchor-hosted interface rendered inside a wallet.
 
-To enable an interactive flow, fiat-backed Anchors (aka on/off ramps) should implement two SEPs in addition to SEP-24: [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md), which links meta-information to organizations and assets (and which we go over in detail in [this guide](../issuing-assets/publishing-asset-info.mdx)), and [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md), which creates authenticated user session.  In this guide, we'll walk through setting up all that infrastructure on both the testnet and the public network.
+To enable an interactive flow, fiat-backed Anchors (aka on/off ramps) should
+implement two SEPs in addition to SEP-24:
+[SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md),
+which links meta-information to organizations and assets (and which we go over
+in detail in [this guide](../issuing-assets/publishing-asset-info.mdx)), and
+[SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md),
+which creates authenticated user session. In this guide, we'll walk through
+setting up all that infrastructure on both the testnet and the public network.

--- a/content/docs/enabling-deposit-and-withdrawal/launch.mdx
+++ b/content/docs/enabling-deposit-and-withdrawal/launch.mdx
@@ -3,54 +3,116 @@ title: Launch
 order: 50
 ---
 
-Once the testnet and mainnet servers are deployed, KYC collection conforms to regulations, banking rails are integrated, and the whole system is audited, it's time to prepare for launch.
+Once the testnet and mainnet servers are deployed, KYC collection conforms to
+regulations, banking rails are integrated, and the whole system is audited, it's
+time to prepare for launch.
 
 ## Polishing and Internationalization
 
-Supporting two languages (English and the fiat currency country language) allows users to have a seamless experience while navigating through screens, and supports international institutions (like wallets) that need to test the product before starting new integrations. 
+Supporting two languages (English and the fiat currency country language) allows
+users to have a seamless experience while navigating through screens, and
+supports international institutions (like wallets) that need to test the product
+before starting new integrations.
 
-You can support multiple languages in your webapp by using the `Accept-Language` parameter from the http request headers to localize the content and allowing users to change that in a simple way (e.g. a flag icon on the top bar). If a specific wallet doesn't send the header parameter, we recommend showing the user a language selection screen in the beginning of the deposit and withdraw processes. Once a user chooses a language, you can store their selection so you only need to ask them once. In addition to localizing text, make sure to check number formatting, dates, etc.
+You can support multiple languages in your webapp by using the `Accept-Language`
+parameter from the http request headers to localize the content and allowing
+users to change that in a simple way (e.g. a flag icon on the top bar). If a
+specific wallet doesn't send the header parameter, we recommend showing the user
+a language selection screen in the beginning of the deposit and withdraw
+processes. Once a user chooses a language, you can store their selection so you
+only need to ask them once. In addition to localizing text, make sure to check
+number formatting, dates, etc.
 
-Having a group of beta testers is a great way to check if there are any edge cases that need polishing, and to confirm that the system is working well with a variety of user inputs. You can beta test using a soft launch stage before you start putting effort into marketing and distribution. Documenting the testing process with screenshots and videos is very helpful for future security audits, and gives new partners and potential users clarity and confidence in the product.
+Having a group of beta testers is a great way to check if there are any edge
+cases that need polishing, and to confirm that the system is working well with a
+variety of user inputs. You can beta test using a soft launch stage before you
+start putting effort into marketing and distribution. Documenting the testing
+process with screenshots and videos is very helpful for future security audits,
+and gives new partners and potential users clarity and confidence in the
+product.
 
 ## Market Making
 
-Once your asset is available for in - app deposit and withdrawal, its order book will start to fill up with user buy and sell orders. To make sure these orders have liquidity — in other words, to make sure people can actually buy and sell your asset if and when they want to—it's essential to have a healthy market with a small spread and a deep set of orders on both sides.
+Once your asset is available for in - app deposit and withdrawal, its order book
+will start to fill up with user buy and sell orders. To make sure these orders
+have liquidity — in other words, to make sure people can actually buy and sell
+your asset if and when they want to—it's essential to have a healthy market with
+a small spread and a deep set of orders on both sides.
 
-SDF maintains a trading bot called [Kelp](https://kelpbot.io/) that supports many trading and market making strategies out of the box, all of which are described in [Kelp's Github Repo](https://github.com/stellar/kelp#kelp). You can use Kelp for free and start automating the order placement process in a matter of minutes.
+SDF maintains a trading bot called [Kelp](https://kelpbot.io/) that supports
+many trading and market making strategies out of the box, all of which are
+described in [Kelp's Github Repo](https://github.com/stellar/kelp#kelp). You can
+use Kelp for free and start automating the order placement process in a matter
+of minutes.
 
-Once the order placement is automatic, you should track the health of your token's market with these two parameters:
-* Bid/Ask Amounts: Both sides of the order book should have at least 25k USD
-* Spread Size: The average price of the bids and asks should be within 4% of each other.
+Once the order placement is automatic, you should track the health of your
+token's market with these two parameters:
 
-The 25k USD value is relative to a new anchor that is still developing its business. Once the volume of traded assets (and the total supply) grows, this value should be increased.
+- Bid/Ask Amounts: Both sides of the order book should have at least 25k USD
+- Spread Size: The average price of the bids and asks should be within 4% of
+  each other.
+
+The 25k USD value is relative to a new anchor that is still developing its
+business. Once the volume of traded assets (and the total supply) grows, this
+value should be increased.
 
 ## Creating an Anchor Website
 
-A website allows wallets and consumers to find information about your team and your business, get in contact with questions and feedback, and understand how your service works.  Your issuing account should link to that website so there's a clear connection between the Stellar asset and the URL. To do that, usee the `set options`, and choose the URL as the home domain.  You can find more information about how that process works [in our guide to publishing asset information](../issuing-assets/publishing-asset-info.mdx).
+A website allows wallets and consumers to find information about your team and
+your business, get in contact with questions and feedback, and understand how
+your service works. Your issuing account should link to that website so there's
+a clear connection between the Stellar asset and the URL. To do that, usee the
+`set options`, and choose the URL as the home domain. You can find more
+information about how that process works
+[in our guide to publishing asset information](../issuing-assets/publishing-asset-info.mdx).
 
-Here is a list of requirements to make sure users have a great experience navigating through your website:
+Here is a list of requirements to make sure users have a great experience
+navigating through your website:
 
 ### Branding Visuals
 
-Users should feel that they are in the company's domain based on the branding of the webpage. The brand universe can include many aspects, such as: company logo or symbol, slogan, colors, fonts, icons, etc...
+Users should feel that they are in the company's domain based on the branding of
+the webpage. The brand universe can include many aspects, such as: company logo
+or symbol, slogan, colors, fonts, icons, etc...
 
 ### Company Description
 
-Users want to know who you are and what you do before they'll trust your service or hold your asset.  Your website should describe your  business, clarify your mission, and outline your vision.  Giving more information about your company's executive team, or about your team in general, is a great way to increase users' confidence, and conversions.
+Users want to know who you are and what you do before they'll trust your service
+or hold your asset. Your website should describe your business, clarify your
+mission, and outline your vision. Giving more information about your company's
+executive team, or about your team in general, is a great way to increase users'
+confidence, and conversions.
 
-Describing how are you integrated with the Stellar Network (and with which wallets) is also a great way to show users that the system is reliable, and that it conforms to the best protocols and practices of the financial industry.
+Describing how are you integrated with the Stellar Network (and with which
+wallets) is also a great way to show users that the system is reliable, and that
+it conforms to the best protocols and practices of the financial industry.
 
-Finally, make sure to describe what your asset represents, how it's backed (e.g. it's 1:1 with a fiat reserve), how users can redeem it, and who can use it (anyone, just for retail, etc).
+Finally, make sure to describe what your asset represents, how it's backed (e.g.
+it's 1:1 with a fiat reserve), how users can redeem it, and who can use it
+(anyone, just for retail, etc).
 
 ### Customer Support
 
-Your webpage is also where users will go to report problems and reach out with questions and feedback. Make sure you clearly describe the process for contacting you, and for reporting bugs, and have a plan in place to offer necessary support.Adding a FAQ section once is a great way to defray support tickets and get information to users faster.
+Your webpage is also where users will go to report problems and reach out with
+questions and feedback. Make sure you clearly describe the process for
+contacting you, and for reporting bugs, and have a plan in place to offer
+necessary support.Adding a FAQ section once is a great way to defray support
+tickets and get information to users faster.
 
-You should also have a contact email so customers can get in touch, report inconsistencies, and open tickets.  Once you get those tickets, you need to answer them in a reasonable amount of time.
+You should also have a contact email so customers can get in touch, report
+inconsistencies, and open tickets. Once you get those tickets, you need to
+answer them in a reasonable amount of time.
 
 ## Connecting to Wallets
 
-All Anchor user interactions are done through a Wallet (or Exchange), so it's vital for Anchors to be connected to Wallets that have a good market penetration in the region where the business is most focused. Connecting to Wallets is a simple process, since both ends of that integration are already compliant with SEPs. 
+All Anchor user interactions are done through a Wallet (or Exchange), so it's
+vital for Anchors to be connected to Wallets that have a good market penetration
+in the region where the business is most focused. Connecting to Wallets is a
+simple process, since both ends of that integration are already compliant with
+SEPs.
 
-Stellar.org maintains a [list of wallets](https://www.stellar.org/ecosystem/projects), many of which currently support SEP-24  Sending them a message with more information on an asset and an issuer account is a great way to start getting some real users to the Anchor.
+Stellar.org maintains a
+[list of wallets](https://www.stellar.org/ecosystem/projects), many of which
+currently support SEP-24 Sending them a message with more information on an
+asset and an issuer account is a great way to start getting some real users to
+the Anchor.

--- a/content/docs/enabling-deposit-and-withdrawal/reference-implementations.mdx
+++ b/content/docs/enabling-deposit-and-withdrawal/reference-implementations.mdx
@@ -3,33 +3,76 @@ title: Reference Implementations
 order: 20
 ---
 
-These docs walk through the steps necessary to set up and launch both a test server and a production server to handle deposits and withdrawals, but before you get any deeper, it's worth noting: you don't have to start from scratch.  SDF offers some tools that make it easy to implement those servers, and test them from the client side.   
+These docs walk through the steps necessary to set up and launch both a test
+server and a production server to handle deposits and withdrawals, but before
+you get any deeper, it's worth noting: you don't have to start from scratch. SDF
+offers some tools that make it easy to implement those servers, and test them
+from the client side.
 
 ## Anchor Server Reference Implementation
 
-To help with server setup, SDF created [Polaris](https://github.com/stellar/django-polaris), an extendable django reusable-app that comes with fully-implemented endpoints, templates, and database models. It's built in Python using the community-supported [Stellar Python SDK](https://github.com/StellarCN/py-stellar-base), and is compliant with the Stellar Ecosystem Protocols mentioned in the previous section.
- 
+To help with server setup, SDF created
+[Polaris](https://github.com/stellar/django-polaris), an extendable django
+reusable-app that comes with fully-implemented endpoints, templates, and
+database models. It's built in Python using the community-supported
+[Stellar Python SDK](https://github.com/StellarCN/py-stellar-base), and is
+compliant with the Stellar Ecosystem Protocols mentioned in the previous
+section.
+
 **Image 1: Screenshots of the reference implementation**
 
-Polaris modularizes the parts of the codebase that interface with the Stellar network, and provides clear methods for developers to integrate their own deposit and withdrawal forms, KYC process, and banking rails connections. That means you can focus on implementing the business- and country-related aspects of your product without having to spend much time defining how to connect the server to the Stellar Network.
+Polaris modularizes the parts of the codebase that interface with the Stellar
+network, and provides clear methods for developers to integrate their own
+deposit and withdrawal forms, KYC process, and banking rails connections. That
+means you can focus on implementing the business- and country-related aspects of
+your product without having to spend much time defining how to connect the
+server to the Stellar Network.
 
-If you choose to use Polaris, you can jumpstart your deployment, and connect local rails to Stellar in weeks instead of months. 
+If you choose to use Polaris, you can jumpstart your deployment, and connect
+local rails to Stellar in weeks instead of months.
 
 ## Demo Client & Deployed Example
 
-Once you have a server set up, SDF also maintains a [Demo Client Project](https://github.com/stellar/sep24-demo-client) that makes it easy to test your implementation on both the testnet and the pubnet. 
+Once you have a server set up, SDF also maintains a
+[Demo Client Project](https://github.com/stellar/sep24-demo-client) that makes
+it easy to test your implementation on both the testnet and the pubnet.
 
-We've even deployed a [Deployed Demo Client](https://sep24.stellar.org/), which allows you to run those tests with a UI without needing to set up a new hosting infrastructure for that project.
+We've even deployed a [Deployed Demo Client](https://sep24.stellar.org/), which
+allows you to run those tests with a UI without needing to set up a new hosting
+infrastructure for that project.
 
 **Image 2: Screenshots of the demo client**
 
-With the demo client, you can test your deposit and withdraw flows, and get information about the transactions that are created during those processes. It gives a clear step-by-step visual example of how the functionalities work along with insightful information about the requests, protocols, and possible validation messages.  To start testing the deploys, simply update the settings of the Demo Client (click the gear button on the bottom right) to include your project's information.
+With the demo client, you can test your deposit and withdraw flows, and get
+information about the transactions that are created during those processes. It
+gives a clear step-by-step visual example of how the functionalities work along
+with insightful information about the requests, protocols, and possible
+validation messages. To start testing the deploys, simply update the settings of
+the Demo Client (click the gear button on the bottom right) to include your
+project's information.
 
 ## Anchor Validation Suite
-The SEP-24 Anchor Validation Suite is a set of tests that helps confirming if your anchor implementation is compliant with the latest specifications of the SEP-24 standard. This is a great resource for people that are getting started building an anchor and want to check what's still missing in their implementation, or for teams that have already finalized the anchor development and want an extra validation on the codebase. Also, the Anchor Validation Suite doesn't replace the necessity of having a professional security auditor reviewing the whole project.
+
+The SEP-24 Anchor Validation Suite is a set of tests that helps confirming if
+your anchor implementation is compliant with the latest specifications of the
+SEP-24 standard. This is a great resource for people that are getting started
+building an anchor and want to check what's still missing in their
+implementation, or for teams that have already finalized the anchor development
+and want an extra validation on the codebase. Also, the Anchor Validation Suite
+doesn't replace the necessity of having a professional security auditor
+reviewing the whole project.
 
 **Image 3: of the Anchor Validation Suite's UI**
 
-The SEP-24 Anchor Validation Suite codebase is available in an open-sourced [Github Repository](https://github.com/stellar/transfer-server-validator/), where you can check in details exactly how all tests work. SDF also maintains a [deployed version of the Validation Suite](http://anchor-validator.stellar.org/) with a UI for running the tests without the need to setup your own infrastructure.
-In order to also test the interactive parts of SEP-24, you'll need to add test values to all the required interactive flow fields. The [Github Repository Readme file](https://github.com/stellar/transfer-server-validator/#providing-field-values) has more information on how exactly those fields need to be added.
-Finally, you can also trigger the tests directly from a Continuous Integration tool (like CircleCI or Jenkins), in order to have continuous monitoring of your anchor infrastructure.
+The SEP-24 Anchor Validation Suite codebase is available in an open-sourced
+[Github Repository](https://github.com/stellar/transfer-server-validator/),
+where you can check in details exactly how all tests work. SDF also maintains a
+[deployed version of the Validation Suite](http://anchor-validator.stellar.org/)
+with a UI for running the tests without the need to setup your own
+infrastructure. In order to also test the interactive parts of SEP-24, you'll
+need to add test values to all the required interactive flow fields. The
+[Github Repository Readme file](https://github.com/stellar/transfer-server-validator/#providing-field-values)
+has more information on how exactly those fields need to be added. Finally, you
+can also trigger the tests directly from a Continuous Integration tool (like
+CircleCI or Jenkins), in order to have continuous monitoring of your anchor
+infrastructure.

--- a/content/docs/enabling-deposit-and-withdrawal/setting-up-production-server.mdx
+++ b/content/docs/enabling-deposit-and-withdrawal/setting-up-production-server.mdx
@@ -3,91 +3,199 @@ title: Set Up a Production Server
 order: 40
 ---
 
-Once the test server is live and you have tested both deposit and withdraw flows, it's time to get started with the real deploy connected to real KYC and real banking rails providers. Before using any banking APIs, it's critical that you perform a full security audit on the system to make sure that there aren't any vulnerabilities.
+Once the test server is live and you have tested both deposit and withdraw
+flows, it's time to get started with the real deploy connected to real KYC and
+real banking rails providers. Before using any banking APIs, it's critical that
+you perform a full security audit on the system to make sure that there aren't
+any vulnerabilities.
 
 ## Deploying a Secure Environment
 
-Make sure to keep the test server up, and deploy the production (mainnet) system in a separate environment. Having two deploys allows you to validate new features on the testnet before moving them to the final production deploy. You can also have a third staging environment if there's a big team working on this codebase and/or there will be many pushes to be tested internally before sharing with other institutions.
+Make sure to keep the test server up, and deploy the production (mainnet) system
+in a separate environment. Having two deploys allows you to validate new
+features on the testnet before moving them to the final production deploy. You
+can also have a third staging environment if there's a big team working on this
+codebase and/or there will be many pushes to be tested internally before sharing
+with other institutions.
 
-To switch to Stellar's public (mainnet) network, all you have to do is change the network [passphrase](../glossary/network-passphrase.mdx) (for authenticating requests) and [Horizon URL](https://horizon.stellar.org/). Stellar SDKs have all the built-in logic to switch from test to public with minor changes to the codebase.
+To switch to Stellar's public (mainnet) network, all you have to do is change
+the network [passphrase](../glossary/network-passphrase.mdx) (for authenticating
+requests) and [Horizon URL](https://horizon.stellar.org/). Stellar SDKs have all
+the built-in logic to switch from test to public with minor changes to the
+codebase.
 
-If you're issuing your own asset in addition of offering an on/off ramp, make sure you follow [best practices for asset issuance](../issuing-assets/how-to-issue-an-asset.mdx) by creating a distribution account that is separate from the issuing account before distributing real assets on the public network. The issuing account secret key should be highly secured via means such as cold storage or multi-signature, and should only be used to send (and, consequently, issue) assets to the distribution account. The distribution account will be used by your server to send (and receive) assets to other accounts programmatically.
+If you're issuing your own asset in addition of offering an on/off ramp, make
+sure you follow
+[best practices for asset issuance](../issuing-assets/how-to-issue-an-asset.mdx)
+by creating a distribution account that is separate from the issuing account
+before distributing real assets on the public network. The issuing account
+secret key should be highly secured via means such as cold storage or
+multi-signature, and should only be used to send (and, consequently, issue)
+assets to the distribution account. The distribution account will be used by
+your server to send (and receive) assets to other accounts programmatically.
 
-Since the distribution account will be managed programmatically, it should only have a balance necessary to keep operations running for a short period of time. The issuing account should send small amounts of an asset to the distribution account frequently to represent the expected deposit volume for a given period. You should set up the transfer from the issuing account to the distribution account once day (or once a week week) to make sure the distribution account only has the minimum necessary balance to keep the operation functional in that short period.
+Since the distribution account will be managed programmatically, it should only
+have a balance necessary to keep operations running for a short period of time.
+The issuing account should send small amounts of an asset to the distribution
+account frequently to represent the expected deposit volume for a given period.
+You should set up the transfer from the issuing account to the distribution
+account once day (or once a week week) to make sure the distribution account
+only has the minimum necessary balance to keep the operation functional in that
+short period.
 
 ## Connecting to Real KYC
 
-Most anchors need to collect  [Know Your Customer](https://en.wikipedia.org/wiki/Know_your_customer) information to comply with local regulations before honoring deposits and withdrawals. The KYC flow usually consists of a simple form that gathers relevant information about the user such as name, email, address, age, and government-issued ID number.
+Most anchors need to collect
+[Know Your Customer](https://en.wikipedia.org/wiki/Know_your_customer)
+information to comply with local regulations before honoring deposits and
+withdrawals. The KYC flow usually consists of a simple form that gathers
+relevant information about the user such as name, email, address, age, and
+government-issued ID number.
 
-How you handle KYC is up to you: there are many services that provide KYC solutions through APIs and iFrames, and validate the input data and sync with governmental databases to verify requirements. Each jurisdiction has specific KYC requirements, and they differ from jurisdiction to jurisdiction, so it's best to find a country-specific KYC provider that meets your needs.
+How you handle KYC is up to you: there are many services that provide KYC
+solutions through APIs and iFrames, and validate the input data and sync with
+governmental databases to verify requirements. Each jurisdiction has specific
+KYC requirements, and they differ from jurisdiction to jurisdiction, so it's
+best to find a country-specific KYC provider that meets your needs.
 
-Some countries require different KYC fields depending on the amount to be deposited or withdrawn. If that's the case in your jurisdiction and you need to adapt your KYC forms based on the deposit or withdrawal amount, simply add an amount field before the KYC form, and make sure that the KYC fields are updated based on that value.
+Some countries require different KYC fields depending on the amount to be
+deposited or withdrawn. If that's the case in your jurisdiction and you need to
+adapt your KYC forms based on the deposit or withdrawal amount, simply add an
+amount field before the KYC form, and make sure that the KYC fields are updated
+based on that value.
 
-KYC information should be linked to the session created through [Stellar Web Authentication](./setting-up-test-server.mdx#authentication) and, consequently, to the user, so you only need to ask the user for it once. After the first KYC flow is complete, a user shouldn't have to input the information again.
+KYC information should be linked to the session created through
+[Stellar Web Authentication](./setting-up-test-server.mdx#authentication) and,
+consequently, to the user, so you only need to ask the user for it once. After
+the first KYC flow is complete, a user shouldn't have to input the information
+again.
 
-Make sure the errors and validation messages are clear and include instructions for what to do next to ensure a good user experience and increase the KYC conversion rate. You should also localize messages based on the user's language and location.
+Make sure the errors and validation messages are clear and include instructions
+for what to do next to ensure a good user experience and increase the KYC
+conversion rate. You should also localize messages based on the user's language
+and location.
 
 ## Pre-Filling the KYC Form
 
-Pre-filling the KYC form is a great way to reduce the friction of getting started using an anchor, and wallets usually provide a set of fields that are commonly used throughout the ecosystem. In summary, the anchor can render the KYC form with the user's values that were previously sent by the wallet in the /transactions/deposit/interactive and /transactions/withdraw/interactive endpoints.
-All fields from [SEP-9](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md) can be sent by wallets in the previously mentioned endpoints, but the most common are: email, first name, last name and phone number. Also, you should still enable the pre-filled fields to be editable, since the user might have inputted a different name in the Wallet's sign-up process, and could want to edit it before finalizing the Anchor's KYC process.
-
+Pre-filling the KYC form is a great way to reduce the friction of getting
+started using an anchor, and wallets usually provide a set of fields that are
+commonly used throughout the ecosystem. In summary, the anchor can render the
+KYC form with the user's values that were previously sent by the wallet in the
+/transactions/deposit/interactive and /transactions/withdraw/interactive
+endpoints. All fields from
+[SEP-9](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md)
+can be sent by wallets in the previously mentioned endpoints, but the most
+common are: email, first name, last name and phone number. Also, you should
+still enable the pre-filled fields to be editable, since the user might have
+inputted a different name in the Wallet's sign-up process, and could want to
+edit it before finalizing the Anchor's KYC process.
 
 ## Connecting to Real Banking Rails
 
-Fiat-backed token issuers are expected to manage a full reserve.  That means there's a 1:1 relationship between Stellar-network tokens and money in the bank.  Since each fiat token on Stellar is backed by, and can be redeemed for, an underlying, real-world asset, issuers of fiat-backed tokens need to connect to real banking rails to validate user deposits (through bank transfers, credit card payments, etc.) and to complete user withdrawals (generally through bank transfers).  If you're an anchor honoring deposits and withdrawals of a token another organization issues, you'll follow a similar process.
+Fiat-backed token issuers are expected to manage a full reserve. That means
+there's a 1:1 relationship between Stellar-network tokens and money in the bank.
+Since each fiat token on Stellar is backed by, and can be redeemed for, an
+underlying, real-world asset, issuers of fiat-backed tokens need to connect to
+real banking rails to validate user deposits (through bank transfers, credit
+card payments, etc.) and to complete user withdrawals (generally through bank
+transfers). If you're an anchor honoring deposits and withdrawals of a token
+another organization issues, you'll follow a similar process.
 
-In order to fetch (and identify) a user transfer, issuers usually take one of two approaches:
+In order to fetch (and identify) a user transfer, issuers usually take one of
+two approaches:
 
-* API Polling: this option consists of fetching the bank's API, through a cron job, to check for the updated status of the list of transfers received by (and sent from) the issuer's bank account. Once the system confirms a new transaction and identifies that it relates to a specific deposit, it can send the digital funds to that user's account
-* Webhook: not all banking rails support this option, but it's the leanest in terms of back-end logic. In this approach, the bank proactively hits an issuer's endpoint once it receives a new transfer, updating that information on the issuer's database. The issuer can then can match that transaction to an existing in-process deposit, and validate that the user can receive their digital funds
+- API Polling: this option consists of fetching the bank's API, through a cron
+  job, to check for the updated status of the list of transfers received by (and
+  sent from) the issuer's bank account. Once the system confirms a new
+  transaction and identifies that it relates to a specific deposit, it can send
+  the digital funds to that user's account
+- Webhook: not all banking rails support this option, but it's the leanest in
+  terms of back-end logic. In this approach, the bank proactively hits an
+  issuer's endpoint once it receives a new transfer, updating that information
+  on the issuer's database. The issuer can then can match that transaction to an
+  existing in-process deposit, and validate that the user can receive their
+  digital funds
 
-There are many ways to identify that a specific bank transfer relates to a specific deposit (and, consequently, to a user). Some banks (and countries) have transfer infrastructure that allows the creation of a single bank account per transfer; others require users to add an identification parameter to their transfers.  Some banks provide the user ID number in the transaction information so issuers can match that with the information provided in the KYC form.
+There are many ways to identify that a specific bank transfer relates to a
+specific deposit (and, consequently, to a user). Some banks (and countries) have
+transfer infrastructure that allows the creation of a single bank account per
+transfer; others require users to add an identification parameter to their
+transfers. Some banks provide the user ID number in the transaction information
+so issuers can match that with the information provided in the KYC form.
 
-Make sure to do a full security audit on your systems when banking rails connections are in place. Some banks provide a testing API that can be used for development and deployment to testnet or staging environments, which means you can test and audit the codebase before moving to a final production-ready bank integration. For better security, some anchors also prefer to add a manual final step before approving withdrawal transfers. In terms of UX, this manual approval is acceptable as long as the wait times align with user expectations, which usually means they aren't longer than a couple of hours. 
+Make sure to do a full security audit on your systems when banking rails
+connections are in place. Some banks provide a testing API that can be used for
+development and deployment to testnet or staging environments, which means you
+can test and audit the codebase before moving to a final production-ready bank
+integration. For better security, some anchors also prefer to add a manual final
+step before approving withdrawal transfers. In terms of UX, this manual approval
+is acceptable as long as the wait times align with user expectations, which
+usually means they aren't longer than a couple of hours.
 
 ## Testing Edge Cases
 
-Once your application is fully functional, it's a good idea to test different scenarios and edge cases to make sure the system is behaving as expected. Here's a list of testing suggestions that should cover a large amount of the application's edge cases:
+Once your application is fully functional, it's a good idea to test different
+scenarios and edge cases to make sure the system is behaving as expected. Here's
+a list of testing suggestions that should cover a large amount of the
+application's edge cases:
 
 ### General Tests
 
-* Check to make sure the interactive interface follows our [UX Guidelines](https://github.com/stellar/anchor-ux-guidelines)
-* Test the interactive flow usability on really small and really large screens
-* Check that the issuing account is set up with the correct home domain, and that the website on that home domain has branding visuals, content about your company, clear language telling users how to report problems, and a method for contacting you to seek support.
-* Test the interface using different locale information, and check for translated content including error messages, responses, date formatting, and number formatting
+- Check to make sure the interactive interface follows our
+  [UX Guidelines](https://github.com/stellar/anchor-ux-guidelines)
+- Test the interactive flow usability on really small and really large screens
+- Check that the issuing account is set up with the correct home domain, and
+  that the website on that home domain has branding visuals, content about your
+  company, clear language telling users how to report problems, and a method for
+  contacting you to seek support.
+- Test the interface using different locale information, and check for
+  translated content including error messages, responses, date formatting, and
+  number formatting
 
 ### KYC Tests
 
-* Check that KYC appears with a new wallet SK
-* Check that KYC (and email, if it's being used to identify users) is not appearing when using a previous wallet SK
-* Check that KYC doesn't accept incorrectly formatted inputs, and that the error messages are comprehensible
-* Check that you can use the same KYC information (email, phone number, username, etc) multiple times
-* Check that you can go through KYC multiple times with the same Stellar SK.
+- Check that KYC appears with a new wallet SK
+- Check that KYC (and email, if it's being used to identify users) is not
+  appearing when using a previous wallet SK
+- Check that KYC doesn't accept incorrectly formatted inputs, and that the error
+  messages are comprehensible
+- Check that you can use the same KYC information (email, phone number,
+  username, etc) multiple times
+- Check that you can go through KYC multiple times with the same Stellar SK.
 
 ### Deposit Test
 
-* Check that deposits are disabled for really small and really large values
-* Check that the deposit flow goes through, and that the banking rails are working
-* Check that the endpoint returns an error if the JWT token is missing
-* Check that all deposit response params conform to [protocols](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#deposit)
+- Check that deposits are disabled for really small and really large values
+- Check that the deposit flow goes through, and that the banking rails are
+  working
+- Check that the endpoint returns an error if the JWT token is missing
+- Check that all deposit response params conform to
+  [protocols](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#deposit)
 
 ### Withdraw Tests
 
-* Check that withdrawals are disabled for really small and really large values
-* Check that you cannot make a withdrawal with a value higher than the current balance
-* Check that the withdraw flow goes through, and that the banking rails are working
-* Check that  the endpoint returns an error if the JWT token is missing
-* Check that all withdraw params conform to [protocols](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#withdraw)
+- Check that withdrawals are disabled for really small and really large values
+- Check that you cannot make a withdrawal with a value higher than the current
+  balance
+- Check that the withdraw flow goes through, and that the banking rails are
+  working
+- Check that the endpoint returns an error if the JWT token is missing
+- Check that all withdraw params conform to
+  [protocols](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#withdraw)
 
 ### Transaction(s) Tests
 
-* Check that the `/transaction` endpoint is working for a newly created transaction
-* Check that the `/transaction` endpoint is working for a completed transaction
-* Check that the `/transactions` endpoint returns all transactions from a specific user
+- Check that the `/transaction` endpoint is working for a newly created
+  transaction
+- Check that the `/transaction` endpoint is working for a completed transaction
+- Check that the `/transactions` endpoint returns all transactions from a
+  specific user
 
 ### Security Tests
 
-* Ensure distribution is done through a dedicated distribution account (not the issuing account)
-* Ensure market making is done through a dedicated account (not the issuing account)
-* Make sure all authenticated endpoints are not accessible without the JWT tokens
+- Ensure distribution is done through a dedicated distribution account (not the
+  issuing account)
+- Ensure market making is done through a dedicated account (not the issuing
+  account)
+- Make sure all authenticated endpoints are not accessible without the JWT
+  tokens

--- a/content/docs/enabling-deposit-and-withdrawal/setting-up-test-server.mdx
+++ b/content/docs/enabling-deposit-and-withdrawal/setting-up-test-server.mdx
@@ -6,37 +6,64 @@ order: 30
 import { CodeExample } from "components/CodeExample";
 import { Alert } from "components/Alert";
 
-Before setting up a server that connects to live banking rails and real money, you should build out a test rig connected to the [Stellar test network](../glossary/testnet.mdx). The testnet works just like the main Stellar network, but it uses test data and allows you to fund test accounts for free using a tool called [Friendbot](../glossary/testnet.mdx#friendbot).
+Before setting up a server that connects to live banking rails and real money,
+you should build out a test rig connected to the
+[Stellar test network](../glossary/testnet.mdx). The testnet works just like the
+main Stellar network, but it uses test data and allows you to fund test accounts
+for free using a tool called [Friendbot](../glossary/testnet.mdx#friendbot).
 
 <Alert>
 
-Note: the testnet is reset every three months, so when building on it, make sure you have a plan to recreate necessary accounts and other data.  For more info, check out the [best practices for using the testnet](../glossary/testnet.mdx#best-practices-for-using-testnet).
+Note: the testnet is reset every three months, so when building on it, make sure
+you have a plan to recreate necessary accounts and other data. For more info,
+check out the
+[best practices for using the testnet](../glossary/testnet.mdx#best-practices-for-using-testnet).
 
 </Alert>
 
-At the end of this section, you should have a sandboxed system capable of interfacing with the Stellar testnet that you can easily convert into a production-ready deployment on the main Stellar network. You should always keep a testnet deployment up and running — even once you have a production version — so that wallets can test your implementation without the risk of losing real user funds.
+At the end of this section, you should have a sandboxed system capable of
+interfacing with the Stellar testnet that you can easily convert into a
+production-ready deployment on the main Stellar network. You should always keep
+a testnet deployment up and running — even once you have a production version —
+so that wallets can test your implementation without the risk of losing real
+user funds.
 
-You can also find an outline of the basic steps issuers need to complete in the [intro to SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#basic-anchor-implementation), the interactive deposit and and withdrawal specification.
+You can also find an outline of the basic steps issuers need to complete in the
+[intro to SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#basic-anchor-implementation),
+the interactive deposit and and withdrawal specification.
 
 ## Prerequisites
 
-Before you start building infrastructure to connect a Stellar-network token to banking rails, you need to:
+Before you start building infrastructure to connect a Stellar-network token to
+banking rails, you need to:
 
-1. Issue an asset on the network – which you can find out how to do in the [Issue Assets](../issuing-assets/index.mdx/) section — or find another trustworthy issuer and coordinate with them to broker their asset.
-1. Add meta-information about the asset (if you issue one) and define the location of your `TRANSFER_SERVER_SEP0024` in your `stellar.toml` so that wallets know where to find the server and relevant endpoints.  You can consult [this guide](../issuing-assets/index.mdx/) for help completing your `stellar.toml`.
+1. Issue an asset on the network – which you can find out how to do in the
+   [Issue Assets](../issuing-assets/index.mdx/) section — or find another
+   trustworthy issuer and coordinate with them to broker their asset.
+1. Add meta-information about the asset (if you issue one) and define the
+   location of your `TRANSFER_SERVER_SEP0024` in your `stellar.toml` so that
+   wallets know where to find the server and relevant endpoints. You can consult
+   [this guide](../issuing-assets/index.mdx/) for help completing your
+   `stellar.toml`.
 
 Once you've taken those steps, you're ready to implement an `/info` endpoint.
 
 ## Implementing the `/info` Endpoint
 
-The `/info` endpoint allows issuers to communicate basic information to wallets, exchange interfaces, and other Stellar apps. It responds to client queries with a JSON object detailing which currencies the issuer supports for deposit and withdrawal, and laying out the fee structure for each currency.
+The `/info` endpoint allows issuers to communicate basic information to wallets,
+exchange interfaces, and other Stellar apps. It responds to client queries with
+a JSON object detailing which currencies the issuer supports for deposit and
+withdrawal, and laying out the fee structure for each currency.
 
 Generally, issuers structure fees one of two ways:
 
 - Fixed Fees: a fixed value that is applied to the transactions
 - Fee Percent: a percentage of the transaction value
 
-Since those are both pretty straightforward, the `/info` endpoint can convey those structures directly. If, however, you use a more complicated fee structure, you’ll need to use the `/fee` endpoint, and indicate it’s enabled in the `/info` response.
+Since those are both pretty straightforward, the `/info` endpoint can convey
+those structures directly. If, however, you use a more complicated fee
+structure, you’ll need to use the `/fee` endpoint, and indicate it’s enabled in
+the `/info` response.
 
 Here's an example `/info` response:
 
@@ -79,43 +106,84 @@ Here's an example `/info` response:
 
 </CodeExample>
 
-You can find the complete parameters for the `/info` endpoint in the Interactive Anchor/Wallet Asset Transfer Server spec (aka [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md)).
+You can find the complete parameters for the `/info` endpoint in the Interactive
+Anchor/Wallet Asset Transfer Server spec (aka
+[SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md)).
 
 ## Authentication
 
-To provide a simpler experience for wallet users, anchors (aka on/off ramps) can authenticate individuals with their Stellar accounts instead of requiring usernames and passwords. The method for doing that is specified in the Stellar Web Authentication SEP (aka [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)).
+To provide a simpler experience for wallet users, anchors (aka on/off ramps) can
+authenticate individuals with their Stellar accounts instead of requiring
+usernames and passwords. The method for doing that is specified in the Stellar
+Web Authentication SEP (aka
+[SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)).
 
-Stellar Web Authentication is a protocol for verifying that a user controls a Stellar private key for a given account, and for creating a persistent session for that user. It relies on a variation of mutual challenge-response, and uses Stellar transactions to encode challenges and responses: an asset issuer provides a 'challenge' transaction; the client signs it on behalf of the user and returns it to the issuer; the issuer checks that the signature is valid, and if it is, issues a JWT.
+Stellar Web Authentication is a protocol for verifying that a user controls a
+Stellar private key for a given account, and for creating a persistent session
+for that user. It relies on a variation of mutual challenge-response, and uses
+Stellar transactions to encode challenges and responses: an asset issuer
+provides a 'challenge' transaction; the client signs it on behalf of the user
+and returns it to the issuer; the issuer checks that the signature is valid, and
+if it is, issues a JWT.
 
-The JWT then acts as a re-usable key for a client to perform an action on behalf of a user. It can contain an arbitrary amount of information, and is signed by the provider — in this case the asset issuer — to ensure validity. You can read the full spec [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md).
+The JWT then acts as a re-usable key for a client to perform an action on behalf
+of a user. It can contain an arbitrary amount of information, and is signed by
+the provider — in this case the asset issuer — to ensure validity. You can read
+the full spec
+[here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md).
 
 ### Requesting a Challenge
 
-To start the authentication flow, the client requests a challenge, which is a Stellar transaction with the sequence number set to 0. A transaction with a sequence number of 0 is, by definition, invalid, so it can't actually be submitted to the network. The issuer can, however, verify that the transaction is signed correctly (which is what happens in the next step).
+To start the authentication flow, the client requests a challenge, which is a
+Stellar transaction with the sequence number set to 0. A transaction with a
+sequence number of 0 is, by definition, invalid, so it can't actually be
+submitted to the network. The issuer can, however, verify that the transaction
+is signed correctly (which is what happens in the next step).
 
-The only information needed to request a challenge is the client's public key, passed as the `account` parameter. Here's an example: `GET <AUTH_ENDPOINT>?account=GXXXXXX`
+The only information needed to request a challenge is the client's public key,
+passed as the `account` parameter. Here's an example:
+`GET <AUTH_ENDPOINT>?account=GXXXXXX`
 
 ### Exchanging the Signed Challenge
 
-Once the client signs the challenge transaction on behalf of the user using standard [Stellar SDK tools](../software-and-sdks/index.mdx), it sends the signed transaction back to the provider. Using those same Stellar SDKs, the provider then checks to see if the transaction is properly signed, and if it is, offers the client a JWT.
+Once the client signs the challenge transaction on behalf of the user using
+standard [Stellar SDK tools](../software-and-sdks/index.mdx), it sends the
+signed transaction back to the provider. Using those same Stellar SDKs, the
+provider then checks to see if the transaction is properly signed, and if it is,
+offers the client a JWT.
 
-This JWT should be created with the claims that are appropriate given the account that signed the challenge. It can be created with any existing JWT library.
+This JWT should be created with the claims that are appropriate given the
+account that signed the challenge. It can be created with any existing JWT
+library.
 
 Here are the fields included in the JWT:
 
 - The `sub` key contains the account of the authenticated user
-- The `exp` key contains the expiration of the JWT. Some JWTs should be short-lived if the claims inside of it are expected to change, or if the JWT is used in less secure environments
+- The `exp` key contains the expiration of the JWT. Some JWTs should be
+  short-lived if the claims inside of it are expected to change, or if the JWT
+  is used in less secure environments
 - Other keys can contain any type of claim or data the Anchor wishes.
 
-Since the `sub` field contains the address of the authenticated user, it's kind of like a username. The JWT authenticates said user.
+Since the `sub` field contains the address of the authenticated user, it's kind
+of like a username. The JWT authenticates said user.
 
-Since some tokens are used in less secure environments, such as as query parameters in URLs, you may want to create a short-lived or one-time use token to prevent a JWT from falling into the wrong hands.
+Since some tokens are used in less secure environments, such as as query
+parameters in URLs, you may want to create a short-lived or one-time use token
+to prevent a JWT from falling into the wrong hands.
 
 ## Deposit Flow
 
-Once you have implemented an `/info` endpoint and set up for user authentication, your next step is to set up a deposit flow. The deposit flow is the on-ramp to the Stellar Network. In it, a user transfers funds via local rails to a stablecoin issuer in return for a digital version of those funds on the Stellar Network. This section will go through all the steps necessary to implement a working deposit functionality.
+Once you have implemented an `/info` endpoint and set up for user
+authentication, your next step is to set up a deposit flow. The deposit flow is
+the on-ramp to the Stellar Network. In it, a user transfers funds via local
+rails to a stablecoin issuer in return for a digital version of those funds on
+the Stellar Network. This section will go through all the steps necessary to
+implement a working deposit functionality.
 
-Deposit flows involve a back-and-forth between an issuer's server and a wallet's client that starts with the wallet polling the `/info` endpoint and setting up an authenticated user session as described in the previous sections. The general sequence of deposit events looks like this:
+Deposit flows involve a back-and-forth between an issuer's server and a wallet's
+client that starts with the wallet polling the `/info` endpoint and setting up
+an authenticated user session as described in the previous sections. The general
+sequence of deposit events looks like this:
 
 ```mermaid
 sequenceDiagram
@@ -138,60 +206,131 @@ sequenceDiagram
     note left of Anchor: Deposit confirmed
     Anchor->>Stellar: POST /transaction [Horizon]
     Stellar->>Anchor: Transaction result [Horizon]
-    Stellar->>Wallet: Transaction result 
-```    
+    Stellar->>Wallet: Transaction result
+```
 
 ### The POST `/transactions/deposit/interactive` Endpoint
 
-To start a new deposit transaction, the wallet POSTs to the `/transactions/deposit/interactive` endpoint and lets the issuer know the user’s Stellar account via the `account` parameter, and what type of asset the user plans to deposit via the `asset_code` parameter.
+To start a new deposit transaction, the wallet POSTs to the
+`/transactions/deposit/interactive` endpoint and lets the issuer know the user’s
+Stellar account via the `account` parameter, and what type of asset the user
+plans to deposit via the `asset_code` parameter.
 
-Those are the only required fields to initiate a deposit request, so that’s all we’ll cover here. To find out about other optional parameters you should support, check the [complete spec](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#deposit).
+Those are the only required fields to initiate a deposit request, so that’s all
+we’ll cover here. To find out about other optional parameters you should
+support, check the
+[complete spec](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#deposit).
 
 ### Initiate Interactive Flow
 
-In the interactive flow, the anchor’s server responds to the wallet’s POST with the `interactive customer information needed` response detailed [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#2-interactive-customer-information-needed). That response is a JSON object containing a URL that the wallet uses to open an issuer-hosted webapp, which is what the issuer uses to collect the information it needs from a user to complete a deposit. The reason this flow relies on an issuer-hosted webapp is that wallets can’t predict what type of information an issuer will need.
+In the interactive flow, the anchor’s server responds to the wallet’s POST with
+the `interactive customer information needed` response detailed
+[here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#2-interactive-customer-information-needed).
+That response is a JSON object containing a URL that the wallet uses to open an
+issuer-hosted webapp, which is what the issuer uses to collect the information
+it needs from a user to complete a deposit. The reason this flow relies on an
+issuer-hosted webapp is that wallets can’t predict what type of information an
+issuer will need.
 
-If authentication is required, it should be handled before kicking off the deposit by the server hosting the interactive flow, usually using a one-time-use JWT to start a backend persistent session as described in the [previous section](./#authentication). If you use [Polaris](./reference-implementations.mdx), authentication is handled for you.
+If authentication is required, it should be handled before kicking off the
+deposit by the server hosting the interactive flow, usually using a one-time-use
+JWT to start a backend persistent session as described in the
+[previous section](./#authentication). If you use
+[Polaris](./reference-implementations.mdx), authentication is handled for you.
 
-When the flow is finished, the webapp should respond to the callback given by the client. This can be either a javascript `postMessage` call or a call to a wallet-provided URL. In native apps, this URL can have a custom protocol to call back to the opening app.
+When the flow is finished, the webapp should respond to the callback given by
+the client. This can be either a javascript `postMessage` call or a call to a
+wallet-provided URL. In native apps, this URL can have a custom protocol to call
+back to the opening app.
 
 ### Webapp Interface
 
-The webapp is an interface that collects any information you need from the user, including KYC requirements and deposit information, such as amount. It doesn’t have to be complicated, but to provide a seamless user experience that aligns with wallets’ expectations, it should follow the UX guidelines described in this [Github repo](https://github.com/stellar/anchor-ux-guidelines). If you’ve already collected information from this user, you can either skip these screens or pre-fill them.
+The webapp is an interface that collects any information you need from the user,
+including KYC requirements and deposit information, such as amount. It doesn’t
+have to be complicated, but to provide a seamless user experience that aligns
+with wallets’ expectations, it should follow the UX guidelines described in this
+[Github repo](https://github.com/stellar/anchor-ux-guidelines). If you’ve
+already collected information from this user, you can either skip these screens
+or pre-fill them.
 
-For testing purposes, it's important that the staging infrastructure allows third parties to complete the flow without a real bank account or phone number, and without transferring any real money. Each screen should be properly internationalized using either an existing customer's preferences or the optional `lang` parameter from the initial `POST /transactions/deposit/interactive` call.
+For testing purposes, it's important that the staging infrastructure allows
+third parties to complete the flow without a real bank account or phone number,
+and without transferring any real money. Each screen should be properly
+internationalized using either an existing customer's preferences or the
+optional `lang` parameter from the initial
+`POST /transactions/deposit/interactive` call.
 
 ### More_info_url
 
-The `more_info_url` is a parameter returned by the `/transactions/deposit/interactive` endpoint that is vital to complete deposits that require a bank transfer. It is automatically opened by wallets once the interactive flow is complete, and should have information on the bank account that the user should send the funds to.
+The `more_info_url` is a parameter returned by the
+`/transactions/deposit/interactive` endpoint that is vital to complete deposits
+that require a bank transfer. It is automatically opened by wallets once the
+interactive flow is complete, and should have information on the bank account
+that the user should send the funds to.
 
-After the Anchor confirms that the user has sent the transfer, this page can be used to show more information about the transaction. The `more_info_url` is relative to a single transaction, and it's used throughout the endpoints as a way for users to get more data on that specific entry.
+After the Anchor confirms that the user has sent the transfer, this page can be
+used to show more information about the transaction. The `more_info_url` is
+relative to a single transaction, and it's used throughout the endpoints as a
+way for users to get more data on that specific entry.
 
-The `more_info_url` should be a standalone page that users can also visit after the interactive flow is complete (not necessarily right after), since it's common for people to only be able to start the actual bank transfer a while after they've started the deposit process in the webapp and wallet interfaces.
+The `more_info_url` should be a standalone page that users can also visit after
+the interactive flow is complete (not necessarily right after), since it's
+common for people to only be able to start the actual bank transfer a while
+after they've started the deposit process in the webapp and wallet interfaces.
 
 ## Transaction(s) Endpoints
 
-The `/transaction` and `/transactions` endpoints provide a way for wallets to fetch information about a single transaction (to check its status) and about all transactions that belong to a user account (in order to show a historical view of their operations) respectively.
+The `/transaction` and `/transactions` endpoints provide a way for wallets to
+fetch information about a single transaction (to check its status) and about all
+transactions that belong to a user account (in order to show a historical view
+of their operations) respectively.
 
-Wallets poll the `/transaction` endpoint when waiting for a transaction’s status to change. For example, when a user has initiated a withdrawal, the wallet will poll the relevant transaction after sending all the required information to the issuer for processing. Once the transaction is completed on the Stellar network, the transaction’s status will update from “pending_stellar” to “completed.” Through polling, the wallet knows to notify the user of the successful withdrawal.
+Wallets poll the `/transaction` endpoint when waiting for a transaction’s status
+to change. For example, when a user has initiated a withdrawal, the wallet will
+poll the relevant transaction after sending all the required information to the
+issuer for processing. Once the transaction is completed on the Stellar network,
+the transaction’s status will update from “pending_stellar” to “completed.”
+Through polling, the wallet knows to notify the user of the successful
+withdrawal.
 
-Wallets need access to the transactions associated with the user’s account for displaying history or past activity. This can be accomplished with a `/transactions` endpoint. Wallets may also use this endpoint after making a POST request to `/transactions/deposit/interactive` to make sure a transaction was successfully created.
+Wallets need access to the transactions associated with the user’s account for
+displaying history or past activity. This can be accomplished with a
+`/transactions` endpoint. Wallets may also use this endpoint after making a POST
+request to `/transactions/deposit/interactive` to make sure a transaction was
+successfully created.
 
 ### Transactions History Endpoint
 
-The `/transactions` endpoint should accept a number of parameters for filtering the transactions returned in the response. Refer to the [transaction history section of the SEP](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#transaction-history) for a complete list of parameters and response values.
+The `/transactions` endpoint should accept a number of parameters for filtering
+the transactions returned in the response. Refer to the
+[transaction history section of the SEP](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#transaction-history)
+for a complete list of parameters and response values.
 
-It should also be noted that the JSON object representation of a particular transaction should be the same in response to both `/transaction` and `/transactions`.
+It should also be noted that the JSON object representation of a particular
+transaction should be the same in response to both `/transaction` and
+`/transactions`.
 
 ### Single Historical Transaction Endpoint
 
-The `/transaction` endpoint should return a single JSON object representing the specified transaction. Unlike the filtering parameters for `/transactions`, this endpoint should accept the various identifiers for a particular transaction. Again, refer to the [SEP](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#single-historical-transaction) for a complete spec.
+The `/transaction` endpoint should return a single JSON object representing the
+specified transaction. Unlike the filtering parameters for `/transactions`, this
+endpoint should accept the various identifiers for a particular transaction.
+Again, refer to the
+[SEP](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#single-historical-transaction)
+for a complete spec.
 
 ## Withdrawal Flow
 
-The withdrawal flow is the off-ramp from the Stellar Network. In it, a user makes a payment on the Stellar network to return digital assets to an anchor, and receives the equivalent value as fiat currency from the anchor in their bank account in return. This section will go through all the steps necessary to implement a working withdrawal functionality
+The withdrawal flow is the off-ramp from the Stellar Network. In it, a user
+makes a payment on the Stellar network to return digital assets to an anchor,
+and receives the equivalent value as fiat currency from the anchor in their bank
+account in return. This section will go through all the steps necessary to
+implement a working withdrawal functionality
 
-Like deposit flows, withdraw flows involve a back-and-forth between an anchor’s server and a wallet’s client that starts with the wallet polling the `/info` endpoint and setting up an authenticated user session as described in the previous sections. The general sequence of deposit events looks like this:
+Like deposit flows, withdraw flows involve a back-and-forth between an anchor’s
+server and a wallet’s client that starts with the wallet polling the `/info`
+endpoint and setting up an authenticated user session as described in the
+previous sections. The general sequence of deposit events looks like this:
 
 ```mermaid
 sequenceDiagram
@@ -213,33 +352,77 @@ sequenceDiagram
     note left of Anchor: Withdraw confirmed
     Anchor->>Stellar: POST /transaction [Horizon]
     Stellar->>Anchor: Transaction result [Horizon]
-    Stellar->>Wallet: Transaction result 
-```    
+    Stellar->>Wallet: Transaction result
+```
 
 ### `/transactions/withdraw/interactive` Endpoint
 
-Before initiating a withdrawal, a wallet hits the anchor’s `/info` endpoint and creates an authenticated user session as described in the [previous section](./#authentication). Once that’s done, a wallet makes a POST request to an issuer’s `/transactions/withdraw/interactive` endpoint to start a withdrawal, which creates a new but incomplete transaction record in the issuer’s database. The issuer’s response to the request should contain the transaction’s ID as well as the URL that should be requested to begin the interactive flow.
+Before initiating a withdrawal, a wallet hits the anchor’s `/info` endpoint and
+creates an authenticated user session as described in the
+[previous section](./#authentication). Once that’s done, a wallet makes a POST
+request to an issuer’s `/transactions/withdraw/interactive` endpoint to start a
+withdrawal, which creates a new but incomplete transaction record in the
+issuer’s database. The issuer’s response to the request should contain the
+transaction’s ID as well as the URL that should be requested to begin the
+interactive flow.
 
 The webapp then collects the information necessary to complete the transaction.
 
-The only required parameter for a withdraw query is `asset_code`, however you will likely want to collect `account` as well. Another notable parameter is `lang`. This parameter can be used on the deposit and info endpoints as well, and should be supported if you intend to serve users who speak different languages. Polaris supports English, Spanish, and Portuguese out of the box.
+The only required parameter for a withdraw query is `asset_code`, however you
+will likely want to collect `account` as well. Another notable parameter is
+`lang`. This parameter can be used on the deposit and info endpoints as well,
+and should be supported if you intend to serve users who speak different
+languages. Polaris supports English, Spanish, and Portuguese out of the box.
 
-For an exhaustive list of the parameters and response values check out the [withdraw section](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#withdraw) of the Interactive Anchor/Wallet Transfer Server SEP.
+For an exhaustive list of the parameters and response values check out the
+[withdraw section](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#withdraw)
+of the Interactive Anchor/Wallet Transfer Server SEP.
 
 ### Initiate Interactive Flow
 
-The response to the wallet’s POST request to the `/transactions/withdraw/interactive` endpoint provides a URL. Since this URL will be requested as if in a browser (via popup or iframe), authentication headers cannot be added. DO NOT include the SEP-10 JWT token in the URL for authentication for the interactive flow, as this is considered insecure.
+The response to the wallet’s POST request to the
+`/transactions/withdraw/interactive` endpoint provides a URL. Since this URL
+will be requested as if in a browser (via popup or iframe), authentication
+headers cannot be added. DO NOT include the SEP-10 JWT token in the URL for
+authentication for the interactive flow, as this is considered insecure.
 
-[Polaris](./reference-implementations.mdx) gets around this issue by adding a short-lived JWT token to the URL and using session cookies for the remainder of the interactive flow to identify the authenticated user. If you’re not using Polaris, feel free to implement your own authentication mechanisms for the interactive flows, but reference [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#authentication) for guidance.
+[Polaris](./reference-implementations.mdx) gets around this issue by adding a
+short-lived JWT token to the URL and using session cookies for the remainder of
+the interactive flow to identify the authenticated user. If you’re not using
+Polaris, feel free to implement your own authentication mechanisms for the
+interactive flows, but reference
+[SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#authentication)
+for guidance.
 
 ### Mocked Interface
 
-There are a number of UI pages that should be served to the user while walking through the withdraw flow. These pages can be divided into three separate categories or phases.
+There are a number of UI pages that should be served to the user while walking
+through the withdraw flow. These pages can be divided into three separate
+categories or phases.
 
-- Mocked KYC: When starting a withdrawal, the anchor may be legally obligated to collect specific information from the user. In the testing phase, you don’t need to store this information permanently, but you still need to provide the interface to collect it. There is no restriction on the number of pages used, but often, you can get all you need with a single page. Make sure you understand relevant legal requirements before implementing this phase of the process.
-- Withdrawal information: The issuer needs to collect the numerical amount of the asset to transfer. There may be other pieces of data you want to collect as well. Make sure you have all the information necessary to submit a successful transaction to the stellar network.
-- Waiting for transfer: Once the issuer has collected all the information needed for a withdrawal, the last page rendered in the interactive flow should make a `postMessage` call to the Wallet, notifying the wallet that it has all the information it needs.
+- Mocked KYC: When starting a withdrawal, the anchor may be legally obligated to
+  collect specific information from the user. In the testing phase, you don’t
+  need to store this information permanently, but you still need to provide the
+  interface to collect it. There is no restriction on the number of pages used,
+  but often, you can get all you need with a single page. Make sure you
+  understand relevant legal requirements before implementing this phase of the
+  process.
+- Withdrawal information: The issuer needs to collect the numerical amount of
+  the asset to transfer. There may be other pieces of data you want to collect
+  as well. Make sure you have all the information necessary to submit a
+  successful transaction to the stellar network.
+- Waiting for transfer: Once the issuer has collected all the information needed
+  for a withdrawal, the last page rendered in the interactive flow should make a
+  `postMessage` call to the Wallet, notifying the wallet that it has all the
+  information it needs.
 
-The wallet then submits the transaction to the Stellar network that sends tokens from the user’s Stellar account to the issuer’s Stellar account, andl begins polling the issuer’s `/transaction` endpoint until the relevant transaction has the expected status. For withdrawals, the expected status is “complete.”
+The wallet then submits the transaction to the Stellar network that sends tokens
+from the user’s Stellar account to the issuer’s Stellar account, andl begins
+polling the issuer’s `/transaction` endpoint until the relevant transaction has
+the expected status. For withdrawals, the expected status is “complete.”
 
-The issuer should detect that the wallet has submitted a withdrawal transaction by streaming transaction events for the user’s account. Once a matching transaction has been detected, the issuer should mark the transaction as “complete” if it succeeds on the Stellar network, or “error” if there was a problem.
+The issuer should detect that the wallet has submitted a withdrawal transaction
+by streaming transaction events for the user’s account. Once a matching
+transaction has been detected, the issuer should mark the transaction as
+“complete” if it succeeds on the Stellar network, or “error” if there was a
+problem.

--- a/content/docs/glossary/accounts.mdx
+++ b/content/docs/glossary/accounts.mdx
@@ -1,25 +1,42 @@
 ---
 title: Accounts
-order: 
+order:
 ---
 
-Accounts are the central data structure in Stellar.  They hold balances, sign transactions, and issue assets.  All entries that persist on the ledger are owned by a particular account. 
+Accounts are the central data structure in Stellar. They hold balances, sign
+transactions, and issue assets. All entries that persist on the ledger are owned
+by a particular account.
 
-In addition to a valid keypair, an account needs a balance of XLM sufficient to meet the network reserve before it exists on the ledger.    
+In addition to a valid keypair, an account needs a balance of XLM sufficient to
+meet the network reserve before it exists on the ledger.
 
-## Keypair 
+## Keypair
 
-Stellar relies on public key cryptography to ensure that transactions are secure: every account requires a valid keypair consisting of a *public key* a *private key*. The public key is, as the name suggests, public.  It’s visible on the ledger, anyone can look it up, and it’s what others use to send payments to the account, identify the issuer an asset, and verify that a given transaction is authorized.  
+Stellar relies on public key cryptography to ensure that transactions are
+secure: every account requires a valid keypair consisting of a _public key_ a
+_private key_. The public key is, as the name suggests, public. It’s visible on
+the ledger, anyone can look it up, and it’s what others use to send payments to
+the account, identify the issuer an asset, and verify that a given transaction
+is authorized.
 
-The private key, however, is something an account holder should guard closely. It’s kind of like the combination to a lock — anyone who knows it can access the account, sign transactions, send funds, whatever.  Do not share your private key with anyone.
+The private key, however, is something an account holder should guard closely.
+It’s kind of like the combination to a lock — anyone who knows it can access the
+account, sign transactions, send funds, whatever. Do not share your private key
+with anyone.
 
 You can use any Stellar wallet or SDK to generate a valid keypair.
 
 ## Account Creation
 
-A keypair alone doesn’t create an account: before an account exists on the ledger, it needs an XLM balance sufficient to meet the minimum network reserve.  The minimum reserve, which is determined by validator vote, is intended to disincentivize the creation of tons of unused accounts in order to prevent ledger spam and maintain the efficiency and scalability of the network.
+A keypair alone doesn’t create an account: before an account exists on the
+ledger, it needs an XLM balance sufficient to meet the minimum network reserve.
+The minimum reserve, which is determined by validator vote, is intended to
+disincentivize the creation of tons of unused accounts in order to prevent
+ledger spam and maintain the efficiency and scalability of the network.
 
-There is a specific operation, Create Account, which you use to make a payment to a valid public key that does not exist on the ledger, thereby creating the account.
+There is a specific operation, Create Account, which you use to make a payment
+to a valid public key that does not exist on the ledger, thereby creating the
+account.
 
 ## Account fields
 
@@ -27,48 +44,70 @@ Accounts have the following fields:
 
 ### Account ID
 
-The public key that was used to create the account.  Even if you replace the signer on the with a different key, the original account ID will always be used to identify the account.
+The public key that was used to create the account. Even if you replace the
+signer on the with a different key, the original account ID will always be used
+to identify the account.
 
 ### Sequence number
 
-The current transaction sequence number of the account. This number starts equal to the ledger number at which the account was created, and increments upward as the account signs transactions.  
+The current transaction sequence number of the account. This number starts equal
+to the ledger number at which the account was created, and increments upward as
+the account signs transactions.
 
 ### Number of subentries
 
-Number of entries the account owns. This number is used to calculate the account's minimum balance: each subentry increases an account’s reserve by 0.5XLM.  Subentries include:
+Number of entries the account owns. This number is used to calculate the
+account's minimum balance: each subentry increases an account’s reserve by
+0.5XLM. Subentries include:
 
-*Trustlines
-*Offers
-*Signers
-*Data entries
+*Trustlines *Offers *Signers *Data entries
 
 ### Thresholds
 
-Operations have varying levels of access. This field specifies thresholds for low-, medium-, and high-access levels, as well as the weight of the master key. For more info, see [multi-sig](link).
+Operations have varying levels of access. This field specifies thresholds for
+low-, medium-, and high-access levels, as well as the weight of the master key.
+For more info, see [multi-sig](link).
 
 ### Home domain
 
-A [fully qualified domain name](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) such as `example.com` linked to the account. A home domain is required of asset issuers, who use it to [publish meta-information](link) for Stellar wallets and potential token holders, and for organizations running validators, who use it to [self-identify their nodes](link).
+A
+[fully qualified domain name](https://en.wikipedia.org/wiki/Fully_qualified_domain_name)
+such as `example.com` linked to the account. A home domain is required of asset
+issuers, who use it to [publish meta-information](link) for Stellar wallets and
+potential token holders, and for organizations running validators, who use it to
+[self-identify their nodes](link).
 
 To add a home domain to an account, use the [Set Options](link) operation.
 
 ### Flags
 
-Asset issuers set flags at the account level if they want to control access to the assets they issue.  There are three flags:
- - **Authorization required (0x1)**: Requires the issuing account to grant an account permission to hold an asset.
- - **Authorization revocable (0x2)**: Allows the issuing account to revoke an asset held by other accounts.
- - **Authorization immutable (0x4)**: Prevents the issuer from setting either of the above flags or deleting the issuing account.
+Asset issuers set flags at the account level if they want to control access to
+the assets they issue. There are three flags:
+
+- **Authorization required (0x1)**: Requires the issuing account to grant an
+  account permission to hold an asset.
+- **Authorization revocable (0x2)**: Allows the issuing account to revoke an
+  asset held by other accounts.
+- **Authorization immutable (0x4)**: Prevents the issuer from setting either of
+  the above flags or deleting the issuing account.
 
 ### Balances
 
-Each account has a balance for each token the account holds, including XLM.  
+Each account has a balance for each token the account holds, including XLM.
 
 ### Liabilities
 
-Each account also tracks its liabilities. Buying liabilities equal the total amount of an asset offered to buy aggregated over all offers owned by this account, and selling liabilities equal the total amount of an asset offered to sell aggregated over all offers owned by this account. 
+Each account also tracks its liabilities. Buying liabilities equal the total
+amount of an asset offered to buy aggregated over all offers owned by this
+account, and selling liabilities equal the total amount of an asset offered to
+sell aggregated over all offers owned by this account.
 
-An account must always have a balance sufficiently above the minimum reserve to satisfy its lumen selling liabilities, and a balance sufficiently below the maximum to accommodate its lumen buying liabilities.
+An account must always have a balance sufficiently above the minimum reserve to
+satisfy its lumen selling liabilities, and a balance sufficiently below the
+maximum to accommodate its lumen buying liabilities.
 
 ### Signers
 
-You can add signers to an account, and this field lists other public keys and their weights that can be used to authorize transactions.  For more info, see [multisig](link).
+You can add signers to an account, and this field lists other public keys and
+their weights that can be used to authorize transactions. For more info, see
+[multisig](link).

--- a/content/docs/glossary/fees.mdx
+++ b/content/docs/glossary/fees.mdx
@@ -5,11 +5,16 @@ order:
 
 import { CodeExample } from "components/CodeExample";
 
-To prevent ledger spam and maintain the efficiency of the network, Stellar requires small transaction fees and minimum balances on accounts.  Transaction fees are also used to prioritize transactions when the network enters surge pricing mode.
+To prevent ledger spam and maintain the efficiency of the network, Stellar
+requires small transaction fees and minimum balances on accounts. Transaction
+fees are also used to prioritize transactions when the network enters surge
+pricing mode.
 
 ## Fee Formula
 
-Stellar transactions can contain anywhere from 1 to a defined limit of 100 operations.  The fee for a given transaction is equal to the number of operations the transaction contains multiplied by the base fee for a given ledger.  
+Stellar transactions can contain anywhere from 1 to a defined limit of 100
+operations. The fee for a given transaction is equal to the number of operations
+the transaction contains multiplied by the base fee for a given ledger.
 
 <CodeExample>
 
@@ -19,28 +24,65 @@ Transaction fee = # of operations * base fee
 
 </CodeExample>
 
-Stellar deducts the entire fee from the transaction’s source account, regardless of which accounts are involved in each operation or who signed the transaction.
+Stellar deducts the entire fee from the transaction’s source account, regardless
+of which accounts are involved in each operation or who signed the transaction.
 
 ## Base Fee
 
-The base fee for a given ledger is determined dynamically using a version of a [VCG auction](https://en.wikipedia.org/wiki/Vickrey%E2%80%93Clarke%E2%80%93Groves_auction).  When you submit a transaction to the network, you specify the *maximum base fee* you’re willing to pay per operation, but you’re actually charged the *lowest possible fee* based on network activity.   
+The base fee for a given ledger is determined dynamically using a version of a
+[VCG auction](https://en.wikipedia.org/wiki/Vickrey%E2%80%93Clarke%E2%80%93Groves_auction).
+When you submit a transaction to the network, you specify the _maximum base fee_
+you’re willing to pay per operation, but you’re actually charged the _lowest
+possible fee_ based on network activity.
 
-When network activity is below capacity, you pay the network minimum, which is currently **100 stroops (0.00001 XLM)** per operation. 
+When network activity is below capacity, you pay the network minimum, which is
+currently **100 stroops (0.00001 XLM)** per operation.
 
 ## Surge Pricing
 
-When the number of operations submitted to a ledger exceeds network capacity (**currently 1,000 ops/ledger**), the network enters surge pricing mode, which uses market dynamics to decide which submissions are included. Essentially, submissions that offer a higher fee per operation make it onto the ledger first.
+When the number of operations submitted to a ledger exceeds network capacity
+(**currently 1,000 ops/ledger**), the network enters surge pricing mode, which
+uses market dynamics to decide which submissions are included. Essentially,
+submissions that offer a higher fee per operation make it onto the ledger first.
 
-If there’s a tie — in other words multiple transactions that offer the same base fee are competing for the same limited space in the ledger — the transactions are (pseudo-randomly) shuffled, and transactions at the top of the heap make the ledger.  The rest of the transactions, the ones that didn’t make the cut, are pushed on to the next ledger, or discarded if they’ve been waiting for too long.  If your transaction is discarded, Horizon will return a [timeout error](https://www.stellar.org/developers/horizon/reference/errors/timeout.html).  For more information, see [transaction life cycle](./transactions.md#life-cycle).  
+If there’s a tie — in other words multiple transactions that offer the same base
+fee are competing for the same limited space in the ledger — the transactions
+are (pseudo-randomly) shuffled, and transactions at the top of the heap make the
+ledger. The rest of the transactions, the ones that didn’t make the cut, are
+pushed on to the next ledger, or discarded if they’ve been waiting for too long.
+If your transaction is discarded, Horizon will return a
+[timeout error](https://www.stellar.org/developers/horizon/reference/errors/timeout.html).
+For more information, see
+[transaction life cycle](./transactions.md#life-cycle).
 
-The goal of the transaction pricing specification, which you can read in full [here](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0005.md), is to maximize network throughput while minimizing transaction fees. 
-Fee Stats and Fee Strategy
-The general rule of thumb: choose the highest fee you're willing to pay to ensure your transaction makes the ledger.  Wallet developers may want to offer users a chance to specify their own base fee, though it may make more sense to set a persistent global base fee multiple orders of magnitude above the market rate — 0.1 XLM, for instance — since the average user probably won't care if they’re paying 0.8 cents or 0.00008 cents.
+The goal of the transaction pricing specification, which you can read in full
+[here](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0005.md),
+is to maximize network throughput while minimizing transaction fees. Fee Stats
+and Fee Strategy The general rule of thumb: choose the highest fee you're
+willing to pay to ensure your transaction makes the ledger. Wallet developers
+may want to offer users a chance to specify their own base fee, though it may
+make more sense to set a persistent global base fee multiple orders of magnitude
+above the market rate — 0.1 XLM, for instance — since the average user probably
+won't care if they’re paying 0.8 cents or 0.00008 cents.
 
-If you keep getting a timeout error when you submit a transaction, you may need to increase your base fee, or wait until network activity abates and re-submit your transaction.  To help inform that decision, you can consult the Horizon `/fee_stats` endpoint, which provides detailed information about per-operation fee stats for the last five ledgers.  You can find the same information on the fee stats panel of the dashboard.  All three of the SDF-maintained SDKs also allow you to poll the `/fee_stats` endpoint: [Go](https://godoc.org/github.com/stellar/go/clients/horizonclient#Client.FeeStats), [Java](https://stellar.github.io/java-stellar-sdk/), [Javascript](https://stellar.github.io/js-stellar-sdk/Server.html#feeStats).   
+If you keep getting a timeout error when you submit a transaction, you may need
+to increase your base fee, or wait until network activity abates and re-submit
+your transaction. To help inform that decision, you can consult the Horizon
+`/fee_stats` endpoint, which provides detailed information about per-operation
+fee stats for the last five ledgers. You can find the same information on the
+fee stats panel of the dashboard. All three of the SDF-maintained SDKs also
+allow you to poll the `/fee_stats` endpoint:
+[Go](https://godoc.org/github.com/stellar/go/clients/horizonclient#Client.FeeStats),
+[Java](https://stellar.github.io/java-stellar-sdk/),
+[Javascript](https://stellar.github.io/js-stellar-sdk/Server.html#feeStats).
 
 ## Fee Pool
 
 The fee pool is the lot of lumens collected from transaction fees.
 
-SDF does not retain these lumens. They go into a locked account and sit there unused by anyone. 
+SDF does not retain these lumens. They go into a locked account and sit there
+unused by anyone.
+
+```
+
+```

--- a/content/docs/glossary/ledger.mdx
+++ b/content/docs/glossary/ledger.mdx
@@ -1,21 +1,34 @@
 ---
 title: Ledger
-order: 
+order:
 ---
 
-A ledger represents the state of the Stellar universe at a given point in time. It’s shared across all the nodes that make up the network, and contains the list of all accounts and balances, all orders on the distributed exchange, and any other data that persists.
+A ledger represents the state of the Stellar universe at a given point in time.
+It’s shared across all the nodes that make up the network, and contains the list
+of all accounts and balances, all orders on the distributed exchange, and any
+other data that persists.
 
-Every Stellar Consensus Protocol (SCP) round, the network reaches consensus on which transaction set to apply to the last closed ledger; when the new set is applied, a new "last closed ledger" is defined.
+Every Stellar Consensus Protocol (SCP) round, the network reaches consensus on
+which transaction set to apply to the last closed ledger; when the new set is
+applied, a new "last closed ledger" is defined.
 
-Each ledger is cryptographically linked to a unique previous ledger, creating a historical ledger chain that goes back to the genesis ledger, which is the first ledger in the history of the network.
+Each ledger is cryptographically linked to a unique previous ledger, creating a
+historical ledger chain that goes back to the genesis ledger, which is the first
+ledger in the history of the network.
 
 The sequence number of a ledger is defined recursively:
-* The genesis ledger has sequence number 1
-* The ledger directly following a ledger with sequence number n has sequence number n+1
+
+- The genesis ledger has sequence number 1
+- The ledger directly following a ledger with sequence number n has sequence
+  number n+1
 
 ## Ledger header
 
-Every ledger has a **ledger header**. This header has references to the actual data within the ledger as well as a reference to the previous ledger. References here are cryptographic hashes of the content being referenced — the hashes behave like pointers in typical data structures but with added security guarantees.
+Every ledger has a **ledger header**. This header has references to the actual
+data within the ledger as well as a reference to the previous ledger. References
+here are cryptographic hashes of the content being referenced — the hashes
+behave like pointers in typical data structures but with added security
+guarantees.
 
 You can think of the historical ledger chain as a linked list of ledger headers:
 
@@ -25,60 +38,103 @@ Every ledger header has the following fields:
 
 - **Version**: Protocol version of this ledger.
 
-- **Previous Ledger Hash**: Hash of the previous ledger. Forms a chain of ledgers stretching back to the genesis ledger.
+- **Previous Ledger Hash**: Hash of the previous ledger. Forms a chain of
+  ledgers stretching back to the genesis ledger.
 
-- **SCP value**: During consensus all the validating nodes in the network run SCP and come to an agreement about a particular value, which is a transaction set they will apply to a ledger. This value is stored here and in the next three fields (transaction set hash, close time, and upgrades).
+- **SCP value**: During consensus all the validating nodes in the network run
+  SCP and come to an agreement about a particular value, which is a transaction
+  set they will apply to a ledger. This value is stored here and in the next
+  three fields (transaction set hash, close time, and upgrades).
 
-  - **Transaction set hash**: Hash of the transaction set that was applied to the previous ledger.
+  - **Transaction set hash**: Hash of the transaction set that was applied to
+    the previous ledger.
 
   - **Close time**: When the network closed this ledger. UNIX timestamp.
 
-  - **Upgrades**: How the network adjusts overall values like the [base fee](./fees.md) and agrees to network-wide changes like switching to a new protocol version. This field is usually empty. When there *is* a network-wide upgrade in the works, the SDF will inform and help coordinate participants using the [#validators channel on Keybase](link).  So if you run a validator, it’s important to join and monitor that channel.  For more info, see [versioning](./versioning.md).
+  - **Upgrades**: How the network adjusts overall values like the
+    [base fee](./fees.md) and agrees to network-wide changes like switching to a
+    new protocol version. This field is usually empty. When there _is_ a
+    network-wide upgrade in the works, the SDF will inform and help coordinate
+    participants using the [#validators channel on Keybase](link). So if you run
+    a validator, it’s important to join and monitor that channel. For more info,
+    see [versioning](./versioning.md).
 
-- **Transaction set result hash**: Hash of the results of applying the transaction set. This data is not, strictly speaking, necessary for validating the results of the transactions. However, it makes it easier for entities to validate the result of a given transaction without having to apply the transaction set to the previous ledger.
+- **Transaction set result hash**: Hash of the results of applying the
+  transaction set. This data is not, strictly speaking, necessary for validating
+  the results of the transactions. However, it makes it easier for entities to
+  validate the result of a given transaction without having to apply the
+  transaction set to the previous ledger.
 
-- **Bucket list hash**: Hash of all the objects in this ledger. The data structure that contains all the objects is called the [bucket list](https://github.com/stellar/stellar-core/tree/master/src/bucket).
+- **Bucket list hash**: Hash of all the objects in this ledger. The data
+  structure that contains all the objects is called the
+  [bucket list](https://github.com/stellar/stellar-core/tree/master/src/bucket).
 
 - **Ledger sequence**: The sequence number of this ledger.
 
 - **Total coins**: Total number of lumens in existence.
 
-- **Fee pool**: Number of lumens that have been paid in fees. This number will be added to the inflation pool and reset to 0 the next time inflation runs. Note this is denominated in lumens, even though a transaction’s [`fee`](./transactions.md#fee) field is in stroops.
+- **Fee pool**: Number of lumens that have been paid in fees. This number will
+  be added to the inflation pool and reset to 0 the next time inflation runs.
+  Note this is denominated in lumens, even though a transaction’s
+  [`fee`](./transactions.md#fee) field is in stroops.
 
 - **Inflation sequence**: Number of times inflation has been run.
 
-- **ID pool**: The last used global ID. These IDs are used for generating objects.
+- **ID pool**: The last used global ID. These IDs are used for generating
+  objects.
 
-- **Maximum Number of Transactions**: The maximum number of operations validators have agreed to process in a given ledger. If more transactions are submitted than this number, the network will enter into surge pricing mode, which uses a VCG auction to decide which to include in a ledger.  For more info, see [fees and surge pricing](./fees.md)
+- **Maximum Number of Transactions**: The maximum number of operations
+  validators have agreed to process in a given ledger. If more transactions are
+  submitted than this number, the network will enter into surge pricing mode,
+  which uses a VCG auction to decide which to include in a ledger. For more
+  info, see [fees and surge pricing](./fees.md)
 
-- **Base fee**: The [fee](./fees.md#transaction-fee) the network charges per [operation](./operations.md) in a [transaction](./transactions.md). This field is in stroops, which are 1/10,000,000th of a lumen.
+- **Base fee**: The [fee](./fees.md#transaction-fee) the network charges per
+  [operation](./operations.md) in a [transaction](./transactions.md). This field
+  is in stroops, which are 1/10,000,000th of a lumen.
 
-- **Base reserve**: The [reserve](./fees.md#minimum-account-balance) the network uses when calculating an account's minimum balance.
+- **Base reserve**: The [reserve](./fees.md#minimum-account-balance) the network
+  uses when calculating an account's minimum balance.
 
-- **Skip list**: Hashes of ledgers in the past. Allows you to jump back in time in the ledger chain without walking back ledger by ledger. There are 4 ledger hashes stored in the skip list. Each slot contains the oldest ledger that is mod of either 50  5000  50000 or 500000 depending on index skipList[0] mod(50), skipList[1] mod(5000), etc.
+- **Skip list**: Hashes of ledgers in the past. Allows you to jump back in time
+  in the ledger chain without walking back ledger by ledger. There are 4 ledger
+  hashes stored in the skip list. Each slot contains the oldest ledger that is
+  mod of either 50 5000 50000 or 500000 depending on index skipList[0] mod(50),
+  skipList[1] mod(5000), etc.
 
 ## Ledger Entries
 
-The ledger is a collection of **entries**. Currently there are 4 types of ledger entries. They're specified in
+The ledger is a collection of **entries**. Currently there are 4 types of ledger
+entries. They're specified in
 [`src/xdr/Stellar-ledger-entries.x`](https://github.com/stellar/stellar-core/blob/master/src/xdr/Stellar-ledger-entries.x).
 
 ### Account entry
 
-This entry represents an account. In Stellar, everything is built around accounts: transactions are performed by accounts, and accounts control the access rights to balances.
+This entry represents an account. In Stellar, everything is built around
+accounts: transactions are performed by accounts, and accounts control the
+access rights to balances.
 
 Other entries are add-ons, owned by a main account entry. With every new entry
-attached to the account, the minimum balance in XLM goes up for the account. For details, the docs on minimum balance.
+attached to the account, the minimum balance in XLM goes up for the account. For
+details, the docs on minimum balance.
 
 ### Trustline entry
 
-Trustlines are lines of credit the account has given a particular issuer in a specific asset.
+Trustlines are lines of credit the account has given a particular issuer in a
+specific asset.
 
-Trustline entries define the rules around the use of this currency. Rules can be defined by the user — who can set a maximum balance limit to limit risk — or by the issuer — who can set a  flag to control access to the asset.
+Trustline entries define the rules around the use of this currency. Rules can be
+defined by the user — who can set a maximum balance limit to limit risk — or by
+the issuer — who can set a flag to control access to the asset.
 
 ### Offer entry
 
-Offers are entries that an account creates in the orderbook. They are a way to automate simple trading inside the Stellar network. For more on offers, refer to the distributed exchange documentation.
+Offers are entries that an account creates in the orderbook. They are a way to
+automate simple trading inside the Stellar network. For more on offers, refer to
+the distributed exchange documentation.
 
 ### Data entry
 
-Data entries are key/value pairs attached to an account. They allow account controllers to attach arbitrary data to their account, and provide a flexible extension point to add application specific data to the ledger.
+Data entries are key/value pairs attached to an account. They allow account
+controllers to attach arbitrary data to their account, and provide a flexible
+extension point to add application specific data to the ledger.

--- a/content/docs/glossary/minimum-balance.mdx
+++ b/content/docs/glossary/minimum-balance.mdx
@@ -1,11 +1,13 @@
 ---
 title: Minimum Balance
-order: 
+order:
 ---
 
 import { CodeExample } from "components/CodeExample";
 
-All Stellar accounts must maintain a minimum balance of lumens. The minimum balance is calculated using the **base reserve,** which is currently **0.5 XLM**:
+All Stellar accounts must maintain a minimum balance of lumens. The minimum
+balance is calculated using the **base reserve,** which is currently **0.5
+XLM**:
 
 <CodeExample>
 
@@ -15,19 +17,32 @@ Minimum Balance = (2 + # of entries) * base reserve
 
 </CodeExample>
 
-The absolute minimum balance for an account is 1 XLM, which is equal to `(2 + 0 entries) * 0.5 base reserve`. Each additional entry reserves an additional 0.5 XLM. Entries include:
+The absolute minimum balance for an account is 1 XLM, which is equal to
+`(2 + 0 entries) * 0.5 base reserve`. Each additional entry reserves an
+additional 0.5 XLM. Entries include:
 
 - Trustlines
 - Offers
 - Signers
 - Data entries
 
-For example, an account with 1 trustline and 2 offers would have a minimum balance of `(2 + 3 entries) * 0.5 base reserve = 2.5 XLM`.
+For example, an account with 1 trustline and 2 offers would have a minimum
+balance of `(2 + 3 entries) * 0.5 base reserve = 2.5 XLM`.
 
-Any transaction that would reduce an account's balance to less than the minimum will be rejected with an `INSUFFICIENT_BALANCE` error.  Likewise, lumen selling liabilities that would reduce an account's balance to less than the minimum plus lumen selling liabilities will be rejected with an `INSUFFICIENT_BALANCE` error.
+Any transaction that would reduce an account's balance to less than the minimum
+will be rejected with an `INSUFFICIENT_BALANCE` error. Likewise, lumen selling
+liabilities that would reduce an account's balance to less than the minimum plus
+lumen selling liabilities will be rejected with an `INSUFFICIENT_BALANCE` error.
 
-The minimum balance is held in reserve, and closing an entry frees up the associated base reserve.  For instance: if you zero-out a non-lumen balance and close the associated trustline, the 0.5 XLM base reserve that secured that trustline is added to your available balance. 
+The minimum balance is held in reserve, and closing an entry frees up the
+associated base reserve. For instance: if you zero-out a non-lumen balance and
+close the associated trustline, the 0.5 XLM base reserve that secured that
+trustline is added to your available balance.
 
 ## Changes to Transaction Fees and Minimum Balances
 
-Validatorw can vote to change he base reserve — just as they can vote to change ledger limits and and the minimum base fee — but that's relatively uncommon.  It should only happen every few years. For the most part, you can think of the base reserve as a fixed value. When it is changed, the change works by the same consensus process as any transaction. For details, see [versioning](link).
+Validatorw can vote to change he base reserve — just as they can vote to change
+ledger limits and and the minimum base fee — but that's relatively uncommon. It
+should only happen every few years. For the most part, you can think of the base
+reserve as a fixed value. When it is changed, the change works by the same
+consensus process as any transaction. For details, see [versioning](link).

--- a/content/docs/glossary/network-passphrase.mdx
+++ b/content/docs/glossary/network-passphrase.mdx
@@ -3,36 +3,46 @@ title: Network Passphrase
 order:
 ---
 
-Stellar has two public networks: the Public Network (pubnet), which is the main network used by
-applications in production, and the Test Network ([testnet](test-net.mdx)), which is a network
-maintained by the Stellar Development Foundation that developers can use to test their
-Applications.
+Stellar has two public networks: the Public Network (pubnet), which is the main
+network used by applications in production, and the Test Network
+([testnet](test-net.mdx)), which is a network maintained by the Stellar
+Development Foundation that developers can use to test their Applications.
 
-Each Stellar network has its own unique passphrase, which is used when validating signatures on a given transaction. If you sign a transaction for one network but submit it to another, it won't be considered valid. By convention, the format of a passphrase is `'[Network Name] ; [Month of
-Creation] [Year of Creation]'`.
+Each Stellar network has its own unique passphrase, which is used when
+validating signatures on a given transaction. If you sign a transaction for one
+network but submit it to another, it won't be considered valid. By convention,
+the format of a passphrase is
+`'[Network Name] ; [Month of Creation] [Year of Creation]'`.
 
 The current passphrases for the Stellar pubnet and testnet are:
 
-* Pubnet: `'Public Global Stellar Network ; September 2015'`
-* Testnet: `'Test SDF Network ; September 2015'`
+- Pubnet: `'Public Global Stellar Network ; September 2015'`
+- Testnet: `'Test SDF Network ; September 2015'`
 
 The passphrase serves two main purposes:
 
-* It is used as the seed for the root account (master network key) at genesis.
-* It is used to build hashes of transactions, which are ultimately what is signed by each signer's
-  secret key in a transaction envelope. Again, this allows you to verify that a transaction was
-  intended for a specific network by its signers.
+- It is used as the seed for the root account (master network key) at genesis.
+- It is used to build hashes of transactions, which are ultimately what is
+  signed by each signer's secret key in a transaction envelope. Again, this
+  allows you to verify that a transaction was intended for a specific network by
+  its signers.
 
-Most SDKs have the passphrases hardcoded for the Stellar pubnet and testnet, but if you're running a private network, you'll need to manually pass in a passphrase to be used whenever transaction hashes are generated. All of Stellar's official SDKs give you the ability to use a network with a custom passphrase.
+Most SDKs have the passphrases hardcoded for the Stellar pubnet and testnet, but
+if you're running a private network, you'll need to manually pass in a
+passphrase to be used whenever transaction hashes are generated. All of
+Stellar's official SDKs give you the ability to use a network with a custom
+passphrase.
 
 ## Moving To Production
 
-When creating your application on top of the Stellar network, we recommend starting on the testnet, and migrate to pubnet after rigorous testing has proved it to be production ready (_we are talking about money here_).
+When creating your application on top of the Stellar network, we recommend
+starting on the testnet, and migrate to pubnet after rigorous testing has proved
+it to be production ready (_we are talking about money here_).
 
-For applications that don't rely on the state of a network (such as specific accounts needing to
-exist), moving to production is as simple as changing the network passphrase and
-ensuring your Horizon instance is connected to pubnet.
+For applications that don't rely on the state of a network (such as specific
+accounts needing to exist), moving to production is as simple as changing the
+network passphrase and ensuring your Horizon instance is connected to pubnet.
 
 If you've been running a stellar-core or Horizon instance against the test
-network, and want to switch to production, changing the passphrase will require both respective
-databases to be completely reinitialized. 
+network, and want to switch to production, changing the passphrase will require
+both respective databases to be completely reinitialized.

--- a/content/docs/glossary/operations.mdx
+++ b/content/docs/glossary/operations.mdx
@@ -1,13 +1,18 @@
 ---
 title: Operations
-order: 
+order:
 ---
 
-Operations are the bread and butter of Stellar: they’re the individual commands that mutate the ledger.  Transactions, which accounts sign and submit for inclusion in the ledger, are really just bundles of operations.  Transactions can, by definition, include anywhere from 1 to 100 operations.
+Operations are the bread and butter of Stellar: they’re the individual commands
+that mutate the ledger. Transactions, which accounts sign and submit for
+inclusion in the ledger, are really just bundles of operations. Transactions
+can, by definition, include anywhere from 1 to 100 operations.
 
-Network capacity, which is determined by validator vote, is measured in terms of operations/ledger.  Currently, it’s set to 1,000. 
+Network capacity, which is determined by validator vote, is measured in terms of
+operations/ledger. Currently, it’s set to 1,000.
 
 There are thirteen possible operation types:
+
 - [Create Account](./list-of-operations.md#create-account)
 - [Payment](./list-of-operations.md#payment)
 - [Path Payment Strict Send](./list-of-operations.md#path-payment-strict-send)
@@ -22,38 +27,52 @@ There are thirteen possible operation types:
 - [Manage Data](./list-of-operations.md#manage-data)
 - [Bump Sequence](./list-of-operations.md#bump-sequence)
 
-Operations are executed on behalf of the source account specified in the transaction, unless there is an override defined for the operation.
+Operations are executed on behalf of the source account specified in the
+transaction, unless there is an override defined for the operation.
 
 ## Thresholds
 
 Each operation falls under a specific threshold category: low, medium, or high.
 Thresholds define the level of privilege an operation needs in order to succeed.
 
-* Low Security:
-  * `AllowTrust`
-  * `BumpSequence`
-* Medium Security:
-  * Everything Else (`Payment`, `ChangeTrust`, etc.).
-* High Security:
-  * `AccountMerge`
-  * `SetOptions` (only when changing signers and the thresholds for each category).
+- Low Security:
+  - `AllowTrust`
+  - `BumpSequence`
+- Medium Security:
+  - Everything Else (`Payment`, `ChangeTrust`, etc.).
+- High Security:
+  - `AccountMerge`
+  - `SetOptions` (only when changing signers and the thresholds for each
+    category).
 
 ## Validity of an Operation
 
-When a transaction is submitted to a node, the node checks the validity of each operation in the transaction before attempting to include it in a candidate transaction set.  These initial operation validity checks are intended to be fast and simple: more intensive checks come later, after fees have been consumed. For an operation to pass this first validity check, it has to meet the following conditions:
+When a transaction is submitted to a node, the node checks the validity of each
+operation in the transaction before attempting to include it in a candidate
+transaction set. These initial operation validity checks are intended to be fast
+and simple: more intensive checks come later, after fees have been consumed. For
+an operation to pass this first validity check, it has to meet the following
+conditions:
 
-1. The signatures on the transaction must be valid for the operation. That means:
-   * The signatures are from valid signers for the source account of the operation.
-   * The combined weight of all signatures for the source account _of the operation_ meets the
-     threshold for the operation.
-2. The operation itself must be well formed. Typically this means checking the parameters for the operation to see if they're in a valid format.
-   * For example, only positive values can be set for the amount of a payment operation.
-3. The operation must be valid in the current protocol version of the network. Deprecated operations, such as inflation, are invalid by design. 
- 
-For more details on this process, see the [lifecycle of a transaction][tx-lifecycle].
+1. The signatures on the transaction must be valid for the operation. That
+   means:
+   - The signatures are from valid signers for the source account of the
+     operation.
+   - The combined weight of all signatures for the source account _of the
+     operation_ meets the threshold for the operation.
+2. The operation itself must be well formed. Typically this means checking the
+   parameters for the operation to see if they're in a valid format.
+   - For example, only positive values can be set for the amount of a payment
+     operation.
+3. The operation must be valid in the current protocol version of the network.
+   Deprecated operations, such as inflation, are invalid by design.
+
+For more details on this process, see the [lifecycle of a
+transaction][tx-lifecycle].
 
 ## Result
 
-For each operation, there is a matching result type. In the case of success, this result allows
-users to gather information about the effects of the operation. In the case of failure, it allows
-users to learn more about the error.
+For each operation, there is a matching result type. In the case of success,
+this result allows users to gather information about the effects of the
+operation. In the case of failure, it allows users to learn more about the
+error.

--- a/content/docs/glossary/testnet.mdx
+++ b/content/docs/glossary/testnet.mdx
@@ -3,80 +3,118 @@ title: Testnet
 order:
 ---
 
-The testnet is a small test Stellar network, run by the Stellar Development Foundation (SDF).  It's free to use, functions just like the main public network, and is the best place to start developing on Stellar since it doesn't connect to real money. 
+The testnet is a small test Stellar network, run by the Stellar Development
+Foundation (SDF). It's free to use, functions just like the main public network,
+and is the best place to start developing on Stellar since it doesn't connect to
+real money.
 
 SDF runs 3 Stellar Core validators on the testnet.
 
-You can connect a node to the testnet by configuring [stellar-core](https://github.com/stellar/stellar-core) to use this
+You can connect a node to the testnet by configuring
+[stellar-core](https://github.com/stellar/stellar-core) to use this
 [configuration](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_testnet.cfg).
 
-There is also a [Horizon instance](https://horizon-testnet.stellar.org/) that can directly interact with the testnet.
+There is also a [Horizon instance](https://horizon-testnet.stellar.org/) that
+can directly interact with the testnet.
 
 ## What is the Stellar testnet good for?
 
-* [Creating test accounts](../get-started/create-account.md) (with funding thanks to Friendbot).
-* Developing applications and exploring tutorials on Stellar without the
+- [Creating test accounts](../get-started/create-account.md) (with funding
+  thanks to Friendbot).
+- Developing applications and exploring tutorials on Stellar without the
   potential to lose any valuable [assets](assets.md).
-* Testing existing applications against new releases or release candidates of
-  [Stellar Core](https://github.com/stellar/stellar-core/releases) and [Horizon](https://github.com/stellar/go/releases).
-* Performing data analysis on a smaller, non-trivial data set compared to the public network.
+- Testing existing applications against new releases or release candidates of
+  [Stellar Core](https://github.com/stellar/stellar-core/releases) and
+  [Horizon](https://github.com/stellar/go/releases).
+- Performing data analysis on a smaller, non-trivial data set compared to the
+  public network.
 
 ## What is the Stellar testnet not good for?
 
-* Load and stress testing.
-  * If you want to test for performance, a good place to
-    start is
+- Load and stress testing.
+  - If you want to test for performance, a good place to start is
     [Stellar Core's core performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md#networks-to-test-against).
-* High availability test infrastructure - SDF makes no guarantees about the
+- High availability test infrastructure - SDF makes no guarantees about the
   availability of the testnet.
-* Long term storage of data on the network - [the network is ephemeral, and resets periodically](test-net.md#periodic-reset-of-testnet-data).
-* A testing infrastructure that requires more control over the test environment,
+- Long term storage of data on the network -
+  [the network is ephemeral, and resets periodically](test-net.md#periodic-reset-of-testnet-data).
+- A testing infrastructure that requires more control over the test environment,
   such as:
-  * The ability to control the data reset frequency.
-  * The need to secure private or sensitive data (before launching on the public network)
+  - The ability to control the data reset frequency.
+  - The need to secure private or sensitive data (before launching on the public
+    network)
 
-Keep in mind that you can always run your own test network for use cases that don't work well with SDF's testnet.
+Keep in mind that you can always run your own test network for use cases that
+don't work well with SDF's testnet.
 
 ## Best Practices For Using Testnet
 
 ### Surge Pricing on the Testnet
 
-The testnet has a capacity limit of **100 operations per ledger**.  When more than 100 operations are submitted to a given ledger, the network enters surge pricing mode, which uses market dynamics to decide which submissions are included.  It works exactly the same way as surge pricing on the public network.
+The testnet has a capacity limit of **100 operations per ledger**. When more
+than 100 operations are submitted to a given ledger, the network enters surge
+pricing mode, which uses market dynamics to decide which submissions are
+included. It works exactly the same way as surge pricing on the public network.
 
-If you are having trouble submitting transactions to the testnet, you may need to offer a higher fee.  You can also take the opportunity to develop a fee strategy, which may prove useful when you move your project into production.
+If you are having trouble submitting transactions to the testnet, you may need
+to offer a higher fee. You can also take the opportunity to develop a fee
+strategy, which may prove useful when you move your project into production.
 
 ### Periodic Reset of Testnet Data
 
-In order to preserve a good experience for developers, the SDF testnet is periodically reset to the genesis (initial) ledger. Resets declutter the network, remove spam, minimize the time required to catch up to the latest ledger, and help maintain the system over time.
+In order to preserve a good experience for developers, the SDF testnet is
+periodically reset to the genesis (initial) ledger. Resets declutter the
+network, remove spam, minimize the time required to catch up to the latest
+ledger, and help maintain the system over time.
 
-A reset clears all ledger entries (such as accounts, trustlines, offers, etc), transactions, and historical data from both Stellar Core and\ Horizon, which is why developers should not rely on the persistence of any accounts or on the state of any balances when using testnet.
+A reset clears all ledger entries (such as accounts, trustlines, offers, etc),
+transactions, and historical data from both Stellar Core and\ Horizon, which is
+why developers should not rely on the persistence of any accounts or on the
+state of any balances when using testnet.
 
-After a reset, you will need to take a few steps to re-join and re-synch to the testnet.  Those steps are outlined [here](https://github.com/stellar/packages#testnet-reset), along with line-by-line instructions for people using core + horizon ubuntu packages.  If you need help with other packages, check [Stellar's Stack Exchange](https://stellar.stackexchange.com/) for guidance.
+After a reset, you will need to take a few steps to re-join and re-synch to the
+testnet. Those steps are outlined
+[here](https://github.com/stellar/packages#testnet-reset), along with
+line-by-line instructions for people using core + horizon ubuntu packages. If
+you need help with other packages, check
+[Stellar's Stack Exchange](https://stellar.stackexchange.com/) for guidance.
 
-SDF will try to make testnet resets as painless as possible, and will announce the exact date at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/), and via several of Stellar’s online developer communities.
+SDF will try to make testnet resets as painless as possible, and will announce
+the exact date at least two weeks in advance on the
+[Stellar Dashboard](http://dashboard.stellar.org/), and via several of Stellar’s
+online developer communities.
 
-The testnet resets once per quarter (every three months).  The 2020 dates:
+The testnet resets once per quarter (every three months). The 2020 dates:
 
-* 1/29/20
-* 4/29/20
-* 7/29/20
-* 10/28/20
+- 1/29/20
+- 4/29/20
+- 7/29/20
+- 10/28/20
 
-The testnet will always restart on the announced reset date at 0900 UTC.  
+The testnet will always restart on the announced reset date at 0900 UTC.
 
 ### Test Data Automation
 
 Since most applications rely on data being present to do anything useful, it is
-highly recommended that you have testing infrastructure that can repopulate testnet with useful data after a reset. Not only will this make testing more reliable, but it will also help you scale out your testing infrastructure to a private test network if you choose to do so.
+highly recommended that you have testing infrastructure that can repopulate
+testnet with useful data after a reset. Not only will this make testing more
+reliable, but it will also help you scale out your testing infrastructure to a
+private test network if you choose to do so.
 
 For example, you may want to:
-* Generate issuers of assets for testing the development of a wallet.
-* Generate orders on the order book (both current and historical) for testing
+
+- Generate issuers of assets for testing the development of a wallet.
+- Generate orders on the order book (both current and historical) for testing
   the development of a trading client.
 
-As a maintainer of an application, you will want to think about creating a data set that is representative enough to test your primary use cases, and allow for robust testing even when testnet is not available.
+As a maintainer of an application, you will want to think about creating a data
+set that is representative enough to test your primary use cases, and allow for
+robust testing even when testnet is not available.
 
-A script can automate this entire process by [creating an account with Friendbot](../get-started/create-account.md), and submitting a set of transactions that are predefined as a part of your testing infrastructure.
+A script can automate this entire process by
+[creating an account with Friendbot](../get-started/create-account.md), and
+submitting a set of transactions that are predefined as a part of your testing
+infrastructure.
 
 For additional questions we recommend heading over to
 [Stellar's Stack Exchange](https://stellar.stackexchange.com/).

--- a/content/docs/glossary/transactions.mdx
+++ b/content/docs/glossary/transactions.mdx
@@ -3,7 +3,13 @@ title: Transactions
 order:
 ---
 
-Transactions are commands that modify the ledger state. They consist of a list of anywhere from 1 to 100 operations, and they are signed, submitted to the network, and considered for inclusion in the transaction set via SCP.  They contain the operations used to send payments, enter orders into the [distributed exchange](link), change settings on accounts, and authorize accounts to hold assets. If you think of the ledger as a database, then transactions are SQL commands.
+Transactions are commands that modify the ledger state. They consist of a list
+of anywhere from 1 to 100 operations, and they are signed, submitted to the
+network, and considered for inclusion in the transaction set via SCP. They
+contain the operations used to send payments, enter orders into the
+[distributed exchange](link), change settings on accounts, and authorize
+accounts to hold assets. If you think of the ledger as a database, then
+transactions are SQL commands.
 
 ## Transaction Attributes
 
@@ -11,71 +17,130 @@ Each transaction has the following attributes:
 
 ### Source Account
 
-The account that originates the transaction. This account also provides the fee and sequence number for the transaction.
+The account that originates the transaction. This account also provides the fee
+and sequence number for the transaction.
 
 ### Fee
 
-Each transaction incurs a fee, which is paid by the source account.  When you submit a transaction, you set the maximum that you are willing to pay per operation, but you’re charged the minimum fee possible based on network activity.  For more info, see [transaction fees](./transaction-fees.mdx)
+Each transaction incurs a fee, which is paid by the source account. When you
+submit a transaction, you set the maximum that you are willing to pay per
+operation, but you’re charged the minimum fee possible based on network
+activity. For more info, see [transaction fees](./transaction-fees.mdx)
 
 ### Sequence Number
 
-Each transaction has a sequence number associated with the source account. Transactions follow a strict ordering rule when it comes to processing transactions per account in order to prevent double-spending. When submitting a single transaction, you should submit a sequence number 1 greater than the current sequence number. For example, if the sequence number on the account is 4, then the incoming transaction should have a sequence number of 5.
+Each transaction has a sequence number associated with the source account.
+Transactions follow a strict ordering rule when it comes to processing
+transactions per account in order to prevent double-spending. When submitting a
+single transaction, you should submit a sequence number 1 greater than the
+current sequence number. For example, if the sequence number on the account is
+4, then the incoming transaction should have a sequence number of 5.
 
-However, if several transactions with the same source account make it into the same transaction set, they are ordered and applied according to sequence number. For example, if you submitted 3 transactions that shared the same source account and the account is currently at sequence number 5, the transactions must have sequence numbers 6, 7, and 8.
+However, if several transactions with the same source account make it into the
+same transaction set, they are ordered and applied according to sequence number.
+For example, if you submitted 3 transactions that shared the same source account
+and the account is currently at sequence number 5, the transactions must have
+sequence numbers 6, 7, and 8.
 
 ### List of Operations
 
-Transactions contain an arbitrary list of [operations](./operations.md) inside them. Typically there is just one operation, but it's possible to have multiple (up to 100).  Operations are executed in order as one ACID transaction, meaning that either all operations are applied or none are.  If any operation fails, the whole transaction fails. If operations are on accounts other than the source account, then they require signatures of the accounts in question.
+Transactions contain an arbitrary list of [operations](./operations.md) inside
+them. Typically there is just one operation, but it's possible to have multiple
+(up to 100). Operations are executed in order as one ACID transaction, meaning
+that either all operations are applied or none are. If any operation fails, the
+whole transaction fails. If operations are on accounts other than the source
+account, then they require signatures of the accounts in question.
 
 ### List of Signatures
 
-Up to 20 signatures can be attached to a transaction. See [Multi-sig](./multi-sig.md) for more information. A transaction is considered invalid if it includes signatures that aren't needed to authorize the transaction—superfluous signatures aren't allowed.
+Up to 20 signatures can be attached to a transaction. See
+[Multi-sig](./multi-sig.md) for more information. A transaction is considered
+invalid if it includes signatures that aren't needed to authorize the
+transaction—superfluous signatures aren't allowed.
 
-Signatures are required to authorize operations and to authorize changes to the source account (fee and sequence number).
+Signatures are required to authorize operations and to authorize changes to the
+source account (fee and sequence number).
 
 ### Memo
 
-The memo contains optional extra information. It is the responsibility of the client to interpret this value. Memos can be one of the following types:
-   - `MEMO_TEXT` : A string encoded using either ASCII or UTF-8, up to 28-bytes long.
-   - `MEMO_ID` :  A 64 bit unsigned integer.
-   - `MEMO_HASH` : A 32 byte hash.
-   - `MEMO_RETURN` : A 32 byte hash intended to be interpreted as the hash of the transaction the sender is refunding.
+The memo contains optional extra information. It is the responsibility of the
+client to interpret this value. Memos can be one of the following types:
+
+- `MEMO_TEXT` : A string encoded using either ASCII or UTF-8, up to 28-bytes
+  long.
+- `MEMO_ID` : A 64 bit unsigned integer.
+- `MEMO_HASH` : A 32 byte hash.
+- `MEMO_RETURN` : A 32 byte hash intended to be interpreted as the hash of the
+  transaction the sender is refunding.
 
 ### Time Bounds
 
-The optional UNIX timestamp (in seconds), determined by ledger time, of a lower and upper bound of when this transaction will be valid. If a transaction is submitted too early or too late, it will fail to make it into the transaction set. `maxTime` equal `0` means that it's not set. _We highly advise for all transactions to use time bounds, and many SDKs enforce their usage._ If a
-transaction doesn't make it into the transaction set, it is kept around in memory in order to be
-added to the next transaction set on a best effort basis. Because of this behavior, we highly
-advise that all transactions are created with time bounds in order to invalidate transactions
-after a certain amount of time, especially if you plan to resubmit your transaction at a later time.
+The optional UNIX timestamp (in seconds), determined by ledger time, of a lower
+and upper bound of when this transaction will be valid. If a transaction is
+submitted too early or too late, it will fail to make it into the transaction
+set. `maxTime` equal `0` means that it's not set. _We highly advise for all
+transactions to use time bounds, and many SDKs enforce their usage._ If a
+transaction doesn't make it into the transaction set, it is kept around in
+memory in order to be added to the next transaction set on a best effort basis.
+Because of this behavior, we highly advise that all transactions are created
+with time bounds in order to invalidate transactions after a certain amount of
+time, especially if you plan to resubmit your transaction at a later time.
 
 ## Transaction Envelopes
 
-Once a transaction is ready to be signed, the transaction object is wrapped in an object called a
-`Transaction Envelope`, which contains the transaction as well as a set of signatures. Most
-transaction envelopes only contain a single signature along with the transaction, but in
+Once a transaction is ready to be signed, the transaction object is wrapped in
+an object called a `Transaction Envelope`, which contains the transaction as
+well as a set of signatures. Most transaction envelopes only contain a single
+signature along with the transaction, but in
 [multi-signature setups](./multi-sig.md) it can contain many signatures.
 
-Ultimately, transaction envelopes are passed around the network and are included in transaction sets, as opposed to raw Transaction objects.
+Ultimately, transaction envelopes are passed around the network and are included
+in transaction sets, as opposed to raw Transaction objects.
 
-It's of note that each signer signs the hash of the transaction object in addition to the network
-passphrase. This is done to ensure that a given transaction can only be submitted to the intended network by its signers. For more information, see [Networks](./networks.md).
+It's of note that each signer signs the hash of the transaction object in
+addition to the network passphrase. This is done to ensure that a given
+transaction can only be submitted to the intended network by its signers. For
+more information, see [Networks](./networks.md).
+
 ## Validity of a Transaction
-To determine if a transaction is valid, many checks take place over the course of the transaction's lifecycle. The following conditions determine whether a transaction is valid:
 
-* **Source Account** — The source account must exist on the ledger.
-* **Fee** — The fee must be greater than or equal to the [network minimum fee](./fees.md) for the number of operations submitted as part of the transaction. Note that this does not guarantee that the transaction will be applied; it only guarantees that it is valid. In addition, the source account must be able to pay the fee specified. In the case where multiple transactions are submitted but only a subset of them can be paid for, they are checked for validity in order of sequence number.
-* **Sequence Number** — For the transaction to be valid, the sequence number
-  must be 1 greater than the sequence number stored in the source account [account
-  entry](./accounts.md) _when the transaction is applied_. This means when checking the validity of multiple transactions with the same source account in a candidate transaction set, they must all be valid transactions and their sequence numbers must be offset by 1 from each other. When it comes to apply time, they are ordered and applied according to their sequence number.
-  * For example, if your source account's sequence number is 5 and you submit 3 transactions, all transactions must be considered valid and their sequence numbers must be 6, 7, and 8 in order for any of them to make it into a candidate transaction set.
-* **List of Operations** — Each operation must pass all of the [validity checks for an
-  operation](./operations.md#validity-of-an-operation).
-* **List of Signatures** — In addition to meeting the signature requirements of each operation in the transaction, the following requirements must be met for the transaction:
-  * The appropriate network passphrase was part of the transaction hash that was signed by each of the signers. See [Networks](./networks.md) for more on network passphrases.
-  * The combined weight of all signatures for the source account _of the transaction_ meets
-    the low threshold for the source account. This is necessary in order for fees to be taken and
-    the sequence number to be incremented later in the transaction lifecycle.
-* **Memo** — The memo type must be a valid type, and the memo itself must be adhere to the formatting of the memo type.
-* **Time Bounds** — The transaction must be submitted within the set time bounds of the
-  transaction, otherwise it will be considered invalid.
+To determine if a transaction is valid, many checks take place over the course
+of the transaction's lifecycle. The following conditions determine whether a
+transaction is valid:
+
+- **Source Account** — The source account must exist on the ledger.
+- **Fee** — The fee must be greater than or equal to the
+  [network minimum fee](./fees.md) for the number of operations submitted as
+  part of the transaction. Note that this does not guarantee that the
+  transaction will be applied; it only guarantees that it is valid. In addition,
+  the source account must be able to pay the fee specified. In the case where
+  multiple transactions are submitted but only a subset of them can be paid for,
+  they are checked for validity in order of sequence number.
+- **Sequence Number** — For the transaction to be valid, the sequence number
+  must be 1 greater than the sequence number stored in the source account
+  [account entry](./accounts.md) _when the transaction is applied_. This means
+  when checking the validity of multiple transactions with the same source
+  account in a candidate transaction set, they must all be valid transactions
+  and their sequence numbers must be offset by 1 from each other. When it comes
+  to apply time, they are ordered and applied according to their sequence
+  number.
+  - For example, if your source account's sequence number is 5 and you submit 3
+    transactions, all transactions must be considered valid and their sequence
+    numbers must be 6, 7, and 8 in order for any of them to make it into a
+    candidate transaction set.
+- **List of Operations** — Each operation must pass all of the
+  [validity checks for an operation](./operations.md#validity-of-an-operation).
+- **List of Signatures** — In addition to meeting the signature requirements of
+  each operation in the transaction, the following requirements must be met for
+  the transaction:
+  - The appropriate network passphrase was part of the transaction hash that was
+    signed by each of the signers. See [Networks](./networks.md) for more on
+    network passphrases.
+  - The combined weight of all signatures for the source account _of the
+    transaction_ meets the low threshold for the source account. This is
+    necessary in order for fees to be taken and the sequence number to be
+    incremented later in the transaction lifecycle.
+- **Memo** — The memo type must be a valid type, and the memo itself must be
+  adhere to the formatting of the memo type.
+- **Time Bounds** — The transaction must be submitted within the set time bounds
+  of the transaction, otherwise it will be considered invalid.

--- a/content/docs/glossary/versioning.mdx
+++ b/content/docs/glossary/versioning.mdx
@@ -5,42 +5,56 @@ order:
 
 import { CodeExample } from "components/CodeExample";
 
-This document describes the various mechanisms used to keep the overall system working as it evolves.
+This document describes the various mechanisms used to keep the overall system
+working as it evolves.
 
 ## Ledger versioning
 
 ### ledgerVersion
 
-This uint32 stored in the ledger header describes the version number of the overall protocol.
-Protocol in this case is defined both as "wire format"--i.e., the serialized forms of all objects stored in the ledger--and its behavior.
+This uint32 stored in the ledger header describes the version number of the
+overall protocol. Protocol in this case is defined both as "wire format"--i.e.,
+the serialized forms of all objects stored in the ledger--and its behavior.
 
 This version number is incremented every time the protocol changes.
 
 ### Integration with consensus
 
-Most of the time, consensus is simply reached on which transaction set needs to be applied to the previous ledger.
+Most of the time, consensus is simply reached on which transaction set needs to
+be applied to the previous ledger.
 
 Consensus can also, however, be reached on upgrade steps.
 
 One such upgrade step is "update ledgerVersion to value X after ledger N".
 
-If nodes do not consider that the upgrade step is valid, they simply drop the upgrade step from their vote.
+If nodes do not consider that the upgrade step is valid, they simply drop the
+upgrade step from their vote.
 
-A node considers a step invalid either because they do not understand it or some condition is not met. In the previous example, it could be that X is not supported by the node or that the ledger number didn't reach N yet.
+A node considers a step invalid either because they do not understand it or some
+condition is not met. In the previous example, it could be that X is not
+supported by the node or that the ledger number didn't reach N yet.
 
-Upgrade steps are applied before applying the transaction set to ensure that the logic scheduling steps is the same that is processing it. Otherwise, the steps would have to be applied after the ledger is closed.
+Upgrade steps are applied before applying the transaction set to ensure that the
+logic scheduling steps is the same that is processing it. Otherwise, the steps
+would have to be applied after the ledger is closed.
 
 ### Supported versions
 
-Each node has its own way of tracking which version it supports--for example, a "min version", "max version"--but it can also include things like "black listed versions." Supported versions are not tracked from within the protocol.
+Each node has its own way of tracking which version it supports--for example, a
+"min version", "max version"--but it can also include things like "black listed
+versions." Supported versions are not tracked from within the protocol.
 
-Note that minProtocolVersion is distinct from the version an instance understands:
-typically an implementation understands versions n .. maxProtocolVersion, where n <= minProtocolVersion.
-The reason for this is that nodes must be able to replay transactions from history (down to version 'n'), yet there might be some issue/vulnerability that we don't want to be exploitable for new transactions.
+Note that minProtocolVersion is distinct from the version an instance
+understands: typically an implementation understands versions n ..
+maxProtocolVersion, where n <= minProtocolVersion. The reason for this is that
+nodes must be able to replay transactions from history (down to version 'n'),
+yet there might be some issue/vulnerability that we don't want to be exploitable
+for new transactions.
 
 ### Ledger object versioning
 
-Data structures that are likely to evolve over time contain the following extension point:
+Data structures that are likely to evolve over time contain the following
+extension point:
 
 <CodeExample>
 
@@ -54,20 +68,31 @@ case 0:
 
 </CodeExample>
 
-In this case, the version 'v' refers to the version of the object and permits the addition of new arms.
+In this case, the version 'v' refers to the version of the object and permits
+the addition of new arms.
 
 This scheme offers several benefits:
-* Implementations become wire compatible without code changes only by updating their protocol definition files.
-* Even without updating the protocol definition files, older implementations continue to function as long as they don't encounter newer formats.
-* It promotes code sharing between versions of the objects.
 
-Note that while this scheme promotes code sharing for components consuming those objects, code sharing is not necessarily promoted for stellar-core itself because the behavior must be preserved for all versions: In order to reconstruct the ledger chain from arbitrary points in time, the behavior must be 100% compatible.
+- Implementations become wire compatible without code changes only by updating
+  their protocol definition files.
+- Even without updating the protocol definition files, older implementations
+  continue to function as long as they don't encounter newer formats.
+- It promotes code sharing between versions of the objects.
+
+Note that while this scheme promotes code sharing for components consuming those
+objects, code sharing is not necessarily promoted for stellar-core itself
+because the behavior must be preserved for all versions: In order to reconstruct
+the ledger chain from arbitrary points in time, the behavior must be 100%
+compatible.
 
 ### Operations versioning
-Operations are versioned as a whole: If a new parameter needs to be added or changed, versioning is achieved by adding a new operation.
-This causes some duplication of logic in clients but avoids introducing potential bugs. For example, code that would sign only certain types of transactions must be fully aware of what it's signing.
-Envelope versioning
-Pattern used to allow for extensibility of envelopes (signed content):
+
+Operations are versioned as a whole: If a new parameter needs to be added or
+changed, versioning is achieved by adding a new operation. This causes some
+duplication of logic in clients but avoids introducing potential bugs. For
+example, code that would sign only certain types of transactions must be fully
+aware of what it's signing. Envelope versioning Pattern used to allow for
+extensibility of envelopes (signed content):
 
 <CodeExample>
 
@@ -85,26 +110,43 @@ case 0:
 
 </CodeExample>
 
-This pattern allows the capability to modify the envelope if needed and ensures that clients don't blindly consume content that they couldn't validate.
-Upgrading objects that don't have an extension point
-The object's schema must be cloned and its parent object must be updated to use the new object type. The assumption here is that there is no unversioned "root" object.
-Supported implementations lifetime considerations
-In order to keep the codebase in a maintainable state, implementations may not preserve the ability to play back from genesis. Instead they may opt to support a limited range--for example, only preserve the capability to replay the previous 3 months of transactions (assuming that the network's minProtocolVersion is more recent than that).
+This pattern allows the capability to modify the envelope if needed and ensures
+that clients don't blindly consume content that they couldn't validate.
+Upgrading objects that don't have an extension point The object's schema must be
+cloned and its parent object must be updated to use the new object type. The
+assumption here is that there is no unversioned "root" object. Supported
+implementations lifetime considerations In order to keep the codebase in a
+maintainable state, implementations may not preserve the ability to play back
+from genesis. Instead they may opt to support a limited range--for example, only
+preserve the capability to replay the previous 3 months of transactions
+(assuming that the network's minProtocolVersion is more recent than that).
 
-This does not change the ability of the node to (re)join or participate in the network; it only affects the ability for a node to do historical validation.
+This does not change the ability of the node to (re)join or participate in the
+network; it only affects the ability for a node to do historical validation.
 
 ## Overlay versioning
 
-Overlay follows a similar pattern for versioning: It has a min-maxOverlayVersion.
+Overlay follows a similar pattern for versioning: It has a
+min-maxOverlayVersion.
 
-The versioning policy at the overlay layer is a lot more aggressive when it comes to the deprecation schedule; the set of nodes involved is limited to the ones that connect directly to the instance.
+The versioning policy at the overlay layer is a lot more aggressive when it
+comes to the deprecation schedule; the set of nodes involved is limited to the
+ones that connect directly to the instance.
 
-With this in mind, structures follow the "clone" model at this layer: if a message needs to be modified, a new message is defined by cloning the old message type using a new type identifier.
+With this in mind, structures follow the "clone" model at this layer: if a
+message needs to be modified, a new message is defined by cloning the old
+message type using a new type identifier.
 
-Knowing that the older implementation will be deleted anyway, the clone model makes it possible to refactor large parts of the code and avoids the headache of maintaining older versions.
+Knowing that the older implementation will be deleted anyway, the clone model
+makes it possible to refactor large parts of the code and avoids the headache of
+maintaining older versions.
 
-At this layer, it's acceptable to modify the behavior of older versions as long as it stays compatible.
+At this layer, it's acceptable to modify the behavior of older versions as long
+as it stays compatible.
 
-The implementation may decide to share the underlying code--for example, by converting legacy messages into the new format internally.
+The implementation may decide to share the underlying code--for example, by
+converting legacy messages into the new format internally.
 
-The "HELLO" message exchanged when peers connect to each other contains the min and max version the instance supports. The other endpoint may decide to disconnect right away if it's not compatible.
+The "HELLO" message exchanged when peers connect to each other contains the min
+and max version the instance supports. The other endpoint may decide to
+disconnect right away if it's not compatible.

--- a/content/docs/glossary/xdr.mdx
+++ b/content/docs/glossary/xdr.mdx
@@ -3,20 +3,33 @@ title: XDR
 order:
 ---
 
-**XDR**, also known as _External Data Representation_, is used throughout the Stellar network and protocol.  The ledger, transactions, results, history, and even the messages passed between computers running stellar-core are encoded using XDR.
+**XDR**, also known as _External Data Representation_, is used throughout the
+Stellar network and protocol. The ledger, transactions, results, history, and
+even the messages passed between computers running stellar-core are encoded
+using XDR.
 
-XDR is specified in [RFC 4506](http://tools.ietf.org/html/rfc4506.html) and is similar to tools like Protocol Buffers or Thrift. XDR provides a few important features:
+XDR is specified in [RFC 4506](http://tools.ietf.org/html/rfc4506.html) and is
+similar to tools like Protocol Buffers or Thrift. XDR provides a few important
+features:
 
-- It is very compact, so it can be transmitted quickly and stored with minimal disk space.
-- Data encoded in XDR is reliably and predictably stored. Fields are always in the same order, which makes cryptographically signing and verifying XDR messages simple.
-- XDR definitions include rich descriptions of data types and structures, which is not possible in simpler formats like JSON, TOML, or YAML.
+- It is very compact, so it can be transmitted quickly and stored with minimal
+  disk space.
+- Data encoded in XDR is reliably and predictably stored. Fields are always in
+  the same order, which makes cryptographically signing and verifying XDR
+  messages simple.
+- XDR definitions include rich descriptions of data types and structures, which
+  is not possible in simpler formats like JSON, TOML, or YAML.
 
 ## Parsing XDR
 
-Since XDR is a binary format and not as widely known as simpler formats like JSON, the Stellar SDKs all include tools for parsing XDR and will do so automatically when retrieving data.
+Since XDR is a binary format and not as widely known as simpler formats like
+JSON, the Stellar SDKs all include tools for parsing XDR and will do so
+automatically when retrieving data.
 
-In addition, the Horizon API server generally exposes the most important parts of the XDR data in JSON, so they are easier to parse if you are not using an SDK. The XDR data is still included (encoded as a base64 string) inside the JSON in case you need direct access to it.
-.X files
+In addition, the Horizon API server generally exposes the most important parts
+of the XDR data in JSON, so they are easier to parse if you are not using an
+SDK. The XDR data is still included (encoded as a base64 string) inside the JSON
+in case you need direct access to it. .X files
 
 Data structures in XDR are specified in an _interface definition file_ (IDL).
 The IDL files used for the Stellar Network are available

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -5,37 +5,93 @@ order: -100
 
 import { CodeExample } from "components/CodeExample";
 
-Right now, you're looking at the **new Stellar docs**, which are a work in progress.  These new docs will live alongside the [existing Stellar docs](https://www.stellar.org/developers/guides/) until we complete the content, do some polish passes, root out and squash any bugs in the interface, and get feedback from the SDF and the Stellar community at large.
+Right now, you're looking at the **new Stellar docs**, which are a work in
+progress. These new docs will live alongside the
+[existing Stellar docs](https://www.stellar.org/developers/guides/) until we
+complete the content, do some polish passes, root out and squash any bugs in the
+interface, and get feedback from the SDF and the Stellar community at large.
 
-The goal is to keep everything good from the existing docs but to streamline the navigation, improve the looks, and update the content to better reflect where things stand now.  These new docs are also more modular — they're organized around different learning paths —  and the plan is to add new paths as network use cases evolve. 
+The goal is to keep everything good from the existing docs but to streamline the
+navigation, improve the looks, and update the content to better reflect where
+things stand now. These new docs are also more modular — they're organized
+around different learning paths — and the plan is to add new paths as network
+use cases evolve.
 
-As you read through these new docs, you will likely find bugs, errors, typos, or omissions.  When you do, please file PRs or issues in this repo or make a report using [this typeform survey](https://stellarform.typeform.com/to/suEIZI).
+As you read through these new docs, you will likely find bugs, errors, typos, or
+omissions. When you do, please file PRs or issues in this repo or make a report
+using [this typeform survey](https://stellarform.typeform.com/to/suEIZI).
 
-In addition to the docs here, which are guides to building on Stellar, you'll also see a link at the bottom of the left nav to the API Reference.  You should check those out, too: that's a resource most developers consult as they build on Stellar.
+In addition to the docs here, which are guides to building on Stellar, you'll
+also see a link at the bottom of the left nav to the API Reference. You should
+check those out, too: that's a resource most developers consult as they build on
+Stellar.
 
 A rundown of what's here:
 
 ## [Tutorials](./tutorials/create-account.mdx)
-If you’re new to Stellar and want to get an overview of the network, this is where to start.  The early tutorials will show you how to do some basic things like create an account and make payments.  The later tutorials cover more advanced topics like Stellar smart contracts.  If you want to issue an asset or build an app, you're better served checking the sections dedicated to those paths.
+
+If you’re new to Stellar and want to get an overview of the network, this is
+where to start. The early tutorials will show you how to do some basic things
+like create an account and make payments. The later tutorials cover more
+advanced topics like Stellar smart contracts. If you want to issue an asset or
+build an app, you're better served checking the sections dedicated to those
+paths.
 
 ## [Issue Assets](./issuing-assets/index.mdx)
-Stellar is a multi-currency network by design.  The ability to issue assets is fundamental to Stellar, and it's something you can do quickly, safely, and in a few lines of code.  Once you've issued an asset, you can also publish canonical information about it for wallets and consumers, control access to it by setting simple flags, and make it available for trade on the Stellar decentralized exchange.  This section will show you how. 
+
+Stellar is a multi-currency network by design. The ability to issue assets is
+fundamental to Stellar, and it's something you can do quickly, safely, and in a
+few lines of code. Once you've issued an asset, you can also publish canonical
+information about it for wallets and consumers, control access to it by setting
+simple flags, and make it available for trade on the Stellar decentralized
+exchange. This section will show you how.
 
 ## [Enable Deposit and Withdrawal](./enabling-deposit-and-withdrawal/index.mdx)
-Many Stellar assets represent real-world currencies such as dollars, euros, or naira.  Companies that accept deposits and honor withdrawals of those currencies — **anchors** in Stellar terminology — set up standard infrastructure connecting Stellar to banking rails so Stellar interfaces can initiate transactions on behalf of users.  If you want to set up an on/off ramp that interoperates with Stellar wallets, this section is for you.  
+
+Many Stellar assets represent real-world currencies such as dollars, euros, or
+naira. Companies that accept deposits and honor withdrawals of those currencies
+— **anchors** in Stellar terminology — set up standard infrastructure connecting
+Stellar to banking rails so Stellar interfaces can initiate transactions on
+behalf of users. If you want to set up an on/off ramp that interoperates with
+Stellar wallets, this section is for you.
 
 ## [Build Apps](./building-apps/index.mdx)
-Stellar is a self-serve distributed ledger that you can use as a backend to power all kinds of apps and services.  Any app built on Stellar relies on the same basic functions: key storage, account creation, transaction signing, and queries to the Stellar database. This section of the docs will walk you through the process of building a basic wallet that does all those things, and will show you how to add features to it like the support for in-app deposits and withdrawals from anchors.
+
+Stellar is a self-serve distributed ledger that you can use as a backend to
+power all kinds of apps and services. Any app built on Stellar relies on the
+same basic functions: key storage, account creation, transaction signing, and
+queries to the Stellar database. This section of the docs will walk you through
+the process of building a basic wallet that does all those things, and will show
+you how to add features to it like the support for in-app deposits and
+withdrawals from anchors.
 
 ## [Run a Core Node](./run-core-node/index.mdx)
-This section explains the technical and operational aspects of installing, configuring, and maintaining a Stellar Core node, which is a server that connects to the Stellar peer-to-peer network to keep a common distributed ledger.  You don’t have to run a node to get started on Stellar, but you will likely want to if you're in production, need high-availability access network, or want to help increase network health and decentralization.  
+
+This section explains the technical and operational aspects of installing,
+configuring, and maintaining a Stellar Core node, which is a server that
+connects to the Stellar peer-to-peer network to keep a common distributed
+ledger. You don’t have to run a node to get started on Stellar, but you will
+likely want to if you're in production, need high-availability access network,
+or want to help increase network health and decentralization.
 
 ## [Run an API Server](./run-api-server/index.mdx)
-Most developers access the network using Horizon, the Stellar API.  It takes the performance-oriented data structures from Stellar Core and converts them into a friendlier format.  If you're running your own Stellar Core node and using it to submit transactions or get network data, you will likely also want to run your own Horizon instance, and this section will show you how.  If you're just looking to use Horizon (vs. setting up a Horizon server), consult the API Reference.
+
+Most developers access the network using Horizon, the Stellar API. It takes the
+performance-oriented data structures from Stellar Core and converts them into a
+friendlier format. If you're running your own Stellar Core node and using it to
+submit transactions or get network data, you will likely also want to run your
+own Horizon instance, and this section will show you how. If you're just looking
+to use Horizon (vs. setting up a Horizon server), consult the API Reference.
 
 ## [Software and SDKs](./software-and-sdks/index.mdx)
-This is where you'll find all the Stellar SDKs.  There are a lot of them, and they're all pretty well maintained and documented, so you should be able to build on Stellar in your language of choice.  This section is also home to some tools and reference implementations created and maintained by the Stellar Development Foundation to kickstart development.
+
+This is where you'll find all the Stellar SDKs. There are a lot of them, and
+they're all pretty well maintained and documented, so you should be able to
+build on Stellar in your language of choice. This section is also home to some
+tools and reference implementations created and maintained by the Stellar
+Development Foundation to kickstart development.
 
 ## [Glossary](./glossary/accounts.mdx)
-This section defines all the terms and explains all the concepts germane to Stellar.  Use it to look up a word, or to dig deeper into nitty-gritty details.
 
+This section defines all the terms and explains all the concepts germane to
+Stellar. Use it to look up a word, or to dig deeper into nitty-gritty details.

--- a/content/docs/issuing-assets/anatomy-of-an-asset.mdx
+++ b/content/docs/issuing-assets/anatomy-of-an-asset.mdx
@@ -5,34 +5,74 @@ order: 15
 
 import { CodeExample } from "components/CodeExample";
 
-Each Stellar asset has two characteristics: the asset code and the issuer. When you look up or interact with an asset on Stellar, you always use both to identify it.
+Each Stellar asset has two characteristics: the asset code and the issuer. When
+you look up or interact with an asset on Stellar, you always use both to
+identify it.
 
-Many Stellar tokens represent credits that can be redeemed for something outside the network—often fiat currency, but also bonds, carbon credits, gold, etc.—and since more than one organization can issue a credit representing the same underlying asset, asset codes often overlap. More than one company offers a USD token on Stellar, for instance.
+Many Stellar tokens represent credits that can be redeemed for something outside
+the network—often fiat currency, but also bonds, carbon credits, gold, etc.—and
+since more than one organization can issue a credit representing the same
+underlying asset, asset codes often overlap. More than one company offers a USD
+token on Stellar, for instance.
 
-However, the combination of asset code and issuer allows each asset to be uniquely identified: each USD token is offered by, and redeemable with, one specific issuer.
+However, the combination of asset code and issuer allows each asset to be
+uniquely identified: each USD token is offered by, and redeemable with, one
+specific issuer.
 
 ## Asset Code
 
-When you issue an asset, the first thing you do is choose an identifying code. Currently, there are two supported formats.
+When you issue an asset, the first thing you do is choose an identifying code.
+Currently, there are two supported formats.
 
-- **Alphanumeric 4-character maximum**: Any characters from the set [a-z]\[A-Z\][0-9] are allowed. The code can be shorter than 4 characters, but the trailing characters must all be empty.
-- **Alphanumeric 12-character maximum**: Any characters from the set [a-z]\[A-Z\][0-9] are allowed. The code can be any number of characters from 5 to 12, but the trailing characters must all be empty.
+- **Alphanumeric 4-character maximum**: Any characters from the set
+  [a-z]\[A-Z\][0-9] are allowed. The code can be shorter than 4 characters, but
+  the trailing characters must all be empty.
+- **Alphanumeric 12-character maximum**: Any characters from the set
+  [a-z]\[A-Z\][0-9] are allowed. The code can be any number of characters from 5
+  to 12, but the trailing characters must all be empty.
 
-Provided it falls into one of those two buckets, you can choose any asset code you like. That said, if you’re issuing a currency, you should use the appropriate [ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217), and if you’re issuing a stock or bond, the appropriate [ISIN number](https://en.wikipedia.org/wiki/International_Securities_Identification_Number). Doing so makes it easier for Stellar interfaces to properly display and sort your token in their listings, and allows potential token holders to understand, at a glance, what your token represents.
+Provided it falls into one of those two buckets, you can choose any asset code
+you like. That said, if you’re issuing a currency, you should use the
+appropriate [ISO 4217 code](https://en.wikipedia.org/wiki/ISO_4217), and if
+you’re issuing a stock or bond, the appropriate
+[ISIN number](https://en.wikipedia.org/wiki/International_Securities_Identification_Number).
+Doing so makes it easier for Stellar interfaces to properly display and sort
+your token in their listings, and allows potential token holders to understand,
+at a glance, what your token represents.
 
 ## Issuer
 
-There is no dedicated operation to create an asset on Stellar. Instead, assets are created with a payment operation: an issuing account makes a payment using the asset it’s issuing, and that payment actually creates the asset on the network.
+There is no dedicated operation to create an asset on Stellar. Instead, assets
+are created with a payment operation: an issuing account makes a payment using
+the asset it’s issuing, and that payment actually creates the asset on the
+network.
 
-The public key of the issuing account is linked on the ledger to the asset itself. Responsibility for and control over an asset resides with the issuing account, and since settings are stored at the account level on the ledger, the issuing account is where you use `set_options` operations to link to meta-information about an asset and set authorization flags.
+The public key of the issuing account is linked on the ledger to the asset
+itself. Responsibility for and control over an asset resides with the issuing
+account, and since settings are stored at the account level on the ledger, the
+issuing account is where you use `set_options` operations to link to
+meta-information about an asset and set authorization flags.
 
 ## Trustlines
 
-Before an account can hold an asset another account issues, it has to establish something called a trustline, which is a persistent account-level ledger entry created with a `change_trust` operation.
+Before an account can hold an asset another account issues, it has to establish
+something called a trustline, which is a persistent account-level ledger entry
+created with a `change_trust` operation.
 
-A trustline is an explicit opt-in to hold a particular token, so it specifies both asset code and issuer. Each trustline increases an account’s minimum lumen balance by one [base reserve](../glossary/minimum-balance.mdx) — currently 0.5 XLM — and tracks the balance of the asset the account holds. Trustlines can also limit the amount of an asset an account can hold, though more often than not, account holders don’t set that limit: they simply turn the trustline on, which by default allows the maximum.
+A trustline is an explicit opt-in to hold a particular token, so it specifies
+both asset code and issuer. Each trustline increases an account’s minimum lumen
+balance by one [base reserve](../glossary/minimum-balance.mdx) — currently 0.5
+XLM — and tracks the balance of the asset the account holds. Trustlines can also
+limit the amount of an asset an account can hold, though more often than not,
+account holders don’t set that limit: they simply turn the trustline on, which
+by default allows the maximum.
 
-A trustline also tracks liabilities. Buying liabilities equal the total amount of the asset offered to buy aggregated over all offers owned by an account, and selling liabilities equal the total amount of the asset offered to sell aggregated over all offers owned by an account. A trustline must always have balance sufficiently large to satisfy its selling liabilities, and a balance sufficiently below its limit to accommodate its buying liabilities.
+A trustline also tracks liabilities. Buying liabilities equal the total amount
+of the asset offered to buy aggregated over all offers owned by an account, and
+selling liabilities equal the total amount of the asset offered to sell
+aggregated over all offers owned by an account. A trustline must always have
+balance sufficiently large to satisfy its selling liabilities, and a balance
+sufficiently below its limit to accommodate its buying liabilities.
 
 ## Representation
 
@@ -73,17 +113,37 @@ Asset astroDollar = Asset.createNonNativeAsset("AstroDollar", issuer);
 
 ## Amount Precision
 
-Each asset amount is encoded as a signed 64-bit integer in the [XDR structures](../glossary/xdr.mdx) that Stellar uses to encode transactions. The asset amount unit seen by end users is scaled down by a factor of ten million (10,000,000) to arrive at the native 64-bit integer representation.
+Each asset amount is encoded as a signed 64-bit integer in the
+[XDR structures](../glossary/xdr.mdx) that Stellar uses to encode transactions.
+The asset amount unit seen by end users is scaled down by a factor of ten
+million (10,000,000) to arrive at the native 64-bit integer representation.
 
-For example, the integer amount value `25,123,456` equals `2.5123456` units of the asset. This scaling allows for seven decimal places of precision in human-friendly amount units.
+For example, the integer amount value `25,123,456` equals `2.5123456` units of
+the asset. This scaling allows for seven decimal places of precision in
+human-friendly amount units.
 
-The smallest non-zero amount unit is `0.0000001` (one ten-millionth) represented as an integer value of one. The largest amount unit possible is `((2^63)-1)/(10^7)` (derived from max int64 scaled down) which is `922,337,203,685.4775807`.
+The smallest non-zero amount unit is `0.0000001` (one ten-millionth) represented
+as an integer value of one. The largest amount unit possible is
+`((2^63)-1)/(10^7)` (derived from max int64 scaled down) which is
+`922,337,203,685.4775807`.
 
-The numbers are represented as `int64`s. Amount values are stored as only signed integers to avoid bugs that arise from mixing signed and unsigned integers. 
+The numbers are represented as `int64`s. Amount values are stored as only signed
+integers to avoid bugs that arise from mixing signed and unsigned integers.
 
-## Relevance in Horizon and Stellar Client Libraries 
-In Horizon and client-side libraries such as `js-stellar-sdk`, the integer encoded value is abstracted away. Many APIs expect an amount in unit value (the scaled-up amount displayed to end users). Some programming languages (such as JavaScript) have problems with maintaining precision on a number amount. It is recommended to use "big number" libraries that can record arbitrary precision decimal numbers without a loss of precision.
+## Relevance in Horizon and Stellar Client Libraries
+
+In Horizon and client-side libraries such as `js-stellar-sdk`, the integer
+encoded value is abstracted away. Many APIs expect an amount in unit value (the
+scaled-up amount displayed to end users). Some programming languages (such as
+JavaScript) have problems with maintaining precision on a number amount. It is
+recommended to use "big number" libraries that can record arbitrary precision
+decimal numbers without a loss of precision.
 
 ## Lumens (XLM)
 
-Lumens (XLM) are the native currency of the Stellar network, and are the only asset that doesn't require an issuer or a trustline. Every account is required to hold a [minimum lumen balance](../glossary/minimum-balance.mdx), and all [transaction fees](../glossary/fees.mdx) are paid in lumens. The smallest unit of a lumen is a stroop, which is one ten-millionth of a lumen.  For more on lumens, check out the [Stellar.org explainer](https://www.stellar.org/lumens).
+Lumens (XLM) are the native currency of the Stellar network, and are the only
+asset that doesn't require an issuer or a trustline. Every account is required
+to hold a [minimum lumen balance](../glossary/minimum-balance.mdx), and all
+[transaction fees](../glossary/fees.mdx) are paid in lumens. The smallest unit
+of a lumen is a stroop, which is one ten-millionth of a lumen. For more on
+lumens, check out the [Stellar.org explainer](https://www.stellar.org/lumens).

--- a/content/docs/issuing-assets/control-asset-access.mdx
+++ b/content/docs/issuing-assets/control-asset-access.mdx
@@ -7,32 +7,64 @@ import { CodeExample } from "components/CodeExample";
 
 ## High-level view of authorization flags
 
-When you issue an asset on Stellar, anyone can hold it by default.  In general, that’s a good thing: easy access means better reach and better liquidity, and most of the time, issuers with KYC requirements can handle those when an asset moves onto or off of the network.  Most fiat-backed token issuers, for instance, use the transfer server protocol specified in SEP-24 to decide whether to honor deposits and withdrawals rather than setting account-level flags.  You can read about how to do that in the [Enable Deposit and Withdrawal](../enabling-deposit-and-withdrawal/index.mdx) section.      
+When you issue an asset on Stellar, anyone can hold it by default. In general,
+that’s a good thing: easy access means better reach and better liquidity, and
+most of the time, issuers with KYC requirements can handle those when an asset
+moves onto or off of the network. Most fiat-backed token issuers, for instance,
+use the transfer server protocol specified in SEP-24 to decide whether to honor
+deposits and withdrawals rather than setting account-level flags. You can read
+about how to do that in the
+[Enable Deposit and Withdrawal](../enabling-deposit-and-withdrawal/index.mdx)
+section.
 
-However, if you need to control access to an asset to comply with regulations (or for any other reason), you can easily do so by enabling flags on your issuing account. 
+However, if you need to control access to an asset to comply with regulations
+(or for any other reason), you can easily do so by enabling flags on your
+issuing account.
 
-There are three possible flags, and they are created on the *account level* using a `set_options` operation.  They can be set at any time in the life cycle of an asset, not just when you issue it:
+There are three possible flags, and they are created on the _account level_
+using a `set_options` operation. They can be set at any time in the life cycle
+of an asset, not just when you issue it:
 
-### Authorization Required 
+### Authorization Required
 
-When `auth_required` is enabled, an issuer must approve an account before that account can hold its asset.  This setting allows issuers to vet a potential token holders using whatever means they see fit, and to approve trustlines if and only if the holders pass muster. To allow access, the user creates a trustline, and the issuer approves it by setting the `Authorize` flag to **true** with the `allow_trust` operation.
+When `auth_required` is enabled, an issuer must approve an account before that
+account can hold its asset. This setting allows issuers to vet a potential token
+holders using whatever means they see fit, and to approve trustlines if and only
+if the holders pass muster. To allow access, the user creates a trustline, and
+the issuer approves it by setting the `Authorize` flag to **true** with the
+`allow_trust` operation.
 
-### Authorization Revocable 
+### Authorization Revocable
 
-When `auth_revocable` is enabled, an issuer can set the `Authorize` flag of an existing trustline to `false` with the `allow_trust` operation, thereby freezing the asset held by an account.  Doing so means that account can no longer trade or transfer the asset.  It can’t even send the asset back to the issuer. Revoking authorization also cancels an account’s open orders for an asset.  This setting allows the issuing account to revoke assets that it accidentally issued or that were obtained improperly. To use this setting, `AUTHORIZATION REQUIRED` must also be enabled.
+When `auth_revocable` is enabled, an issuer can set the `Authorize` flag of an
+existing trustline to `false` with the `allow_trust` operation, thereby freezing
+the asset held by an account. Doing so means that account can no longer trade or
+transfer the asset. It can’t even send the asset back to the issuer. Revoking
+authorization also cancels an account’s open orders for an asset. This setting
+allows the issuing account to revoke assets that it accidentally issued or that
+were obtained improperly. To use this setting, `AUTHORIZATION REQUIRED` must
+also be enabled.
 
-### Authorization Immutable 
+### Authorization Immutable
 
-With this setting, neither of the other authorization flags can be set, and the issuing account can’t be merged.  You set this flag to signal to potential token holders that your issuing account and its assets will persist on ledger in an open and accessible state.  It’s a fairly weak guarantee since it can be undone unless you lock the issuing account by setting the signing weight low enough to disable the `set_options` operation.
+With this setting, neither of the other authorization flags can be set, and the
+issuing account can’t be merged. You set this flag to signal to potential token
+holders that your issuing account and its assets will persist on ledger in an
+open and accessible state. It’s a fairly weak guarantee since it can be undone
+unless you lock the issuing account by setting the signing weight low enough to
+disable the `set_options` operation.
 
-### Example flow 
+### Example flow
 
-To get a sense of how authorization flags work, you can step through how an issuer would use `AUTHORIZATION REQUIRED` and `AUTHORIZATION REVOCABLE` to grant access to an asset, then to freeze it:
+To get a sense of how authorization flags work, you can step through how an
+issuer would use `AUTHORIZATION REQUIRED` and `AUTHORIZATION REVOCABLE` to grant
+access to an asset, then to freeze it:
 
 1. User decides he/she wants to accept an asset
 2. User opens a trust line with this asset's issuing account
 3. Issuer authorizes the user's trustline
-4. User can accept and send the asset to anyone else that has a trustline open with the issuer
+4. User can accept and send the asset to anyone else that has a trustline open
+   with the issuer
 5. Issuer wants to freeze user's access to asset
 6. Issuer deauthorizes user's trustline
 7. User cannot send or accept this asset
@@ -44,34 +76,36 @@ The following example sets authorization to be both required and revocable:
 <CodeExample title="Asset Authorization">
 
 ```js
-var StellarSdk = require('stellar-sdk');
-var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
 
 // Keys for issuing account
-var issuingKeys = StellarSdk.Keypair.fromSecret('SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4');
+var issuingKeys = StellarSdk.Keypair.fromSecret(
+  "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4",
+);
 
 server
   .loadAccount(issuingKeys.publicKey())
-  .then(function(issuer) {
+  .then(function (issuer) {
     var transaction = new StellarSdk.TransactionBuilder(issuer, {
       fee: 100,
-      networkPassphrase: StellarSdk.Networks.TESTNET
+      networkPassphrase: StellarSdk.Networks.TESTNET,
     })
       .addOperation(
         StellarSdk.Operation.setOptions({
-          setFlags: StellarSdk.AuthRevocableFlag | StellarSdk.AuthRequiredFlag
-        })
+          setFlags: StellarSdk.AuthRevocableFlag | StellarSdk.AuthRequiredFlag,
+        }),
       )
       // setTimeout is required for a transaction
       .setTimeout(100)
-      .build()
+      .build();
     transaction.sign(issuingKeys);
     return server.submitTransaction(transaction);
   })
   .then(console.log)
-  .catch(function(error) {
-    console.error('Error!', error);
-  })
+  .catch(function (error) {
+    console.error("Error!", error);
+  });
 ```
 
 ```java

--- a/content/docs/issuing-assets/how-to-issue-an-asset.mdx
+++ b/content/docs/issuing-assets/how-to-issue-an-asset.mdx
@@ -6,88 +6,150 @@ order: 20
 import { CodeExample } from "components/CodeExample";
 import { Alert } from "components/Alert";
 
-There is no dedicated operation to create an asset on Stellar.  Instead, assets are created with a [payment operation](../start/index.mdx/list-of-operations.mdx#payment): an issuing account makes a payment using the asset it’s issuing, and that payment actually creates the asset on the network.
+There is no dedicated operation to create an asset on Stellar. Instead, assets
+are created with a
+[payment operation](../start/index.mdx/list-of-operations.mdx#payment): an
+issuing account makes a payment using the asset it’s issuing, and that payment
+actually creates the asset on the network.
 
-It’s a pretty simple process that requires four operations: one to create an issuing account, one to create a distribution account, one to establish a trustline, and one to make a payment. 
+It’s a pretty simple process that requires four operations: one to create an
+issuing account, one to create a distribution account, one to establish a
+trustline, and one to make a payment.
 
 <Alert>
 
-Note: you don't actually have to issue assets to a dedicated distribution account: you can issue them to any account with the requisite trustline.  However, using a distribution account is the recommended practice, and it makes the process a lot easier to explain.  So that's how we'll do it in this guide.
+Note: you don't actually have to issue assets to a dedicated distribution
+account: you can issue them to any account with the requisite trustline.
+However, using a distribution account is the recommended practice, and it makes
+the process a lot easier to explain. So that's how we'll do it in this guide.
 
 </Alert>
 
-The code to create those operations and submit them as transactions is below.  Here, we’ll walk through each step so that the process makes sense.  You can breeze through to get a general understanding, or you can use the [Stellar laboratory](https://www.stellar.org/laboratory/), which is an interface that allows you to create and submit transactions, to actually follow along and issue a token right here right now.
+The code to create those operations and submit them as transactions is below.
+Here, we’ll walk through each step so that the process makes sense. You can
+breeze through to get a general understanding, or you can use the
+[Stellar laboratory](https://www.stellar.org/laboratory/), which is an interface
+that allows you to create and submit transactions, to actually follow along and
+issue a token right here right now.
 
-One caveat: if you are creating a token on the public network, there is an additional prerequisite.  You need a funded account to provide the XLM necessary to create the issuing and distribution accounts.
+One caveat: if you are creating a token on the public network, there is an
+additional prerequisite. You need a funded account to provide the XLM necessary
+to create the issuing and distribution accounts.
 
 ## Create the Issuing and Distribution Accounts
 
-The issuing account is the origin of the asset, and will be forever linked to the asset’s identity. The distribution account is the first recipient of the asset.  In the final step of this process, you’ll create the asset by sending a payment from the issuing account to the distribution account.
+The issuing account is the origin of the asset, and will be forever linked to
+the asset’s identity. The distribution account is the first recipient of the
+asset. In the final step of this process, you’ll create the asset by sending a
+payment from the issuing account to the distribution account.
 
 There are two steps to account creation:
 
 1. Generate a keypair
 2. Fund the account using a `create_account` operation
 
-You can generate a keypair for free, but an account doesn’t exist on the Stellar ledger until it is funded with XLM to cover the minimum balance. 
+You can generate a keypair for free, but an account doesn’t exist on the Stellar
+ledger until it is funded with XLM to cover the minimum balance.
 
-If you’re issuing an asset on the testnet, you can fund your accounts by getting free test XLM from Friendbot.  If you’re issuing an asset in production, you will need to use an existing account to send enough live XLM to cover the minimum balance, transaction fees, and, in the case of the distribution account, a trustline.  If you’re not sure where to acquire XLM, consult our [Lumen Buying Guide](https://www.stellar.org/lumens/exchanges#cryptocurrency-exchanges).
+If you’re issuing an asset on the testnet, you can fund your accounts by getting
+free test XLM from Friendbot. If you’re issuing an asset in production, you will
+need to use an existing account to send enough live XLM to cover the minimum
+balance, transaction fees, and, in the case of the distribution account, a
+trustline. If you’re not sure where to acquire XLM, consult our
+[Lumen Buying Guide](https://www.stellar.org/lumens/exchanges#cryptocurrency-exchanges).
 
-Rule of thumb for production: don’t skirt too close to the minimum network balance.  If you do, you may not have enough XLM to do what you need to do.  Since the network minimum balance and transaction fees are low, it doesn’t require much to get started.  5 XLM should be sufficient. 100 XLM is even better.   
+Rule of thumb for production: don’t skirt too close to the minimum network
+balance. If you do, you may not have enough XLM to do what you need to do. Since
+the network minimum balance and transaction fees are low, it doesn’t require
+much to get started. 5 XLM should be sufficient. 100 XLM is even better.
 
 ## Create a Trustline
 
-Stellar requires accounts to explicitly opt-in to holding an asset by creating a trustline, and in this step the distribution account submits a `change_trust` operation to do just that.  The trustline goes from the distribution account to the issuing account. 
+Stellar requires accounts to explicitly opt-in to holding an asset by creating a
+trustline, and in this step the distribution account submits a `change_trust`
+operation to do just that. The trustline goes from the distribution account to
+the issuing account.
 
-The distribution account specifies the issuer’s public key and the asset code in the `change_trust` operation, and since it’s the first time the asset code appears on the ledger, that means the _distribution_ account actually names the asset, not the issuing account. 
+The distribution account specifies the issuer’s public key and the asset code in
+the `change_trust` operation, and since it’s the first time the asset code
+appears on the ledger, that means the _distribution_ account actually names the
+asset, not the issuing account.
 
 Currently, there are two supported formats for asset codes.
 
-* **Alphanumeric 4-character maximum**: Any characters from the set [a-z][A-Z][0-9] are allowed. The code can be shorter than 4 characters, but the trailing characters must all be empty.
-* **Alphanumeric 12-character maximum**: Any characters from the set [a-z][A-Z][0-9] are allowed. The code can be any number of characters from 5 to 12, but the trailing characters must all be empty.
+- **Alphanumeric 4-character maximum**: Any characters from the set
+  [a-z][a-z][0-9] are allowed. The code can be shorter than 4 characters, but
+  the trailing characters must all be empty.
+- **Alphanumeric 12-character maximum**: Any characters from the set
+  [a-z][a-z][0-9] are allowed. The code can be any number of characters from 5
+  to 12, but the trailing characters must all be empty.
 
-Any asset code works provided it falls into one of those two buckets. That said, if you’re issuing a currency, you should use the appropriate [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code, and if you’re issuing a stock or bond, the appropriate [ISIN number](https://en.wikipedia.org/wiki/International_Securities_Identification_Number).  Doing so makes it easier for Stellar interfaces to properly display and sort your token in their listings, and allows potential token holders to understand, at a glance, what your token represents.
-  
+Any asset code works provided it falls into one of those two buckets. That said,
+if you’re issuing a currency, you should use the appropriate
+[ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code, and if you’re issuing a
+stock or bond, the appropriate
+[ISIN number](https://en.wikipedia.org/wiki/International_Securities_Identification_Number).
+Doing so makes it easier for Stellar interfaces to properly display and sort
+your token in their listings, and allows potential token holders to understand,
+at a glance, what your token represents.
+
 ## Make a Payment
 
-This is the step where the magic happens.  The issuing account makes a payment to the distribution account using the newly named asset, and tokens exist where before there were none.  Presto!  
+This is the step where the magic happens. The issuing account makes a payment to
+the distribution account using the newly named asset, and tokens exist where
+before there were none. Presto!
 
-As long as the issuing account remains unlocked, it can continue to create new tokens by making payments to the distribution account, or to any other account with the requisite trustline.  If you want to change that and put a hard limit on the number of tokens an issuing account can issue, check out our instructions on [how to lock an account](./limit-asset-supply.mdx).
+As long as the issuing account remains unlocked, it can continue to create new
+tokens by making payments to the distribution account, or to any other account
+with the requisite trustline. If you want to change that and put a hard limit on
+the number of tokens an issuing account can issue, check out our instructions on
+[how to lock an account](./limit-asset-supply.mdx).
 
-If you’re planning to do, really, anything with your asset, your next step is to [complete a stellar.toml file](./publishing-asset-info.mdx) to provide wallets, exchanges, market listing services, and potential token holders with the information they need to understand what it represents. 
+If you’re planning to do, really, anything with your asset, your next step is to
+[complete a stellar.toml file](./publishing-asset-info.mdx) to provide wallets,
+exchanges, market listing services, and potential token holders with the
+information they need to understand what it represents.
 
-Once you’ve done that, you can also [create a sell offer](./list-asset-on-dex.mdx) to get your asset onto the Stellar decentralized exchange, and put some effort into market making to create liquidity for it.     
+Once you’ve done that, you can also
+[create a sell offer](./list-asset-on-dex.mdx) to get your asset onto the
+Stellar decentralized exchange, and put some effort into market making to create
+liquidity for it.
 
 ## Sample Code
 
 <CodeExample title="Issuing an Asset">
 
 ```js
-var StellarSdk = require('stellar-sdk');
-var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
 
 // Keys for accounts to issue and receive the new asset
-var issuingKeys = StellarSdk.Keypair
-  .fromSecret('SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4');
-var receivingKeys = StellarSdk.Keypair
-  .fromSecret('SDSAVCRE5JRAI7UFAVLE5IMIZRD6N6WOJUWKY4GFN34LOBEEUS4W2T2D');
+var issuingKeys = StellarSdk.Keypair.fromSecret(
+  "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4",
+);
+var receivingKeys = StellarSdk.Keypair.fromSecret(
+  "SDSAVCRE5JRAI7UFAVLE5IMIZRD6N6WOJUWKY4GFN34LOBEEUS4W2T2D",
+);
 
 // Create an object to represent the new asset
-var astroDollar = new StellarSdk.Asset('AstroDollar', issuingKeys.publicKey());
+var astroDollar = new StellarSdk.Asset("AstroDollar", issuingKeys.publicKey());
 
 // First, the receiving account must trust the asset
-server.loadAccount(receivingKeys.publicKey())
-  .then(function(receiver) {
+server
+  .loadAccount(receivingKeys.publicKey())
+  .then(function (receiver) {
     var transaction = new StellarSdk.TransactionBuilder(receiver, {
       fee: 100,
-      networkPassphrase: StellarSdk.Networks.TESTNET
+      networkPassphrase: StellarSdk.Networks.TESTNET,
     })
       // The `changeTrust` operation creates (or alters) a trustline
       // The `limit` parameter below is optional
-      .addOperation(StellarSdk.Operation.changeTrust({
-        asset: astroDollar,
-        limit: '1000'
-      }))
+      .addOperation(
+        StellarSdk.Operation.changeTrust({
+          asset: astroDollar,
+          limit: "1000",
+        }),
+      )
       // setTimeout is required for a transaction
       .setTimeout(100)
       .build();
@@ -97,19 +159,21 @@ server.loadAccount(receivingKeys.publicKey())
   .then(console.log)
 
   // Second, the issuing account actually sends a payment using the asset
-  .then(function() {
-    return server.loadAccount(issuingKeys.publicKey())
+  .then(function () {
+    return server.loadAccount(issuingKeys.publicKey());
   })
-  .then(function(issuer) {
+  .then(function (issuer) {
     var transaction = new StellarSdk.TransactionBuilder(issuer, {
       fee: 100,
-      networkPassphrase: StellarSdk.Networks.TESTNET
+      networkPassphrase: StellarSdk.Networks.TESTNET,
     })
-      .addOperation(StellarSdk.Operation.payment({
-        destination: receivingKeys.publicKey(),
-        asset: astroDollar,
-        amount: '10'
-      }))
+      .addOperation(
+        StellarSdk.Operation.payment({
+          destination: receivingKeys.publicKey(),
+          asset: astroDollar,
+          amount: "10",
+        }),
+      )
       // setTimeout is required for a transaction
       .setTimeout(100)
       .build();
@@ -117,8 +181,8 @@ server.loadAccount(receivingKeys.publicKey())
     return server.submitTransaction(transaction);
   })
   .then(console.log)
-  .catch(function(error) {
-    console.error('Error!', error);
+  .catch(function (error) {
+    console.error("Error!", error);
   });
 ```
 

--- a/content/docs/issuing-assets/index.mdx
+++ b/content/docs/issuing-assets/index.mdx
@@ -3,12 +3,37 @@ title: Overview
 order: 10
 ---
 
-The ability to issue assets is a core feature of Stellar.  In a few simple operations, you can create Stellar-network tokens, and this section of the docs will show you how.  
+The ability to issue assets is a core feature of Stellar. In a few simple
+operations, you can create Stellar-network tokens, and this section of the docs
+will show you how.
 
-The possibilities are endless: any asset can be tokenized, and, once tokenized, transferred or traded over the Stellar network quickly and cheaply.  Since any account can issue an asset on the Stellar network and anyone can set up a Stellar account, _anyone_ can issue an asset: banks, payment processors, money service businesses of all stripes, for-profit enterprises, nonprofits, local communities, even individuals.  It’s a self-serve process, no permission needed.
+The possibilities are endless: any asset can be tokenized, and, once tokenized,
+transferred or traded over the Stellar network quickly and cheaply. Since any
+account can issue an asset on the Stellar network and anyone can set up a
+Stellar account, _anyone_ can issue an asset: banks, payment processors, money
+service businesses of all stripes, for-profit enterprises, nonprofits, local
+communities, even individuals. It’s a self-serve process, no permission needed.
 
-In addition to making it easy to issue an asset, Stellar also provides built-in mechanisms that allow you to tune your asset to specific use cases.  You can — and should — [publish important identifying information](publishing-asset-info.mdx) about your asset so that wallets and consumers know what it represents, and it's easy to link that info to your asset in a single step.  To comply with regulations, you can [control access](control-asset-access.mdx) to your asset using protocol-level flags.  To take advantage of Stellar’s global reach, you can [list your asset](list-asset-on-dex.mdx) on the Stellar decentralized exchange, and use [market making bots](https://kelpbot.io/) to ensure necessary liquidity.    
- 
-Currently, the biggest use case for Stellar is the tokenization of fiat currency to optimize processes like cross-border payments, so there’s also a whole subsequent section — [Enable Deposit and Withdrawal](../enabling-deposit-and-withdrawal/index.mdx) — that focuses on how to connect Stellar tokens to existing rails to allow users to easily deposit real-world assets in exchange for them, and, on the flipside, to redeem them for real-world assets.  Check that section if you're interested in creating an accessible on/off ramp that interoperates with wallets for seamless handling of user KYC, deposits, and withdrawals.
+In addition to making it easy to issue an asset, Stellar also provides built-in
+mechanisms that allow you to tune your asset to specific use cases. You can —
+and should —
+[publish important identifying information](publishing-asset-info.mdx) about
+your asset so that wallets and consumers know what it represents, and it's easy
+to link that info to your asset in a single step. To comply with regulations,
+you can [control access](control-asset-access.mdx) to your asset using
+protocol-level flags. To take advantage of Stellar’s global reach, you can
+[list your asset](list-asset-on-dex.mdx) on the Stellar decentralized exchange,
+and use [market making bots](https://kelpbot.io/) to ensure necessary liquidity.
 
-As more and more developers and businesses explore other possibilities, we’ll expand the docs to cover emerging ideas and applications.
+Currently, the biggest use case for Stellar is the tokenization of fiat currency
+to optimize processes like cross-border payments, so there’s also a whole
+subsequent section —
+[Enable Deposit and Withdrawal](../enabling-deposit-and-withdrawal/index.mdx) —
+that focuses on how to connect Stellar tokens to existing rails to allow users
+to easily deposit real-world assets in exchange for them, and, on the flipside,
+to redeem them for real-world assets. Check that section if you're interested in
+creating an accessible on/off ramp that interoperates with wallets for seamless
+handling of user KYC, deposits, and withdrawals.
+
+As more and more developers and businesses explore other possibilities, we’ll
+expand the docs to cover emerging ideas and applications.

--- a/content/docs/issuing-assets/publishing-asset-info.mdx
+++ b/content/docs/issuing-assets/publishing-asset-info.mdx
@@ -6,172 +6,269 @@ order: 40
 import { CodeExample } from "components/CodeExample";
 import { Alert } from "components/Alert";
 
-When you issue an asset, it’s crucial to provide clear information about it represents. On Stellar, you do that by linking your issuing account to a home domain, publishing a `stellar.toml` file on that domain, and making sure that file is complete.  
+When you issue an asset, it’s crucial to provide clear information about it
+represents. On Stellar, you do that by linking your issuing account to a home
+domain, publishing a `stellar.toml` file on that domain, and making sure that
+file is complete.
 
-The most successful asset issuers give exchanges, wallets, and potential buyers lots of information about themselves in order to establish trust. More information in your `stellar.toml` will mean:
+The most successful asset issuers give exchanges, wallets, and potential buyers
+lots of information about themselves in order to establish trust. More
+information in your `stellar.toml` will mean:
 
-* Your asset gets *more* exposure, and is listed on *more* exchanges
-* Your asset holders are *more* confident in you and the assets you issue.
-* Your project will most likely be *more* successful!
+- Your asset gets _more_ exposure, and is listed on _more_ exchanges
+- Your asset holders are _more_ confident in you and the assets you issue.
+- Your project will most likely be _more_ successful!
 
-The Stellar ticker, which is the source of market data for sites like CoinMarketCap, only includes assets with valid `stellar.toml` files.  Trading interfaces like StellarX, Stellarport, and StellarTerm and wallets like Lobstr and Solar use `stellar.toml` files to populate their listings, and to decide if and how to present assets to their users.  Any and all ecosystem integrations that allow for interoperability — from federation to in-app deposit and withdrawal — rely on information in your `stellar.toml` detailing your Stellar setup.  
+The Stellar ticker, which is the source of market data for sites like
+CoinMarketCap, only includes assets with valid `stellar.toml` files. Trading
+interfaces like StellarX, Stellarport, and StellarTerm and wallets like Lobstr
+and Solar use `stellar.toml` files to populate their listings, and to decide if
+and how to present assets to their users. Any and all ecosystem integrations
+that allow for interoperability — from federation to in-app deposit and
+withdrawal — rely on information in your `stellar.toml` detailing your Stellar
+setup.
 
-Completing your `stellar.toml` is not a step you can skip.   
+Completing your `stellar.toml` is not a step you can skip.
 
 ## What is a stellar.toml?
 
-The `stellar.toml` file is a common place where the Internet can find information
-about your organization’s Stellar integration.  You write it in TOML, a simple and widely used configuration file format designed to be readable by both humans and machines, and publish it at `https://YOUR_DOMAIN/.well-known/stellar.toml`.
+The `stellar.toml` file is a common place where the Internet can find
+information about your organization’s Stellar integration. You write it in TOML,
+a simple and widely used configuration file format designed to be readable by
+both humans and machines, and publish it at
+`https://YOUR_DOMAIN/.well-known/stellar.toml`.
 
-That way, everyone knows where to find it, anyone can look it up, and it *proves* that the owner of the HTTPS domain hosting the stellar.toml claims *responsibility* for the accounts and assets listed in it.  
+That way, everyone knows where to find it, anyone can look it up, and it
+_proves_ that the owner of the HTTPS domain hosting the stellar.toml claims
+_responsibility_ for the accounts and assets listed in it.
 
-Using a [`set_options`](../glossary/operations.mdx#set-options) operation, you can link your Stellar account to the domain that hosts your `stellar.toml`, thereby creating a definitive on-chain connection between this information and that account.
+Using a [`set_options`](../glossary/operations.mdx#set-options) operation, you
+can link your Stellar account to the domain that hosts your `stellar.toml`,
+thereby creating a definitive on-chain connection between this information and
+that account.
 
 ## How to complete your stellar.toml
 
-Stellar Ecosystem Proposals are open protocols for building on top of Stellar, and the very first SEP, aptly named [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md), specifies everything you could ever want to include in a `stellar.toml` file.  This guide, which is targeted toward asset issuers, won’t cover the `Validator Information` section (that’s covered in the [Run a Core Node section](../run-core-node/index.mdx)), and may omit some details relevant to your use case.  
+Stellar Ecosystem Proposals are open protocols for building on top of Stellar,
+and the very first SEP, aptly named
+[SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md),
+specifies everything you could ever want to include in a `stellar.toml` file.
+This guide, which is targeted toward asset issuers, won’t cover the
+`Validator Information` section (that’s covered in the
+[Run a Core Node section](../run-core-node/index.mdx)), and may omit some
+details relevant to your use case.
 
-The goal here is to walk through the sections of [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md) that directly relate to asset issuers, so you should use this guide in conjunction with that SEP to make sure you complete your `stellar.toml` correctly.  The four sections we’ll cover:
+The goal here is to walk through the sections of
+[SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md)
+that directly relate to asset issuers, so you should use this guide in
+conjunction with that SEP to make sure you complete your `stellar.toml`
+correctly. The four sections we’ll cover:
 
-* General Information
-* Organization Documentation
-* Point of Contact Documentation
-* Currency Documentation
+- General Information
+- Organization Documentation
+- Point of Contact Documentation
+- Currency Documentation
 
-For each of those sections, we’ll let you know which fields are **required**, meaning all asset issuers *must* include them to be listed by exchanges and wallets, and which fields are **suggested**.  Completing suggested fields is a good way to make your asset stand out.
-
+For each of those sections, we’ll let you know which fields are **required**,
+meaning all asset issuers _must_ include them to be listed by exchanges and
+wallets, and which fields are **suggested**. Completing suggested fields is a
+good way to make your asset stand out.
 
 <Alert>
 
-Note: it's a good idea to keep the sections in the order presented in [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md), which is also the order they're presented here.  TOML requires arrays to be at the end, so if you move scramble the order, you may cause errors for TOML parsers
+Note: it's a good idea to keep the sections in the order presented in
+[SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md),
+which is also the order they're presented here. TOML requires arrays to be at
+the end, so if you move scramble the order, you may cause errors for TOML
+parsers
 
 </Alert>
 
-
 ### General Information
 
-There is one field in the General Information section required for *all* token issuers:
+There is one field in the General Information section required for _all_ token
+issuers:
 
-* `ACCOUNTS`: A list of **public keys** for all the Stellar accounts associated with your asset.
+- `ACCOUNTS`: A list of **public keys** for all the Stellar accounts associated
+  with your asset.
 
-Listing your public keys lets users confirm that you, in fact, own them. For example, when
-https://google.com hosts a stellar.toml file, users can be sure that *only* the accounts listed on
-it belong to Google. If someone then says, "You need to pay your Google bill this month, send
-payment to address GIAMGOOGLEIPROMISE", but that key is not listed on Google's stellar.toml, then users know to not trust it.
+Listing your public keys lets users confirm that you, in fact, own them. For
+example, when https://google.com hosts a stellar.toml file, users can be sure
+that _only_ the accounts listed on it belong to Google. If someone then says,
+"You need to pay your Google bill this month, send payment to address
+GIAMGOOGLEIPROMISE", but that key is not listed on Google's stellar.toml, then
+users know to not trust it.
 
-In addition, there are several fields where you list information about your Stellar integration to aid in discoverability.  If you are an anchor service, and you have [set up infrastructure](../enabling-deposit-and-withdrawal/index.mdx) to interoperate with wallets and allow for in-app deposit and withdrawal of assets, make sure to include the locations of your servers on your stellar.toml file so those wallets know where to find relevant endpoints to query.  In particular, list your:
-   
-* `TRANSFER_SERVER_SEP0024`, which is where wallets find endpoints to initiate interactive deposit and withdrawal based on the [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md) spec
-* `WEB_AUTH_ENDPOINT`, which is where wallets initiate user authentication sessions based on the [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) spec
+In addition, there are several fields where you list information about your
+Stellar integration to aid in discoverability. If you are an anchor service, and
+you have [set up infrastructure](../enabling-deposit-and-withdrawal/index.mdx)
+to interoperate with wallets and allow for in-app deposit and withdrawal of
+assets, make sure to include the locations of your servers on your stellar.toml
+file so those wallets know where to find relevant endpoints to query. In
+particular, list your:
 
-If you support other Stellar Ecosystem Proposals — such as federation or delegated signing — or host a public Horizon instance that other people can use to query the ledger, you should also add the location of those resources to [General Information](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#general-information) so they're discoverable. 
+- `TRANSFER_SERVER_SEP0024`, which is where wallets find endpoints to initiate
+  interactive deposit and withdrawal based on the
+  [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md)
+  spec
+- `WEB_AUTH_ENDPOINT`, which is where wallets initiate user authentication
+  sessions based on the
+  [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)
+  spec
+
+If you support other Stellar Ecosystem Proposals — such as federation or
+delegated signing — or host a public Horizon instance that other people can use
+to query the ledger, you should also add the location of those resources to
+[General Information](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#general-information)
+so they're discoverable.
 
 ### Organization Documentation
 
-Basic information about your organization goes into a TOML **table** called `[DOCUMENTATION]`.  Organization Documentation is your chance to inform exchanges and buyers about your business, and to  demonstrate that your business is legitimate and trustworthy.
+Basic information about your organization goes into a TOML **table** called
+`[DOCUMENTATION]`. Organization Documentation is your chance to inform exchanges
+and buyers about your business, and to demonstrate that your business is
+legitimate and trustworthy.
 
 #### Required
 
-* `ORG_NAME` The legal name of your organization, and if your business has one, its official `ORG_DBA`.
-* `ORG_URL` The HTTPS URL of your organization's official website.  In order to prove the website is yours, *you must host your stellar.toml on the same domain you list here.*  That way, exchanges and buyers can view the SSL certificate on your website, and feel reasonably confident that you are who you say you are.
-* `ORG_LOGO` A URL to a company logo, which will show up next to your organization on exchanges.  This image should be a square aspect ratio transparent PNG, ideally of size 128x128.  If you fail to provide a logo, the icon next to your organization will appear blank on many exchanges.
-* `ORG_PHYSICAL_ADDRESS` The physical address of your organization. We understand you might want to keep your work address private. At the very least, you should put the *city* and *country* in which you operate. A street address is ideal and provides a higher level of trust and
-  transparency to your potential asset holders.
-* `ORG_OFFICIAL_EMAIL` The best contact email address for you organization. This should be hosted at the same domain as your official website.
+- `ORG_NAME` The legal name of your organization, and if your business has one,
+  its official `ORG_DBA`.
+- `ORG_URL` The HTTPS URL of your organization's official website. In order to
+  prove the website is yours, _you must host your stellar.toml on the same
+  domain you list here._ That way, exchanges and buyers can view the SSL
+  certificate on your website, and feel reasonably confident that you are who
+  you say you are.
+- `ORG_LOGO` A URL to a company logo, which will show up next to your
+  organization on exchanges. This image should be a square aspect ratio
+  transparent PNG, ideally of size 128x128. If you fail to provide a logo, the
+  icon next to your organization will appear blank on many exchanges.
+- `ORG_PHYSICAL_ADDRESS` The physical address of your organization. We
+  understand you might want to keep your work address private. At the very
+  least, you should put the _city_ and _country_ in which you operate. A street
+  address is ideal and provides a higher level of trust and transparency to your
+  potential asset holders.
+- `ORG_OFFICIAL_EMAIL` The best contact email address for you organization. This
+  should be hosted at the same domain as your official website.
 
 #### Suggested
 
-* `ORG_GITHUB` Your organization's official Github account.
-* `ORG_KEYBASE` Your organization's official Keybase account. Your Keybase account should contain proof of ownership of any public online accounts you list here, including your organization's domain.
-* `ORG_TWITTER` Your organization's official Twitter handle.
-* `ORG_DESCRIPTION` A description of your organization. This is fairly open-ended, and you can write as much as you want. It's a great place to distinguish yourself by describing what it is that you do.
+- `ORG_GITHUB` Your organization's official Github account.
+- `ORG_KEYBASE` Your organization's official Keybase account. Your Keybase
+  account should contain proof of ownership of any public online accounts you
+  list here, including your organization's domain.
+- `ORG_TWITTER` Your organization's official Twitter handle.
+- `ORG_DESCRIPTION` A description of your organization. This is fairly
+  open-ended, and you can write as much as you want. It's a great place to
+  distinguish yourself by describing what it is that you do.
 
-Issuers that list verified information including phone/address attestations and Keybase
-verifications are prioritized by Stellar clients.
+Issuers that list verified information including phone/address attestations and
+Keybase verifications are prioritized by Stellar clients.
 
 ### Point of Contact Documentation
 
-Information about the primary point(s) of contact for your organization goes into a TOML [array of tables](https://github.com/toml-lang/toml#array-of-tables) called `[[PRINCIPALS]]`.  You need to put contact information for *at least one person* at your organization.  If you don't, exchanges
-can't verify your offering, and it is unlikely that buyers will be interested. Multiple principals
+Information about the primary point(s) of contact for your organization goes
+into a TOML [array of tables](https://github.com/toml-lang/toml#array-of-tables)
+called `[[PRINCIPALS]]`. You need to put contact information for _at least one
+person_ at your organization. If you don't, exchanges can't verify your
+offering, and it is unlikely that buyers will be interested. Multiple principals
 can be added with additional `[[PRINCIPALS]]` entries.
 
 #### Required
 
-* `name` The name of the primary contact.
-* `email` The primary contact's official email address. This should be hosted at the same domain as your organization's official website.
+- `name` The name of the primary contact.
+- `email` The primary contact's official email address. This should be hosted at
+  the same domain as your organization's official website.
 
 #### Suggested
-* `github` The personal Github account of the point of contact.
-* `twitter` The personal Twitter handle of the point of contact.
-* `keybase` The personal Keybase account for the point of contact. This account should contain
-  proof of ownership of any public online accounts listed here and may contain proof of ownership of your organization's domain.
+
+- `github` The personal Github account of the point of contact.
+- `twitter` The personal Twitter handle of the point of contact.
+- `keybase` The personal Keybase account for the point of contact. This account
+  should contain proof of ownership of any public online accounts listed here
+  and may contain proof of ownership of your organization's domain.
 
 ### Currency Documentation
-Information about the asset(s) you issue goes into a TOML [array of tables](https://github.com/toml-lang/toml#array-of-tables) called `[[CURRENCIES]]`.  If you issue multiple assets, you can include them all in one stellar.toml. Each asset should have its
-own `[[CURRENCIES]]` entry.
+
+Information about the asset(s) you issue goes into a TOML
+[array of tables](https://github.com/toml-lang/toml#array-of-tables) called
+`[[CURRENCIES]]`. If you issue multiple assets, you can include them all in one
+stellar.toml. Each asset should have its own `[[CURRENCIES]]` entry.
 
 #### Required
 
-* `code` The asset code. This is one of two key pieces of information that identify your token.
-  Without it, your token cannot be listed anywhere.
-* `issuer` The Stellar public key of the issuing account. This is the second key piece of information that identifies your token. Without it, your token cannot be listed anywhere.
-* `is_asset_anchored` An indication of whether your token is anchored or native: `true` if your
-  token can be redeemed for an asset outside the Stellar network, `false` if it can’t.  Exchanges
-  use this information to sort tokens by type in listings. If you fail to provide it, your token
-  is unlikely to show up in filtered market views.
+- `code` The asset code. This is one of two key pieces of information that
+  identify your token. Without it, your token cannot be listed anywhere.
+- `issuer` The Stellar public key of the issuing account. This is the second key
+  piece of information that identifies your token. Without it, your token cannot
+  be listed anywhere.
+- `is_asset_anchored` An indication of whether your token is anchored or native:
+  `true` if your token can be redeemed for an asset outside the Stellar network,
+  `false` if it can’t. Exchanges use this information to sort tokens by type in
+  listings. If you fail to provide it, your token is unlikely to show up in
+  filtered market views.
 
-If you're issuing anchored (tethered, stablecoin, asset-backed) tokens, there are several
-additional **required** fields:
+If you're issuing anchored (tethered, stablecoin, asset-backed) tokens, there
+are several additional **required** fields:
 
-* `anchor_asset_type` The type of asset your token represents.  The possible categories are
-  `fiat`, `crypto`, `stock`, `bond`, `commodity`, `realestate`, and `other`.
-* `anchor_asset` The name of the asset that serves as the anchor for your token.
-* `redemption_instructions` Instructions to redeem your token for the underlying asset.
+- `anchor_asset_type` The type of asset your token represents. The possible
+  categories are `fiat`, `crypto`, `stock`, `bond`, `commodity`, `realestate`,
+  and `other`.
+- `anchor_asset` The name of the asset that serves as the anchor for your token.
+- `redemption_instructions` Instructions to redeem your token for the underlying
+  asset.
 
 #### Suggested
-* `desc` A description of your token and what it represents.  This is a good place to clarify
-  what your token does, and why someone might want to own it.
-* `conditions` Any conditions you place on the redemption of your token.
-* `image` A URL to a PNG or GIF image with a transparent background representing your token. Without it, your token will appear blank on many exchanges.
 
+- `desc` A description of your token and what it represents. This is a good
+  place to clarify what your token does, and why someone might want to own it.
+- `conditions` Any conditions you place on the redemption of your token.
+- `image` A URL to a PNG or GIF image with a transparent background representing
+  your token. Without it, your token will appear blank on many exchanges.
 
 ## How to publish your stellar.toml
-After you've followed the steps above to complete your stellar.toml, post it at the following
-location:
+
+After you've followed the steps above to complete your stellar.toml, post it at
+the following location:
 
 `https://YOUR_DOMAIN/.well-known/stellar.toml`
 
-Enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) so people can access this file from other sites, and set the following header for an HTTP response for a
-`/.well-known/stellar.toml` file request.
+Enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) so people
+can access this file from other sites, and set the following header for an HTTP
+response for a `/.well-known/stellar.toml` file request.
 
 `Access-Control-Allow-Origin: *`
 
-Set a `text/plain` content type so that browsers render the contents, rather than prompting for a download.
-‘content-type: text/plain’
+Set a `text/plain` content type so that browsers render the contents, rather
+than prompting for a download. ‘content-type: text/plain’
 
-You should also use the `set_options` operation to set the home domain on your issueing account.
+You should also use the `set_options` operation to set the home domain on your
+issueing account.
 
 ## Sample code to set the home domain of your issuing account
 
 <CodeExample title="Set Home Domain">
 
 ```js
-var StellarSdk = require('stellar-sdk');
-var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
 
 // Keys for issuing account
-var issuingKeys = StellarSdk.Keypair
-  .fromSecret('SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4');
+var issuingKeys = StellarSdk.Keypair.fromSecret(
+  "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4",
+);
 
-server.loadAccount(issuingKeys.publicKey())
-  .then(function(issuer) {
+server
+  .loadAccount(issuingKeys.publicKey())
+  .then(function (issuer) {
     var transaction = new StellarSdk.TransactionBuilder(issuer, {
       fee: 100,
-      networkPassphrase: StellarSdk.Networks.TESTNET
+      networkPassphrase: StellarSdk.Networks.TESTNET,
     })
-      .addOperation(StellarSdk.Operation.setOptions({
-        homeDomain: 'yourdomain.com',
-      }))
+      .addOperation(
+        StellarSdk.Operation.setOptions({
+          homeDomain: "yourdomain.com",
+        }),
+      )
       // setTimeout is required for a transaction
       .setTimeout(100)
       .build();
@@ -179,8 +276,8 @@ server.loadAccount(issuingKeys.publicKey())
     return server.submitTransaction(transaction);
   })
   .then(console.log)
-  .catch(function(error) {
-    console.error('Error!', error);
+  .catch(function (error) {
+    console.error("Error!", error);
   });
 ```
 
@@ -201,6 +298,7 @@ setHomeDomain.sign(issuingKeys);
 server.submitTransaction(setHomeDomain);
 
 ```
+
 </CodeExample>
 
 ## Sample stellar.toml
@@ -275,7 +373,10 @@ fixed_number=10000
 
 </CodeExample>
 
-[sep-0001]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
-[sep-0020]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md
+[sep-0001]:
+  https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+[sep-0020]:
+  https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md
 [seps]: https://github.com/stellar/stellar-protocol/tree/master/ecosystem
-[twilio-guide]: https://support.twilio.com/hc/en-us/articles/223183008-Formatting-International-Phone-Numbers
+[twilio-guide]:
+  https://support.twilio.com/hc/en-us/articles/223183008-Formatting-International-Phone-Numbers

--- a/content/docs/run-api-server/configuring.mdx
+++ b/content/docs/run-api-server/configuring.mdx
@@ -5,28 +5,53 @@ order: 30
 
 import { CodeExample } from "components/CodeExample";
 
-Horizon is configured using command line flags or environment variables.  To see the list of command line flags that are available (and their default values) for your version of Horizon, run:
+Horizon is configured using command line flags or environment variables. To see
+the list of command line flags that are available (and their default values) for
+your version of Horizon, run:
 
 `horizon --help`
 
-When you run the command above, you'll see that Horizon defines a large number of flags; however, only three are required:
+When you run the command above, you'll see that Horizon defines a large number
+of flags; however, only three are required:
 
 | flag                    | envvar                      | example                              |
-|-------------------------|-----------------------------|--------------------------------------|
+| ----------------------- | --------------------------- | ------------------------------------ |
 | `--db-url`              | `DATABASE_URL`              | postgres://localhost/horizon_testnet |
 | `--stellar-core-db-url` | `STELLAR_CORE_DATABASE_URL` | postgres://localhost/core_testnet    |
 | `--stellar-core-url`    | `STELLAR_CORE_URL`          | http://localhost:11626               |
 
-`--db-url` specifies the Horizon database, and its value should be a valid [PostgreSQL Connection URI](http://www.postgresql.org/docs/9.2/static/libpq-connect.html#AEN38419).  `--stellar-core-db-url` specifies a Stellar Core database which will be used to load data from the Stellar ledger.  Finally, `--stellar-core-url` specifies the HTTP control port for an instance of Stellar Core.  This URL should be associated with the Stellar Core server that is writing to the database at `--stellar-core-db-url`.
+`--db-url` specifies the Horizon database, and its value should be a valid
+[PostgreSQL Connection URI](http://www.postgresql.org/docs/9.2/static/libpq-connect.html#AEN38419).
+`--stellar-core-db-url` specifies a Stellar Core database which will be used to
+load data from the Stellar ledger. Finally, `--stellar-core-url` specifies the
+HTTP control port for an instance of Stellar Core. This URL should be associated
+with the Stellar Core server that is writing to the database at
+`--stellar-core-db-url`.
 
-Specifying command line flags every time you invoke Horizon can be cumbersome, and so we recommend using environment variables.  There are many tools you can use to manage environment variables:  we recommend either [direnv](http://direnv.net/) or [dotenv](https://github.com/bkeepers/dotenv).  A template configuration that is compatible with dotenv can be found in the [Horizon git repo](https://github.com/stellar/go/blob/master/services/horizon/.env.template).
+Specifying command line flags every time you invoke Horizon can be cumbersome,
+and so we recommend using environment variables. There are many tools you can
+use to manage environment variables: we recommend either
+[direnv](http://direnv.net/) or [dotenv](https://github.com/bkeepers/dotenv). A
+template configuration that is compatible with dotenv can be found in the
+[Horizon git repo](https://github.com/stellar/go/blob/master/services/horizon/.env.template).
 
 ## Preparing the Database
 
-Before running the Horizon server, you must first prepare the Horizon database.  This database will be used for all of the information produced by Horizon, notably historical information about successful transactions that have occurred on the stellar network.
+Before running the Horizon server, you must first prepare the Horizon database.
+This database will be used for all of the information produced by Horizon,
+notably historical information about successful transactions that have occurred
+on the stellar network.
 
-To prepare a database for Horizon's use, you must first ensure the database is blank.  It's easiest to simply create a new database on your postgres server specifically for Horizon's use.  Next you must install the schema by running `horizon db init`.  Remember to use the appropriate command line flags or environment variables to configure Horizon as explained in [Configuring ](#Configuring).  This command will log any errors that occur.
+To prepare a database for Horizon's use, you must first ensure the database is
+blank. It's easiest to simply create a new database on your postgres server
+specifically for Horizon's use. Next you must install the schema by running
+`horizon db init`. Remember to use the appropriate command line flags or
+environment variables to configure Horizon as explained in
+[Configuring ](#Configuring). This command will log any errors that occur.
 
 ### Postgres Configuration
 
-It is recommended to set `random_page_cost=1` in Postgres configuration if you are using SSD storage. With this setting Query Planner will make a better use of indexes, expecially for `JOIN` queries. We've noticed a huge speed improvement for some queries.
+It is recommended to set `random_page_cost=1` in Postgres configuration if you
+are using SSD storage. With this setting Query Planner will make a better use of
+indexes, expecially for `JOIN` queries. We've noticed a huge speed improvement
+for some queries.

--- a/content/docs/run-api-server/index.mdx
+++ b/content/docs/run-api-server/index.mdx
@@ -5,16 +5,31 @@ order: 0
 
 import { CodeExample } from "components/CodeExample";
 
-Horizon is responsible for providing an HTTP API to data in the Stellar network. It ingests and re-serves the data produced by the stellar network in a form that is easier to consume than the performance-oriented data representations used by stellar-core.
+Horizon is responsible for providing an HTTP API to data in the Stellar network.
+It ingests and re-serves the data produced by the stellar network in a form that
+is easier to consume than the performance-oriented data representations used by
+stellar-core.
 
-This document describes how to administer a **production** Horizon instance. If you are just starting with Horizon and want to deploy it quickly to test it out, consider the [Quickstart Guide](quickstart.md) instead. For information about developing on the Horizon codebase, check out the [Development Guide](developing.md).
+This document describes how to administer a **production** Horizon instance. If
+you are just starting with Horizon and want to deploy it quickly to test it out,
+consider the [Quickstart Guide](quickstart.md) instead. For information about
+developing on the Horizon codebase, check out the
+[Development Guide](developing.md).
 
 ## Why Run Horizon?
 
-You don't need to run your own Horizon instance to build on Stellar: the Stellar Development Foundation runs two Horizon servers, one for the public network and one for the test network: https://horizon.stellar.org and https://horizon-testnet.stellar.org.  These servers are free for anyone to use, and should be fine for development and small-scale projects.  They are, however, rate limited, and we don't recommended using them for production services that need strong reliability.  
+You don't need to run your own Horizon instance to build on Stellar: the Stellar
+Development Foundation runs two Horizon servers, one for the public network and
+one for the test network: https://horizon.stellar.org and
+https://horizon-testnet.stellar.org. These servers are free for anyone to use,
+and should be fine for development and small-scale projects. They are, however,
+rate limited, and we don't recommended using them for production services that
+need strong reliability.
 
-Running Horizon within your own infrastructure provides a number of benefits.  You can:
+Running Horizon within your own infrastructure provides a number of benefits.
+You can:
 
-  - Disable request rate limiting for guaranteed network access
-  - Have full operational control without dependency on the Stellar Development Foundation
-  - Run multiple instances for redundancy and scalability
+- Disable request rate limiting for guaranteed network access
+- Have full operational control without dependency on the Stellar Development
+  Foundation
+- Run multiple instances for redundancy and scalability

--- a/content/docs/run-api-server/installing.mdx
+++ b/content/docs/run-api-server/installing.mdx
@@ -5,26 +5,42 @@ order: 20
 
 import { CodeExample } from "components/CodeExample";
 
-To install Horizon, you have a choice: you can download a [prebuilt release for your target architecture](https://github.com/stellar/go/releases) and operation system or you can [build Horizon yourself](#Building).  When either approach is complete, you will find yourself with a directory containing a file named `horizon`.  This file is a native binary.
+To install Horizon, you have a choice: you can download a
+[prebuilt release for your target architecture](https://github.com/stellar/go/releases)
+and operation system or you can [build Horizon yourself](#Building). When either
+approach is complete, you will find yourself with a directory containing a file
+named `horizon`. This file is a native binary.
 
-After building or unpacking Horizon, you simply need to copy the native binary into a directory that is part of your PATH.  Most unix-like systems have `/usr/local/bin` in PATH by default, so unless you have a preference or know better, we recommend you copy the binary there.
+After building or unpacking Horizon, you simply need to copy the native binary
+into a directory that is part of your PATH. Most unix-like systems have
+`/usr/local/bin` in PATH by default, so unless you have a preference or know
+better, we recommend you copy the binary there.
 
-To test the installation, simply run `horizon --help` from a terminal.  If the help for Horizon is displayed, your installation was successful. Note: some shells, such as zsh, cache PATH lookups.  You may need to clear your cache  (by using `rehash` in zsh, for example) before trying to run `horizon --help`.
-
+To test the installation, simply run `horizon --help` from a terminal. If the
+help for Horizon is displayed, your installation was successful. Note: some
+shells, such as zsh, cache PATH lookups. You may need to clear your cache (by
+using `rehash` in zsh, for example) before trying to run `horizon --help`.
 
 ## Building
 
-Should you decide not to use one of our prebuilt releases, you may instead build Horizon from source.  To do so, you need to install some developer tools:
+Should you decide not to use one of our prebuilt releases, you may instead build
+Horizon from source. To do so, you need to install some developer tools:
 
-- A unix-like operating system with the common core commands (cp, tar, mkdir, bash, etc.)
+- A unix-like operating system with the common core commands (cp, tar, mkdir,
+  bash, etc.)
 - A compatible distribution of Go (Go 1.13 or later)
 - [git](https://git-scm.com/)
 - [mercurial](https://www.mercurial-scm.org/)
 
-1. See the details in [README.md](../../../../README.md#dependencies) for installing dependencies.
-2. Compile the Horizon binary: `go install github.com/stellar/go/services/horizon`. You should see the `horizon` binary in `$GOPATH/bin`.
-3. Add Go binaries to your PATH in your `bashrc` or equivalent, for easy access: `export PATH=${GOPATH//://bin:}/bin:$PATH`
+1. See the details in [README.md](../../../../README.md#dependencies) for
+   installing dependencies.
+2. Compile the Horizon binary:
+   `go install github.com/stellar/go/services/horizon`. You should see the
+   `horizon` binary in `$GOPATH/bin`.
+3. Add Go binaries to your PATH in your `bashrc` or equivalent, for easy access:
+   `export PATH=${GOPATH//://bin:}/bin:$PATH`
 
-Open a new terminal. Confirm everything worked by running `horizon --help` successfully.
+Open a new terminal. Confirm everything worked by running `horizon --help`
+successfully.
 
-Note:  Building directly on windows is not supported.
+Note: Building directly on windows is not supported.

--- a/content/docs/run-api-server/monitoring.mdx
+++ b/content/docs/run-api-server/monitoring.mdx
@@ -5,18 +5,27 @@ order: 60
 
 import { CodeExample } from "components/CodeExample";
 
-To ensure that your instance of Horizon is performing correctly, we encourage you to monitor it, and provide both logs and metrics to do so.
+To ensure that your instance of Horizon is performing correctly, we encourage
+you to monitor it, and provide both logs and metrics to do so.
 
-Horizon will output logs to standard out.  Information about what requests are coming in will be reported, but more importantly, warnings or errors will also be emitted by default.  A correctly running Horizon instance will not output any warning or error log entries.
+Horizon will output logs to standard out. Information about what requests are
+coming in will be reported, but more importantly, warnings or errors will also
+be emitted by default. A correctly running Horizon instance will not output any
+warning or error log entries.
 
-Metrics are collected while a Horizon process is running and they are exposed at the `/metrics` path.  You can see an example at (https://horizon-testnet.stellar.org/metrics).
+Metrics are collected while a Horizon process is running and they are exposed at
+the `/metrics` path. You can see an example at
+(https://horizon-testnet.stellar.org/metrics).
 
-Below we present a few standard log entries with associated fields. You can use them to build metrics and alerts. Please note that these represent Horizon app metrics only. You should also monitor your hardware metrics like CPU or RAM Utilization.
+Below we present a few standard log entries with associated fields. You can use
+them to build metrics and alerts. Please note that these represent Horizon app
+metrics only. You should also monitor your hardware metrics like CPU or RAM
+Utilization.
 
 ### Starting HTTP request
 
 | Key              | Value                                                                                          |
-|------------------|------------------------------------------------------------------------------------------------|
+| ---------------- | ---------------------------------------------------------------------------------------------- |
 | **`msg`**        | **`Starting request`**                                                                         |
 | `client_name`    | Value of `X-Client-Name` HTTP header representing client name                                  |
 | `client_version` | Value of `X-Client-Version` HTTP header representing client version                            |
@@ -35,7 +44,7 @@ Below we present a few standard log entries with associated fields. You can use 
 ### Finished HTTP request
 
 | Key              | Value                                                                                          |
-|------------------|------------------------------------------------------------------------------------------------|
+| ---------------- | ---------------------------------------------------------------------------------------------- |
 | **`msg`**        | **`Finished request`**                                                                         |
 | `bytes`          | Number of response bytes sent                                                                  |
 | `client_name`    | Value of `X-Client-Name` HTTP header representing client name                                  |
@@ -57,34 +66,37 @@ Below we present a few standard log entries with associated fields. You can use 
 
 ### Metrics
 
-Using the entries above you can build metrics that will help understand performance of a given Horizon node.  For example:
-* Number of requests per minute.
-* Number of requests per route (the most popular routes).
-* Average response time per route.
-* Maximum response time for non-streaming requests.
-* Number of streaming vs. non-streaming requests.
-* Number of rate-limited requests.
-* List of rate-limited IPs.
-* Unique IPs.
-* The most popular SDKs/apps sending requests to a given Horizon node.
-* Average ingestion time of a ledger.
-* Average ingestion time of a transaction.
+Using the entries above you can build metrics that will help understand
+performance of a given Horizon node. For example:
+
+- Number of requests per minute.
+- Number of requests per route (the most popular routes).
+- Average response time per route.
+- Maximum response time for non-streaming requests.
+- Number of streaming vs. non-streaming requests.
+- Number of rate-limited requests.
+- List of rate-limited IPs.
+- Unique IPs.
+- The most popular SDKs/apps sending requests to a given Horizon node.
+- Average ingestion time of a ledger.
+- Average ingestion time of a transaction.
 
 ### Alerts
 
-Below are example alerts with potential causes and solutions. Feel free to add more alerts using your metrics:
+Below are example alerts with potential causes and solutions. Feel free to add
+more alerts using your metrics:
 
-Alert | Cause | Solution
--|-|-
-Spike in number of requests | Potential DoS attack | Lower rate-limiting threshold
-Large number of rate-limited requests | Rate-limiting threshold too low | Increase rate-limiting threshold
-Ingestion is slow | Horizon server spec too low | Increase hardware spec
-Spike in average response time of a single route | Possible bug in a code responsible for rendering a route | Report an issue in Horizon repository.
+| Alert                                            | Cause                                                    | Solution                               |
+| ------------------------------------------------ | -------------------------------------------------------- | -------------------------------------- |
+| Spike in number of requests                      | Potential DoS attack                                     | Lower rate-limiting threshold          |
+| Large number of rate-limited requests            | Rate-limiting threshold too low                          | Increase rate-limiting threshold       |
+| Ingestion is slow                                | Horizon server spec too low                              | Increase hardware spec                 |
+| Spike in average response time of a single route | Possible bug in a code responsible for rendering a route | Report an issue in Horizon repository. |
 
 ## I'm Stuck! Help!
 
-If any of the above steps don't work or you are otherwise prevented from correctly setting up
-Horizon, please join our community and let us know. Either
+If any of the above steps don't work or you are otherwise prevented from
+correctly setting up Horizon, please join our community and let us know. Either
 [post a question at our Stack Exchange](https://stellar.stackexchange.com/) or
-[chat with us on Keybase in #dev_discussion](https://keybase.io/team/stellar.public) to ask for
-help.
+[chat with us on Keybase in #dev_discussion](https://keybase.io/team/stellar.public)
+to ask for help.

--- a/content/docs/run-api-server/prerequisites.mdx
+++ b/content/docs/run-api-server/prerequisites.mdx
@@ -5,8 +5,13 @@ order: 10
 
 import { CodeExample } from "components/CodeExample";
 
-Currently, Horizon is dependent on a Stellar Core server.  While we are working to reduce that dependence, at the moment it still needs access to both the SQL database and the HTTP API published by Stelar Core. See [Run a Core Node](link) to learn how to set up and administer a Stellar Core node.  
+Currently, Horizon is dependent on a Stellar Core server. While we are working
+to reduce that dependence, at the moment it still needs access to both the SQL
+database and the HTTP API published by Stelar Core. See [Run a Core Node](link)
+to learn how to set up and administer a Stellar Core node.
 
-Horizon is also dependent upon a postgres server, which it uses to store processed Core data for ease of use. Horizon requires postgres version >= 9.5.
+Horizon is also dependent upon a postgres server, which it uses to store
+processed Core data for ease of use. Horizon requires postgres version >= 9.5.
 
-In addition to the two prerequisites above, you may optionally install a redis server to be used for rate limiting requests.
+In addition to the two prerequisites above, you may optionally install a redis
+server to be used for rate limiting requests.

--- a/content/docs/run-api-server/quickstart.mdx
+++ b/content/docs/run-api-server/quickstart.mdx
@@ -5,20 +5,34 @@ order: 5
 
 import { CodeExample } from "components/CodeExample";
 
-This document describes how to quickly set up a **test** Stellar Core + Horizon node, that you can play around with to get a feel for how a stellar node operates. **This configuration is not secure!** It is **not** intended as a guide for production administration.
+This document describes how to quickly set up a **test** Stellar Core + Horizon
+node, that you can play around with to get a feel for how a stellar node
+operates. **This configuration is not secure!** It is **not** intended as a
+guide for production administration.
 
-For detailed information about running Horizon and Stellar Core safely in production see the [Horizon Administration Guide](admin.md) and the [Stellar Core Administration Guide](https://www.stellar.org/developers/stellar-core/software/admin.html).
+For detailed information about running Horizon and Stellar Core safely in
+production see the [Horizon Administration Guide](admin.md) and the
+[Stellar Core Administration Guide](https://www.stellar.org/developers/stellar-core/software/admin.html).
 
-If you're ready to roll up your sleeves and dig into the code, check out the [Developer Guide](developing.md).
+If you're ready to roll up your sleeves and dig into the code, check out the
+[Developer Guide](developing.md).
 
 ## Install and run the Quickstart Docker Image
-The fastest way to get up and running is using the [Stellar Quickstart Docker Image](https://github.com/stellar/docker-stellar-core-horizon). This is a Docker container that provides both `stellar-core` and `horizon`, pre-configured for testing.
+
+The fastest way to get up and running is using the
+[Stellar Quickstart Docker Image](https://github.com/stellar/docker-stellar-core-horizon).
+This is a Docker container that provides both `stellar-core` and `horizon`,
+pre-configured for testing.
 
 1. Install [Docker](https://www.docker.com/get-started).
 2. Verify your Docker installation works: `docker run hello-world`
-3. Create a local directory that the container can use to record state. This is helpful because it can take a few minutes to sync a new `stellar-core` with enough data for testing, and because it allows you to inspect and modify the configuration if needed. Here, we create a directory called `stellar` to use as the persistent volume:
-`cd $HOME; mkdir stellar`
-4. Download and run the Stellar Quickstart container, replacing `USER` with your username:
+3. Create a local directory that the container can use to record state. This is
+   helpful because it can take a few minutes to sync a new `stellar-core` with
+   enough data for testing, and because it allows you to inspect and modify the
+   configuration if needed. Here, we create a directory called `stellar` to use
+   as the persistent volume: `cd $HOME; mkdir stellar`
+4. Download and run the Stellar Quickstart container, replacing `USER` with your
+   username:
 
 <CodeExample>
 
@@ -44,9 +58,16 @@ supervisorctl tail -f horizon stderr
 
 </CodeExample>
 
-On a modern laptop this test setup takes about 15 minutes to synchronise with the last couple of days of testnet ledgers. At that point Horizon will be available for querying. 
+On a modern laptop this test setup takes about 15 minutes to synchronise with
+the last couple of days of testnet ledgers. At that point Horizon will be
+available for querying.
 
-See the [Quickstart Docker Image](https://github.com/stellar/docker-stellar-core-horizon) documentation for more details, and alternative ways to run the container. 
+See the
+[Quickstart Docker Image](https://github.com/stellar/docker-stellar-core-horizon)
+documentation for more details, and alternative ways to run the container.
 
-You can test your Horizon instance with a query like: http://localhost:8000/transactions?cursor=&limit=10&order=asc. Use the [Stellar Laboratory](https://www.stellar.org/laboratory/) to craft other queries to try out,
-and read about the available endpoints and see examples in the [Horizon API reference](https://www.stellar.org/developers/horizon/reference/).
+You can test your Horizon instance with a query like:
+http://localhost:8000/transactions?cursor=&limit=10&order=asc. Use the
+[Stellar Laboratory](https://www.stellar.org/laboratory/) to craft other queries
+to try out, and read about the available endpoints and see examples in the
+[Horizon API reference](https://www.stellar.org/developers/horizon/reference/).

--- a/content/docs/run-core-node/configuring.mdx
+++ b/content/docs/run-core-node/configuring.mdx
@@ -5,109 +5,213 @@ order: 40
 
 import { CodeExample } from "components/CodeExample";
 
-After you've [installed](link) Stellar Core, your next step is to complete a configuration file that specifies crucial things about your node — like whether it connects to the testnet or the public network, what database it writes to, and which other nodes are in its [quorum set](link).  You do that using a [TOML](link), and by default Stellar Core loads that file from `./stellar-core.cfg`.  You can specify a different file to load using the command line:
+After you've [installed](link) Stellar Core, your next step is to complete a
+configuration file that specifies crucial things about your node — like whether
+it connects to the testnet or the public network, what database it writes to,
+and which other nodes are in its [quorum set](link). You do that using a
+[TOML](link), and by default Stellar Core loads that file from
+`./stellar-core.cfg`. You can specify a different file to load using the command
+line:
 
 `$ stellar-core --conf betterfile.cfg <COMMAND>`
 
-This section of the docs will walk you through the key fields you'll need to include in your config file to get your node up and runninig.
+This section of the docs will walk you through the key fields you'll need to
+include in your config file to get your node up and runninig.
 
 ## Example Configurations
 
-This doc works best in conjunction with concrete config examples, so as you read through it, you may want to check out the following:
+This doc works best in conjunction with concrete config examples, so as you read
+through it, you may want to check out the following:
 
-* The [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg) documents all possible configuration elements, as well as their default values.  It's got every knob you can twiddle and every setting you can tweak along wiith detailed explanations of how to twiddle and tweak them.  You don't need to put everything from the complete example config into your config file — fields you omit will assume the default setting, and the default setting will generally serve you well — but there are a few required fields, and this doc will explain what they are.     
+- The
+  [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg)
+  documents all possible configuration elements, as well as their default
+  values. It's got every knob you can twiddle and every setting you can tweak
+  along wiith detailed explanations of how to twiddle and tweak them. You don't
+  need to put everything from the complete example config into your config file
+  — fields you omit will assume the default setting, and the default setting
+  will generally serve you well — but there are a few required fields, and this
+  doc will explain what they are.
 
-* If you want to connect to the tesnet, check out the [example test network config](https://github.com/stellar/docker-stellar-core-horizon/blob/master/testnet/core/etc/stellar-core.cfg).  As you can see, most of the fields from the [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg) are omitted since the default settings work fine.  You can easily tailor this config to meet your testnet needs.  
+- If you want to connect to the tesnet, check out the
+  [example test network config](https://github.com/stellar/docker-stellar-core-horizon/blob/master/testnet/core/etc/stellar-core.cfg).
+  As you can see, most of the fields from the
+  [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg)
+  are omitted since the default settings work fine. You can easily tailor this
+  config to meet your testnet needs.
 
-* If you want to connet to the public network, check out this [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg).  It includes a properly crafted quorum set with all the current [Tier 1 validators](link), which is a good place to start for most configurations.  This node is set up to both [validate](link) and write history to a [public archive](link), but you can disable either feature to adjust this config so it's a little lighter.
+- If you want to connet to the public network, check out this
+  [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg).
+  It includes a properly crafted quorum set with all the current
+  [Tier 1 validators](link), which is a good place to start for most
+  configurations. This node is set up to both [validate](link) and write history
+  to a [public archive](link), but you can disable either feature to adjust this
+  config so it's a little lighter.
 
-* Here's a config for a [pubnet watcher](https://github.com/stellar/packages/blob/master/docs/stellar-core_pubnet_watcher.cfg).  It's a little out of date — it still uses the old method for quorum set generation — but we'll fix it soon.  
+- Here's a config for a
+  [pubnet watcher](https://github.com/stellar/packages/blob/master/docs/stellar-core_pubnet_watcher.cfg).
+  It's a little out of date — it still uses the old method for quorum set
+  generation — but we'll fix it soon.
 
 ## Database
-Stellar Core stores two copies of the ledger: one in a SQL database and one in XDR files on local disk called [buckets](link).  The database is consulted during consensus, and modified atomically when a transaction set is applied to the ledger.  It's random access, fine-grained, and fast. 
 
-While a SQLite database works with Stellar Core, we generally recommend using a separate PostgreSQL server.  Horizon, for instance, requires PostgreSQL.  A Postgres database is the bread and butter of Stellar Core.
+Stellar Core stores two copies of the ledger: one in a SQL database and one in
+XDR files on local disk called [buckets](link). The database is consulted during
+consensus, and modified atomically when a transaction set is applied to the
+ledger. It's random access, fine-grained, and fast.
 
-You specify your node's database in the aptly named `DATABASE` field of your config file, which you can can read more about in the [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg#L23).  It defaults to an in-memory database, but you can specify a path as per the example config.
+While a SQLite database works with Stellar Core, we generally recommend using a
+separate PostgreSQL server. Horizon, for instance, requires PostgreSQL. A
+Postgres database is the bread and butter of Stellar Core.
+
+You specify your node's database in the aptly named `DATABASE` field of your
+config file, which you can can read more about in the
+[complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg#L23).
+It defaults to an in-memory database, but you can specify a path as per the
+example config.
 
 ## Buckets
-Stellar-core also stores a duplicate copy of the ledger in the form of flat XDR files  called "buckets." These files are placed in a directory specified in the config file as `BUCKET_DIR_PATH`, which defaults to `buckets`. The bucket files are used for hashing and transmission of ledger differences to history archives. 
 
-Buckets should be stored on a fast local disk with sufficient space to store several times the size of the current ledger. 
- 
-For the most part, the contents of both the database and buckets directories can be ignored as they are managed by Stellar Core.  However, when running Stellar Core for the first time, you must initialize both with the following command:
+Stellar-core also stores a duplicate copy of the ledger in the form of flat XDR
+files called "buckets." These files are placed in a directory specified in the
+config file as `BUCKET_DIR_PATH`, which defaults to `buckets`. The bucket files
+are used for hashing and transmission of ledger differences to history archives.
+
+Buckets should be stored on a fast local disk with sufficient space to store
+several times the size of the current ledger.
+
+For the most part, the contents of both the database and buckets directories can
+be ignored as they are managed by Stellar Core. However, when running Stellar
+Core for the first time, you must initialize both with the following command:
 
 `$ stellar-core new-db`
 
-This command initializes the database and bucket directories, and then exits.  You can also use this command if your DB gets corrupted and you want to restart it from scratch.
+This command initializes the database and bucket directories, and then exits.
+You can also use this command if your DB gets corrupted and you want to restart
+it from scratch.
 
 ## Network Passphrase
 
-Use the `NETWORK_PASSPHRASE` field to specify whether your node connects to the [testnet](liink) or the public network.  Your choices:
-* `NETWORK_PASSPHRASE="Test SDF Network ; September 2015"` 
-* `NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"`  
+Use the `NETWORK_PASSPHRASE` field to specify whether your node connects to the
+[testnet](liink) or the public network. Your choices:
 
-For more about the Network Passphrase and how it works, check out the [glossary entry](link).
+- `NETWORK_PASSPHRASE="Test SDF Network ; September 2015"`
+- `NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"`
+
+For more about the Network Passphrase and how it works, check out the
+[glossary entry](link).
 
 ## Validating
 
-By default, Stellar Core isn't set up to validate.  If you want your node to be a [Basic Validator](link) or a [Full Validator](liink), you need to configure it to do so, which means preparing it to take part in [SCP](link) and sign messages pledging that the network agrees to a particular transaction set.  
+By default, Stellar Core isn't set up to validate. If you want your node to be a
+[Basic Validator](link) or a [Full Validator](liink), you need to configure it
+to do so, which means preparing it to take part in [SCP](link) and sign messages
+pledging that the network agrees to a particular transaction set.
 
-Configuring a node to participate in SCP and sign messages is a three step process:
+Configuring a node to participate in SCP and sign messages is a three step
+process:
 
-* Create a keypair `stellar-core gen-seed`
-* Add `NODE_SEED="SD7DN..."` to your configuration file, where `SD7DN...` is the secret key from the keypair
-* Add `NODE_IS_VALIDATOR=true` to your configuration file
+- Create a keypair `stellar-core gen-seed`
+- Add `NODE_SEED="SD7DN..."` to your configuration file, where `SD7DN...` is the
+  secret key from the keypair
+- Add `NODE_IS_VALIDATOR=true` to your configuration file
 
-If you want other validators to add your node to their quorum sets, you should also share your public key (GDMTUTQ... ) by publishing a stellar.toml file on your homedomain following specs laid out in [SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md). 
+If you want other validators to add your node to their quorum sets, you should
+also share your public key (GDMTUTQ... ) by publishing a stellar.toml file on
+your homedomain following specs laid out in
+[SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md).
 
-It's essential to store and safeguard your node's secret key: if someone else has access to it, they can send messages to the network and they will appear to originate from your node.  Each node you run should have its own secret key.
+It's essential to store and safeguard your node's secret key: if someone else
+has access to it, they can send messages to the network and they will appear to
+originate from your node. Each node you run should have its own secret key.
 
-If you run more than one node, set the `HOME_DOMAIN` common to those nodes using the `NODE_HOME_DOMAIN` property.
-Doing so will allow your nodes to be grouped correctly during [quorum set generation](#home-domains-array).
+If you run more than one node, set the `HOME_DOMAIN` common to those nodes using
+the `NODE_HOME_DOMAIN` property. Doing so will allow your nodes to be grouped
+correctly during [quorum set generation](#home-domains-array).
 
 ## Choosing Your Quorum Set
 
-No matter what kind of node you run — Watcher, Basic Validator, Full Validator, or Archiver — you need to select a quorum set, which consists of validators (grouped by organization) that your node checks with to determine whether to apply a transaction set to a ledger.  If you want to know more about how qorum sets work, check this article about [how Stellar approaches quorums](https://www.stellar.org/developers-blog/why-quorums-matter-and-how-stellar-approaches-them).  If you want to see what a quorum set consisting of all the Tier 1 validators looks like — at tried and true setup — check out the [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg)  
+No matter what kind of node you run — Watcher, Basic Validator, Full Validator,
+or Archiver — you need to select a quorum set, which consists of validators
+(grouped by organization) that your node checks with to determine whether to
+apply a transaction set to a ledger. If you want to know more about how qorum
+sets work, check this article about
+[how Stellar approaches quorums](https://www.stellar.org/developers-blog/why-quorums-matter-and-how-stellar-approaches-them).
+If you want to see what a quorum set consisting of all the Tier 1 validators
+looks like — at tried and true setup — check out the
+[public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg)
 
 A good quorum set:
-* aligns with your organization’s priorities 
-* has enough redundancy to handle arbitrary node failures
-* maintains good quorum intersection 
 
-Since crafting a good quorum set is a difficult thing to do, stellar core *automatically* generates a quorum set for you based on structured information you provide in your config file.  You choose the validators you want to trust; stellar core configures them into an optimal quorum set.
+- aligns with your organization’s priorities
+- has enough redundancy to handle arbitrary node failures
+- maintains good quorum intersection
+
+Since crafting a good quorum set is a difficult thing to do, stellar core
+_automatically_ generates a quorum set for you based on structured information
+you provide in your config file. You choose the validators you want to trust;
+stellar core configures them into an optimal quorum set.
 
 To generate a quorum set, stellar core:
-* Groups validators run by the same organization into a subquorum
-* Sets the threshold for each of those subquorums
-* Gives weights to those subquorums based on quality
 
-While this does not absolve you of all responsibility — you still need to pick trustworthy validators and keep an eye on them to ensure that they’re consistent and reliable — it does make your life easier, and reduces the chances for human error.
+- Groups validators run by the same organization into a subquorum
+- Sets the threshold for each of those subquorums
+- Gives weights to those subquorums based on quality
+
+While this does not absolve you of all responsibility — you still need to pick
+trustworthy validators and keep an eye on them to ensure that they’re consistent
+and reliable — it does make your life easier, and reduces the chances for human
+error.
 
 ### Validator discovery
 
-When you add a validating node to your quorum set, it’s generally because you trust the *organization* running the node: you trust SDF, not some anonymous Stellar public key. 
+When you add a validating node to your quorum set, it’s generally because you
+trust the _organization_ running the node: you trust SDF, not some anonymous
+Stellar public key.
 
-In order to create a self-verified link between a node and the organization that runs it, a validator declares a home domain on-chain using a `set_options` operation, and publishes organizational information in a stellar.toml file hosted on that domain.  To find out how that works, take a look at [SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md).  
+In order to create a self-verified link between a node and the organization that
+runs it, a validator declares a home domain on-chain using a `set_options`
+operation, and publishes organizational information in a stellar.toml file
+hosted on that domain. To find out how that works, take a look at
+[SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md).
 
-As a result of that link, you can look up a node by its Stellar public key and check the stellar.toml to find out who runs it.  It’s possible to do that manually, but you can also just consult the list of nodes on [Stellarbeat.io](https://stellarbeat.io/nodes).  If you decide to trust an organization, you can use that list to collect the information necessary to add their nodes to your configuration.  
+As a result of that link, you can look up a node by its Stellar public key and
+check the stellar.toml to find out who runs it. It’s possible to do that
+manually, but you can also just consult the list of nodes on
+[Stellarbeat.io](https://stellarbeat.io/nodes). If you decide to trust an
+organization, you can use that list to collect the information necessary to add
+their nodes to your configuration.
 
-When you look at that list, you will discover that the most reliable organizations actually run more than one validator, and adding all of an organization’s nodes to your quorum set creates the redundancy necessary to sustain arbitrary node failure.  When an organization with a trio of nodes takes one down for maintenance, for instance, the remaining two vote on the organization’s behalf, and the organization’s network presence persists.
+When you look at that list, you will discover that the most reliable
+organizations actually run more than one validator, and adding all of an
+organization’s nodes to your quorum set creates the redundancy necessary to
+sustain arbitrary node failure. When an organization with a trio of nodes takes
+one down for maintenance, for instance, the remaining two vote on the
+organization’s behalf, and the organization’s network presence persists.
 
-One important thing to note: you need to either depend on exactly one entity OR have **at least 4 entities** for automatic quorum set configuration to work properly.  At least 4 is the better option.
+One important thing to note: you need to either depend on exactly one entity OR
+have **at least 4 entities** for automatic quorum set configuration to work
+properly. At least 4 is the better option.
 
 ### Home domains array
 
-To create your quorum set, Stellar Core relies on two arrays of tables: `[[HOME_DOMAINS]]` and `[[VALIDATORS]]`.  Check out the [example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg#L372) to see those arrays in action.
+To create your quorum set, Stellar Core relies on two arrays of tables:
+`[[HOME_DOMAINS]]` and `[[VALIDATORS]]`. Check out the
+[example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg#L372)
+to see those arrays in action.
 
-`[[HOME_DOMAINS]]` defines a superset of validators: when you add nodes hosted by the same organization to your configuration, they share a home domain, and the information in the `[[HOME_DOMAINS]]` table, specifically the quality rating, will automatically apply to every one of those validators. 
+`[[HOME_DOMAINS]]` defines a superset of validators: when you add nodes hosted
+by the same organization to your configuration, they share a home domain, and
+the information in the `[[HOME_DOMAINS]]` table, specifically the quality
+rating, will automatically apply to every one of those validators.
 
-For each organization you want to add, create a separate `[[HOME_DOMAINS]]` table, and complete the following required fields:
+For each organization you want to add, create a separate `[[HOME_DOMAINS]]`
+table, and complete the following required fields:
 
-Field | Requirements | Description
-------|--------------|------------
-HOME_DOMAIN | string | URL of home domain linked to a group of validators
-QUALITY | string | Rating for organization's nodes: `HIGH`, `MEDIUM`, or `LOW`
+| Field       | Requirements | Description                                                 |
+| ----------- | ------------ | ----------------------------------------------------------- |
+| HOME_DOMAIN | string       | URL of home domain linked to a group of validators          |
+| QUALITY     | string       | Rating for organization's nodes: `HIGH`, `MEDIUM`, or `LOW` |
 
 Here’s an example:
 
@@ -127,18 +231,22 @@ QUALITY="LOW"
 
 ### Validators array
 
-For each node you would like to add to your quorum set, complete a `[[VALIDATORS]]` table with the following fields:  
+For each node you would like to add to your quorum set, complete a
+`[[VALIDATORS]]` table with the following fields:
 
-Field | Requirements | Description
-------|--------------|------------
-NAME | string | A unique alias for the node
-QUALITY | string | Rating for node (required unless specified in `[[HOME_DOMAINS]]`): `HIGH`, `MEDIUM`, or `LOW`.
-HOME_DOMAIN | string | URL of home domain linked to validator
-PUBLIC_KEY | string | Stellar public key associated with validator
-ADDRESS | string | Peer:port associated with validator (optional)
-HISTORY | string | archive GET command associated with validator (optional)
+| Field       | Requirements | Description                                                                                    |
+| ----------- | ------------ | ---------------------------------------------------------------------------------------------- |
+| NAME        | string       | A unique alias for the node                                                                    |
+| QUALITY     | string       | Rating for node (required unless specified in `[[HOME_DOMAINS]]`): `HIGH`, `MEDIUM`, or `LOW`. |
+| HOME_DOMAIN | string       | URL of home domain linked to validator                                                         |
+| PUBLIC_KEY  | string       | Stellar public key associated with validator                                                   |
+| ADDRESS     | string       | Peer:port associated with validator (optional)                                                 |
+| HISTORY     | string       | archive GET command associated with validator (optional)                                       |
 
-If the node's `HOME_DOMAIN` aligns with an organization defined in the `[[HOME_DOMAINS]]` array, the quality rating specified there will apply to the node.  If you’re adding an individual node that is *not* covered in that array, you’ll need to specify the `QUALITY` here.
+If the node's `HOME_DOMAIN` aligns with an organization defined in the
+`[[HOME_DOMAINS]]` array, the quality rating specified there will apply to the
+node. If you’re adding an individual node that is _not_ covered in that array,
+you’ll need to specify the `QUALITY` here.
 
 Here’s an example:
 
@@ -171,28 +279,49 @@ ADDRESS="core.rando.com"
 
 ### Validator quality
 
-`QUALITY` is a required field for each node you add to your quorum set.  Whether you specify it for a suite of nodes in `[[HOME_DOMAINS]]` or for a single node in `[[VALIDATORS]]`, it means the same thing, and you have the same three rating options: HIGH, MEDIUM, or LOW.
+`QUALITY` is a required field for each node you add to your quorum set. Whether
+you specify it for a suite of nodes in `[[HOME_DOMAINS]]` or for a single node
+in `[[VALIDATORS]]`, it means the same thing, and you have the same three rating
+options: HIGH, MEDIUM, or LOW.
 
-**HIGH** quality validators are given the most weight in automatic quorum set configuration.  Before assigning a high quality rating to a node, make sure it has low latency and good uptime, and that the organization running the node is reliable and trustworthy.  
+**HIGH** quality validators are given the most weight in automatic quorum set
+configuration. Before assigning a high quality rating to a node, make sure it
+has low latency and good uptime, and that the organization running the node is
+reliable and trustworthy.
 
 A high quality a validator:
-* publishes an archive
-* belongs to a suite of nodes that provide redundancy 
 
-Choosing redundant nodes is good practice.  The archive requirement is programmatically enforced.
+- publishes an archive
+- belongs to a suite of nodes that provide redundancy
 
-**MEDIUM** quality validators are nested below high quality validators, and their combined weight is equivalent to a *single high quality entity*.  If a node doesn't publish an archive, but you deem it reliable, or have an organizational interest in including in your quorum set, give it a medium quality rating.  
+Choosing redundant nodes is good practice. The archive requirement is
+programmatically enforced.
 
-**LOW** quality validators are nested below medium quality validators, and their combined weight is equivalent to a *single medium quality entity*.    Should they prove reliable over time, you can upgrade their rating to medium to give them a bigger role in your quorum set configuration. 
- 
+**MEDIUM** quality validators are nested below high quality validators, and
+their combined weight is equivalent to a _single high quality entity_. If a node
+doesn't publish an archive, but you deem it reliable, or have an organizational
+interest in including in your quorum set, give it a medium quality rating.
+
+**LOW** quality validators are nested below medium quality validators, and their
+combined weight is equivalent to a _single medium quality entity_. Should they
+prove reliable over time, you can upgrade their rating to medium to give them a
+bigger role in your quorum set configuration.
+
 ### Automatic quorum set generation
-Once you add validators to your configuration, stellar core automatically generates a quorum set using the following rules:
-* Validators with the same home domain are automatically grouped together and given a threshold requiring a simple majority (2f+1)
-* Heterogeneous groups of validators are given a threshold assuming byzantine failure (3f+1)
-* Entities are grouped by QUALITY and nested from HIGH to LOW 
-* HIGH quality entities are at the top, and are given decision-making priority 
-* The combined weight of MEDIUM quality entities equals a single HIGH quality entity  
-* The combined weight of LOW quality entities equals a single MEDIUM quality entity
+
+Once you add validators to your configuration, stellar core automatically
+generates a quorum set using the following rules:
+
+- Validators with the same home domain are automatically grouped together and
+  given a threshold requiring a simple majority (2f+1)
+- Heterogeneous groups of validators are given a threshold assuming byzantine
+  failure (3f+1)
+- Entities are grouped by QUALITY and nested from HIGH to LOW
+- HIGH quality entities are at the top, and are given decision-making priority
+- The combined weight of MEDIUM quality entities equals a single HIGH quality
+  entity
+- The combined weight of LOW quality entities equals a single MEDIUM quality
+  entity
 
 Here's a diagram depicting the nested quality levels and how they interact:
 
@@ -200,54 +329,111 @@ Here's a diagram depicting the nested quality levels and how they interact:
 
 ### Quorum and Overlay Network
 
-It is generally a good idea to give information to your validator on other validators that you rely on. This is achieved by configuring `KNOWN_PEERS` and `PREFERRED_PEERS` with the addresses of your dependencies.
+It is generally a good idea to give information to your validator on other
+validators that you rely on. This is achieved by configuring `KNOWN_PEERS` and
+`PREFERRED_PEERS` with the addresses of your dependencies.
 
-Additionally, configuring `PREFERRED_PEER_KEYS` with the keys from your quorum set might be a good idea to give priority to the nodes that allow you to reach consensus.
+Additionally, configuring `PREFERRED_PEER_KEYS` with the keys from your quorum
+set might be a good idea to give priority to the nodes that allow you to reach
+consensus.
 
-Without those settings, your validator depends on other nodes on the network to forward you the right messages, which is typically done as a best effort.
+Without those settings, your validator depends on other nodes on the network to
+forward you the right messages, which is typically done as a best effort.
 
 ### Updating and Coordinating Your Quorum Set
 
-When you join the ranks of node operators, it's also important to join the conversation.  The best way to do that: get on the #validators channel on the [Stellar Keybase](link) and sign up for the [validators google group](link).  That way, you can and coordinate changes with the rest of the network.
+When you join the ranks of node operators, it's also important to join the
+conversation. The best way to do that: get on the #validators channel on the
+[Stellar Keybase](link) and sign up for the [validators google group](link).
+That way, you can and coordinate changes with the rest of the network.
 
-When you need to make changes to your validator or to your quorum set — say you take a validator down for maintenance or add new validators to your node's quorum set — it's crucial to stage the changes to preserve quorum intersection and general good health of the network:
+When you need to make changes to your validator or to your quorum set — say you
+take a validator down for maintenance or add new validators to your node's
+quorum set — it's crucial to stage the changes to preserve quorum intersection
+and general good health of the network:
 
-  * Don't remove too many nodes from your quorum set *before* the nodes are taken down.  If different validators remove different sets, the remaining sets may not overlap, which could cause network splits
-  
-  * Don't add too many nodes in your quorum set at the same time.  If not done carefully, the new nodes could overpower your configuration
+- Don't remove too many nodes from your quorum set _before_ the nodes are taken
+  down. If different validators remove different sets, the remaining sets may
+  not overlap, which could cause network splits
 
-When you want to add or remove nodes, start by making changes to your own nodes' quorum sets, and then coordinate work with others to reflect those changes gradually.
+- Don't add too many nodes in your quorum set at the same time. If not done
+  carefully, the new nodes could overpower your configuration
+
+When you want to add or remove nodes, start by making changes to your own nodes'
+quorum sets, and then coordinate work with others to reflect those changes
+gradually.
 
 ## History
-Stellar Core normally interacts with one or more history archive, which are configurable facilities where [Full Validators](link) and [Archivers](link) store flat files containing history checkpoints: bucket files and history logs. History archives are usually off-site commodity storage services such as Amazon S3, Google Cloud Storage, Azure Blob Storage, or custom SCP/SFTP/HTTP servers.  To find out how to *publish* a history archive, consult [Publishing History Archives](link).
 
-No matter what kind of node you're running, you should configure it to `get` history from one or more public archives.  You can configure any number of archives to download from: Stellar Core will automatically round-robin between them.
+Stellar Core normally interacts with one or more history archive, which are
+configurable facilities where [Full Validators](link) and [Archivers](link)
+store flat files containing history checkpoints: bucket files and history logs.
+History archives are usually off-site commodity storage services such as Amazon
+S3, Google Cloud Storage, Azure Blob Storage, or custom SCP/SFTP/HTTP servers.
+To find out how to _publish_ a history archive, consult
+[Publishing History Archives](link).
 
-When you're [choosing your quorum set](link), you should include [high-quality](link) nodes — which, by defintion, publish archives — and add the location for each node's archive in the `HISTORY` field in the [validators array](#validators-array).   
+No matter what kind of node you're running, you should configure it to `get`
+history from one or more public archives. You can configure any number of
+archives to download from: Stellar Core will automatically round-robin between
+them.
 
-You can also use command templates in the config file to specify additional archives you'd like to use and how to access them. The [example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg) 
-shows how to configure a history archive through command templates. 
+When you're [choosing your quorum set](link), you should include
+[high-quality](link) nodes — which, by defintion, publish archives — and add the
+location for each node's archive in the `HISTORY` field in the
+[validators array](#validators-array).
 
-Note: if you notice a lot of errors related to downloading archives, you should check that all archives in your configuration are up to date.
+You can also use command templates in the config file to specify additional
+archives you'd like to use and how to access them. The
+[example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg)
+shows how to configure a history archive through command templates.
 
+Note: if you notice a lot of errors related to downloading archives, you should
+check that all archives in your configuration are up to date.
 
 ## Automatic Maintenance
-Some tables in Stellar Core's database act as a publishing queue for external systems such as Horizon and generate **meta data** for changes happening to the distributed ledger.
 
-If not managed properly those tables will grow without bounds. To avoid this, a built-in scheduler will delete data from old ledgers that are not used anymore by other parts of the system (external systems included).
+Some tables in Stellar Core's database act as a publishing queue for external
+systems such as Horizon and generate **meta data** for changes happening to the
+distributed ledger.
 
-The settings that control the automatic maintenance behavior are: `AUTOMATIC_MAINTENANCE_PERIOD`,  `AUTOMATIC_MAINTENANCE_COUNT` and `KNOWN_CURSORS`.
+If not managed properly those tables will grow without bounds. To avoid this, a
+built-in scheduler will delete data from old ledgers that are not used anymore
+by other parts of the system (external systems included).
 
-By default, Stellar Core will perform this automatic maintenance, so be sure to disable it until you have done the appropriate data ingestion in downstream systems (Horizon for example sometimes needs to reingest data).
+The settings that control the automatic maintenance behavior are:
+`AUTOMATIC_MAINTENANCE_PERIOD`, `AUTOMATIC_MAINTENANCE_COUNT` and
+`KNOWN_CURSORS`.
 
-If you need to regenerate the metadata, the simplest way is to replay ledgers for the range you're interested in after (optionally) clearing the database with `newdb`.
+By default, Stellar Core will perform this automatic maintenance, so be sure to
+disable it until you have done the appropriate data ingestion in downstream
+systems (Horizon for example sometimes needs to reingest data).
+
+If you need to regenerate the metadata, the simplest way is to replay ledgers
+for the range you're interested in after (optionally) clearing the database with
+`newdb`.
 
 ## Metadata Snapshots and Restoration
-Some deployments of Stellar Core and Horizon will want to retain metadata for the _entire history_ of the network. This metadata can be quite large and computationally expensive to regenerate anew by replaying ledgers in stellar-core from an empty initial database state, as described in the previous section.
 
-This can be especially costly if run more than once. For instance, when bringing a new node online. Or even if running a single node with Horizon, having already ingested the meta data _once_: a subsequent version of Horizon may have a schema change that entails re-ingesting it _again_.
+Some deployments of Stellar Core and Horizon will want to retain metadata for
+the _entire history_ of the network. This metadata can be quite large and
+computationally expensive to regenerate anew by replaying ledgers in
+stellar-core from an empty initial database state, as described in the previous
+section.
 
-Some operators therefore prefer to shut down their stellar-core (and/or Horizon) processes and _take filesystem-level snapshots_ or _database-level dumps_ of the contents of Stellar Core's database and bucket directory, and/or Horizon's database, after metadata generation has occurred the first time. Such snapshots can then be restored, putting stellar-core and/or Horizon in a state containing metadata without performing full replay.
+This can be especially costly if run more than once. For instance, when bringing
+a new node online. Or even if running a single node with Horizon, having already
+ingested the meta data _once_: a subsequent version of Horizon may have a schema
+change that entails re-ingesting it _again_.
 
-Any reasonably recent state will do — if such a snapshot is a little old, stellar-core will replay ledgers from whenever the snapshot was taken to the current network state anyways — but this procedure can greatly accelerate restoring validator nodes, or cloning them to create new ones.
+Some operators therefore prefer to shut down their stellar-core (and/or Horizon)
+processes and _take filesystem-level snapshots_ or _database-level dumps_ of the
+contents of Stellar Core's database and bucket directory, and/or Horizon's
+database, after metadata generation has occurred the first time. Such snapshots
+can then be restored, putting stellar-core and/or Horizon in a state containing
+metadata without performing full replay.
 
+Any reasonably recent state will do — if such a snapshot is a little old,
+stellar-core will replay ledgers from whenever the snapshot was taken to the
+current network state anyways — but this procedure can greatly accelerate
+restoring validator nodes, or cloning them to create new ones.

--- a/content/docs/run-core-node/index.mdx
+++ b/content/docs/run-core-node/index.mdx
@@ -3,72 +3,155 @@ title: "Overview"
 order: 10
 ---
 
-Stellar is a peer-to-peer network made up of nodes, which are computers that keep a common distributed [ledger](link), and that communicate to validate and add [transactions](link) to it.  Nodes use a program called Stellar Core — an implementation of the [Stellar Consensus Protocol](link) — to stay in sync as they work to agree on the validity of transaction sets and to apply them to the ledger.  Generally, nodes reach consensus, apply a transaction set, and update the ledger every 3-5 seconds.
+Stellar is a peer-to-peer network made up of nodes, which are computers that
+keep a common distributed [ledger](link), and that communicate to validate and
+add [transactions](link) to it. Nodes use a program called Stellar Core — an
+implementation of the [Stellar Consensus Protocol](link) — to stay in sync as
+they work to agree on the validity of transaction sets and to apply them to the
+ledger. Generally, nodes reach consensus, apply a transaction set, and update
+the ledger every 3-5 seconds.
 
-You don’t need to run a node to build on Stellar: you can start developing with your [SDK of choice](link), and use public instances of Horizon to query the ledger and submit transactions right away.  In fact, the Stellar Development Foundation offers two public instances of Horizon — one for the public network and one for the testnet — which you can read more about in our [API reference docs](link).  [Lobstr](link) and [Satoshipay](link) also offer public Horizon instances.
+You don’t need to run a node to build on Stellar: you can start developing with
+your [SDK of choice](link), and use public instances of Horizon to query the
+ledger and submit transactions right away. In fact, the Stellar Development
+Foundation offers two public instances of Horizon — one for the public network
+and one for the testnet — which you can read more about in our
+[API reference docs](link). [Lobstr](link) and [Satoshipay](link) also offer
+public Horizon instances.
 
-If you’re serious about building on Stellar, have a production-level product or service that requires high-availability access network, or want to help increase network health and decentralization, then you probably *do* want to run a node, or even a trio of nodes (more on that in the [Tier 1 section](link)).  At that point, you have a choice: you can pay a service provider like [Blockdaemon](link) to set up and run your node for you, or you can do it yourself. 
+If you’re serious about building on Stellar, have a production-level product or
+service that requires high-availability access network, or want to help increase
+network health and decentralization, then you probably _do_ want to run a node,
+or even a trio of nodes (more on that in the [Tier 1 section](link)). At that
+point, you have a choice: you can pay a service provider like
+[Blockdaemon](link) to set up and run your node for you, or you can do it
+yourself.
 
-If you’re going the DIY route, this section of the docs is for you.  It explains the technical and operational aspects of installing, configuring, and maintaining a Stellar Core node, and should help you figure out the best way to set up your Stellar integration.
+If you’re going the DIY route, this section of the docs is for you. It explains
+the technical and operational aspects of installing, configuring, and
+maintaining a Stellar Core node, and should help you figure out the best way to
+set up your Stellar integration.
 
-The basic flow, which you can navigate through using the menu on the left, goes like this:
-* Choose which type of node you want to run
-* Prepare Your Environment
-* Install Stellar Core
-* Configure Stellar Core
-* Join the network
-* Monitor and maintain your node
-* Join the validators channels to stay on top of critical upgrades and network votes
+The basic flow, which you can navigate through using the menu on the left, goes
+like this:
+
+- Choose which type of node you want to run
+- Prepare Your Environment
+- Install Stellar Core
+- Configure Stellar Core
+- Join the network
+- Monitor and maintain your node
+- Join the validators channels to stay on top of critical upgrades and network
+  votes
 
 ## Types of nodes
-All nodes perform the same basic functions: they run Stellar Core, connect to peers, submit transactions, store the state of the ledger in a SQL [database](link), and keep a duplicate copy of the ledger in flat XDR files called [buckets](link).  All nodes also support [Horizon](link), the Stellar API.  
 
-In addition to those basic functions, there are two key configuration options that determine how a node behaves.  A node can:
-* Participate in consensus to [validate transactions](link)
-* Publish an [archive](link) that other nodes can consult to find the complete history of the network. 
+All nodes perform the same basic functions: they run Stellar Core, connect to
+peers, submit transactions, store the state of the ledger in a SQL
+[database](link), and keep a duplicate copy of the ledger in flat XDR files
+called [buckets](link). All nodes also support [Horizon](link), the Stellar API.
 
-To make things easier, we’ll define four types of nodes based on permutations of those two options: **Watcher**, **Basic Validator**, **Full Validator**, and **Archiver**.  You’ll notice that they *all* support Horizon and submit transactions to the network:
+In addition to those basic functions, there are two key configuration options
+that determine how a node behaves. A node can:
 
+- Participate in consensus to [validate transactions](link)
+- Publish an [archive](link) that other nodes can consult to find the complete
+  history of the network.
 
-| Type of Node | Supports Horizon | Submits Transactions | Validates Transactions | Publishes History |
-|--------------|------------------|----------------------|------------------------|-------------------|
-|**Watcher**   | :heavy_check_mark:              | :heavy_check_mark:                 |                    |              |
-|**Basic Validator**| :heavy_check_mark:         | :heavy_check_mark:                 | :heavy_check_mark:                   |                |
-|**Full Validator**| :heavy_check_mark:          | :heavy_check_mark:              | :heavy_check_mark:                | :heavy_check_mark:               |
-|**Archiver**| :heavy_check_mark: | :heavy_check_mark: | |:heavy_check_mark: |
+To make things easier, we’ll define four types of nodes based on permutations of
+those two options: **Watcher**, **Basic Validator**, **Full Validator**, and
+**Archiver**. You’ll notice that they _all_ support Horizon and submit
+transactions to the network:
 
-So why choose one type over another?  Let’s break it down a bit and take a look at what each type is good for.
+| Type of Node        | Supports Horizon   | Submits Transactions | Validates Transactions | Publishes History  |
+| ------------------- | ------------------ | -------------------- | ---------------------- | ------------------ |
+| **Watcher**         | :heavy_check_mark: | :heavy_check_mark:   |                        |                    |
+| **Basic Validator** | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark:     |                    |
+| **Full Validator**  | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark:     | :heavy_check_mark: |
+| **Archiver**        | :heavy_check_mark: | :heavy_check_mark:   |                        | :heavy_check_mark: |
+
+So why choose one type over another? Let’s break it down a bit and take a look
+at what each type is good for.
 
 ### Watcher
-#### Non-validating, no public archive
-A Watcher is the lightest node you can run.  It keeps track of the ledger and submits transactions for possible inclusion, but it is *not* configured to participate in validation or to publish a history archive, which means it doesn’t do anything to support the network or increase decentralization. 
 
-Watchers pair well with Horizon, and if all you need is a Horizon instance to query the ledger or submit transactions, a Watcher is probably the right choice for you.  While there are public instances of Horizon you can use — namely those maintained by [SDF](link), [Lobstr](link), and [Satoshipay](link) — they’re all rate limited, so they won’t work if you need to scale your project or you want to offer your customers an SLA — 99% uptime, for instance.
+#### Non-validating, no public archive
+
+A Watcher is the lightest node you can run. It keeps track of the ledger and
+submits transactions for possible inclusion, but it is _not_ configured to
+participate in validation or to publish a history archive, which means it
+doesn’t do anything to support the network or increase decentralization.
+
+Watchers pair well with Horizon, and if all you need is a Horizon instance to
+query the ledger or submit transactions, a Watcher is probably the right choice
+for you. While there are public instances of Horizon you can use — namely those
+maintained by [SDF](link), [Lobstr](link), and [Satoshipay](link) — they’re all
+rate limited, so they won’t work if you need to scale your project or you want
+to offer your customers an SLA — 99% uptime, for instance.
 
 **Use a Watcher to run Horizon, and to ensure reliable access to the network.**
 
 ### Basic Validator
+
 #### Validating, no public archive
-A Basic Validator is a lot like a Watcher, and has the same advantages and similar operational requirements. The difference between the two is that a Basic Validator requires a secret key, and is [configured to participate in consensus](link) by voting on — and signing off on — changes to the ledger.  
 
-The advantage: signatures can serve as official endorsements of specific ledgers in real time.  That’s important if, for instance, you issue an asset on Stellar that represents a real-world asset: you can let your customers know that you will only honor transactions and redeem assets from ledgers signed by your validator, and in the unlikely scenario that something happens to the network, you can use your node as the final arbiter of truth.  Setting up your node as a validator allows you to resolve any questions *up front and in writing* about how you plan to deal with disasters and disputes. 
+A Basic Validator is a lot like a Watcher, and has the same advantages and
+similar operational requirements. The difference between the two is that a Basic
+Validator requires a secret key, and is
+[configured to participate in consensus](link) by voting on — and signing off on
+— changes to the ledger.
 
-**Use a Basic Validator to run Horizon, ensure reliable access to the network, and sign off on transactions.**
+The advantage: signatures can serve as official endorsements of specific ledgers
+in real time. That’s important if, for instance, you issue an asset on Stellar
+that represents a real-world asset: you can let your customers know that you
+will only honor transactions and redeem assets from ledgers signed by your
+validator, and in the unlikely scenario that something happens to the network,
+you can use your node as the final arbiter of truth. Setting up your node as a
+validator allows you to resolve any questions _up front and in writing_ about
+how you plan to deal with disasters and disputes.
+
+**Use a Basic Validator to run Horizon, ensure reliable access to the network,
+and sign off on transactions.**
 
 ### Full Validator
+
 #### Validating, offers public archive
-A Full Validator is the same as a Basic Validator except that it also publishes a [History Archive](link) containing snapshots of the ledger, including all transactions and their results.  A Full Validator writes to an internet-facing blob store — such as AWS or Azure — so it's a bit more expensive and complex to run, but it also does the most to support the network’s resilience and decentralization.
 
-When other nodes join the network — or experience difficulty and temporarily fall out of sync — they can consult archives offered by Full Validators to catch up on the history of the network.  Redundant archives prevent a single point of failure, and allow network participants to verify the veracity of a given history. 
+A Full Validator is the same as a Basic Validator except that it also publishes
+a [History Archive](link) containing snapshots of the ledger, including all
+transactions and their results. A Full Validator writes to an internet-facing
+blob store — such as AWS or Azure — so it's a bit more expensive and complex to
+run, but it also does the most to support the network’s resilience and
+decentralization.
 
-Full Validators can support Horizon, but generally, organizations that run them don’t use them to query network data or submit transactions.  In fact, they often run a Watcher to handle Horizon *in addition* to Full Validators.  Most of those organizations are also part of — or on track to  join — [Tier 1](link), which is a core group of network participants who run three Full Validators to contribute maximum redundancy.  
+When other nodes join the network — or experience difficulty and temporarily
+fall out of sync — they can consult archives offered by Full Validators to catch
+up on the history of the network. Redundant archives prevent a single point of
+failure, and allow network participants to verify the veracity of a given
+history.
 
-**Use a Full Validator to sign off on transactions, and to contribute to the health and decentralization of the network.**
+Full Validators can support Horizon, but generally, organizations that run them
+don’t use them to query network data or submit transactions. In fact, they often
+run a Watcher to handle Horizon _in addition_ to Full Validators. Most of those
+organizations are also part of — or on track to join — [Tier 1](link), which is
+a core group of network participants who run three Full Validators to contribute
+maximum redundancy.
+
+**Use a Full Validator to sign off on transactions, and to contribute to the
+health and decentralization of the network.**
 
 ### Archiver
-#### Non-validating, offers public archive 
-An Archiver is a rare bird: like a Full Validator, it publishes the activity of the network in long-term storage; unlike a Full Validator, it does not participate in consensus.
 
-Archivers help with decentralization a bit by offering redundant accounts of the network’s history, but they don’t vote or sign ledgers, so their usefulness is fairly limited.  If you run a Stellar-facing service, like a blockchain explorer, you may want to run one.  Otherwise, you’re probably better off choosing one of the other three types.
+#### Non-validating, offers public archive
 
-**Use an archiver if you want to referee the network.  Which is unlikely.**
+An Archiver is a rare bird: like a Full Validator, it publishes the activity of
+the network in long-term storage; unlike a Full Validator, it does not
+participate in consensus.
+
+Archivers help with decentralization a bit by offering redundant accounts of the
+network’s history, but they don’t vote or sign ledgers, so their usefulness is
+fairly limited. If you run a Stellar-facing service, like a blockchain explorer,
+you may want to run one. Otherwise, you’re probably better off choosing one of
+the other three types.
+
+**Use an archiver if you want to referee the network. Which is unlikely.**

--- a/content/docs/run-core-node/installation.mdx
+++ b/content/docs/run-core-node/installation.mdx
@@ -2,34 +2,66 @@
 title: Installing
 order: 30
 ---
-There are three ways to install Stellar Core: you can use a Docker image, use pre-built packages, or build from source.  Using a Docker image is the quickest and easiest method, so it's a good choice for a lot of developers, but if you're running Stellar Core in production you may need to use packages or, if you want to sacrficie convenience for maximum control, build from source.  Whichever method you use, you should make sure to install the latest [release](link) since releases are cumulative and backwards compatible. 
+
+There are three ways to install Stellar Core: you can use a Docker image, use
+pre-built packages, or build from source. Using a Docker image is the quickest
+and easiest method, so it's a good choice for a lot of developers, but if you're
+running Stellar Core in production you may need to use packages or, if you want
+to sacrficie convenience for maximum control, build from source. Whichever
+method you use, you should make sure to install the latest [release](link) since
+releases are cumulative and backwards compatible.
 
 ## Docker-based installation
 
-The SDF maintains a [quickstart image](https://github.com/stellar/docker-stellar-core-horizon) that bundles Stellar Core with Horizon and postgreSQL databases.  It's a quick way to set up a default, non-validating, ephemeral configuration that should work for most developers.
+The SDF maintains a
+[quickstart image](https://github.com/stellar/docker-stellar-core-horizon) that
+bundles Stellar Core with Horizon and postgreSQL databases. It's a quick way to
+set up a default, non-validating, ephemeral configuration that should work for
+most developers.
 
-The SDF also maintains a Stellar-Core-only [standalone image](https://github.com/stellar/docker-stellar-core) that starts a 3 node local stellar-core network, all on the same docker host   
+The SDF also maintains a Stellar-Core-only
+[standalone image](https://github.com/stellar/docker-stellar-core) that starts a
+3 node local stellar-core network, all on the same docker host
 
-In addition to the SDF images, Satoshipay maintains Docker separate images for [Stellar Core](https://github.com/satoshipay/docker-stellar-core) and [Horizon](https://github.com/satoshipay/docker-stellar-horizon).  The Satoshipay Stellar Core Docker image comes in a few flavors, including one with the AWS CLI installed and one with the Google Cloud SDK installed.  The Horizon image supports all Horizon environment varilables.
+In addition to the SDF images, Satoshipay maintains Docker separate images for
+[Stellar Core](https://github.com/satoshipay/docker-stellar-core) and
+[Horizon](https://github.com/satoshipay/docker-stellar-horizon). The Satoshipay
+Stellar Core Docker image comes in a few flavors, including one with the AWS CLI
+installed and one with the Google Cloud SDK installed. The Horizon image
+supports all Horizon environment varilables.
 
 ## Package-based Installation
 
-If you are using Ubuntu 16.04 LTS, we provide the latest stable releases of [stellar-core](https://github.com/stellar/stellar-core) and [stellar-horizon](https://github.com/stellar/go/tree/master/services/horizon) in Debian binary package format.
+If you are using Ubuntu 16.04 LTS, we provide the latest stable releases of
+[stellar-core](https://github.com/stellar/stellar-core) and
+[stellar-horizon](https://github.com/stellar/go/tree/master/services/horizon) in
+Debian binary package format.
 
-You may choose to install these packages individually, which offers the greatest flexibility but requires **manual** creation of the relevant configuration files and configuration of a **PostgreSQL** database.
+You may choose to install these packages individually, which offers the greatest
+flexibility but requires **manual** creation of the relevant configuration files
+and configuration of a **PostgreSQL** database.
 
-Most people, however, choose to install the **stellar-quickstart** package which configures a **Testnet** `stellar-core` and `stellar-horizon` both backed by a local PostgreSQL database.  Once installed you can easily modify either the Stellar Core [configuration](link) if you want to connect to the public network. 
+Most people, however, choose to install the **stellar-quickstart** package which
+configures a **Testnet** `stellar-core` and `stellar-horizon` both backed by a
+local PostgreSQL database. Once installed you can easily modify either the
+Stellar Core [configuration](link) if you want to connect to the public network.
 
 ## Installing from source
 
-See the [install from source](https://github.com/stellar/stellar-core/blob/master/INSTALL.md) for build instructions.
+See the
+[install from source](https://github.com/stellar/stellar-core/blob/master/INSTALL.md)
+for build instructions.
 
 ## Release version
 
-In general you should install the latest [release](https://github.com/stellar/stellar-core/releases) bulds builds are backward compatible and are cumulative.
+In general you should install the latest
+[release](https://github.com/stellar/stellar-core/releases) bulds builds are
+backward compatible and are cumulative.
 
-The version number scheme that we follow is `protocol_version.release_number.patch_number` where:
+The version number scheme that we follow is
+`protocol_version.release_number.patch_number` where:
 
-`protocol_version` is the maximum protocol version supported by that release (all versions are 100% backward compatible),
-`release_number` is bumped when a set of new features or bug fixes not impacting the protocol are included in the release,
-`patch_number` is used when a critical fix has to be deployed.
+`protocol_version` is the maximum protocol version supported by that release
+(all versions are 100% backward compatible), `release_number` is bumped when a
+set of new features or bug fixes not impacting the protocol are included in the
+release, `patch_number` is used when a critical fix has to be deployed.

--- a/content/docs/run-core-node/monitoring.mdx
+++ b/content/docs/run-core-node/monitoring.mdx
@@ -5,15 +5,25 @@ order: 70
 
 import { CodeExample } from "components/CodeExample";
 
-Once your node is up and running, it's important to keep an eye on it to make sure it stays afloat and continues to contribute to the health of the overall network.  To help with that, Stellar Core exposes vital information that you can use to monitor your node and diagnose potential problems.  
+Once your node is up and running, it's important to keep an eye on it to make
+sure it stays afloat and continues to contribute to the health of the overall
+network. To help with that, Stellar Core exposes vital information that you can
+use to monitor your node and diagnose potential problems.
 
-You can access this information using commands and inspecting Stellar Core's output, which is what the first half of this doc covers.  You can also connect [Prometheus](link) to make monitoring easier, combine it with [Alertmanager](link) to automate notification, and use pre-built [Grafana dashboards](link) to create visual representations of your node's well-being.  
+You can access this information using commands and inspecting Stellar Core's
+output, which is what the first half of this doc covers. You can also connect
+[Prometheus](link) to make monitoring easier, combine it with
+[Alertmanager](link) to automate notification, and use pre-built
+[Grafana dashboards](link) to create visual representations of your node's
+well-being.
 
-However you decide to monitor, the most important thing is that you have a system in place to ensure that your integration keeps ticking.
+However you decide to monitor, the most important thing is that you have a
+system in place to ensure that your integration keeps ticking.
 
 ## General Node Information
 
-If you run `$ stellar-core http-command 'info'`, the output will look something like this:
+If you run `$ stellar-core http-command 'info'`, the output will look something
+like this:
 
 <CodeExample>
 
@@ -66,24 +76,32 @@ If you run `$ stellar-core http-command 'info'`, the output will look something 
 
 Some notable fields in `info` are:
 
-  * `build`: the build number for this Stellar Core instance
-  * `ledger`: the local state of your node, which may be different from the network state if your node was disconnected from the network. Some important sub-fields:
-    * `age`: time elapsed since this ledger closed (during normal operation less than 10 seconds)
-    * `num`: ledger number
-    * `version`: protocol version supported by this ledger
-  * `network` is the [network passphrase](link) that this core instance is using to decide whether to connect to the testnet or the public network
-  * `peers`: information on the connectivity to the network
-    * `authenticated_count`: the number of live connections
-    * `pending_count`: the number of connections that are not fully established yet
-  * `protocol_version`: the maximum version of the protocol that this instance recognizes
-  * `state`: the node's synchronization status relative to the network
-  * `quorum`: summarizes the state of the SCP protocol participants, the same as the information returned by the `quorum` command ([see below](link)).
+- `build`: the build number for this Stellar Core instance
+- `ledger`: the local state of your node, which may be different from the
+  network state if your node was disconnected from the network. Some important
+  sub-fields:
+  - `age`: time elapsed since this ledger closed (during normal operation less
+    than 10 seconds)
+  - `num`: ledger number
+  - `version`: protocol version supported by this ledger
+- `network` is the [network passphrase](link) that this core instance is using
+  to decide whether to connect to the testnet or the public network
+- `peers`: information on the connectivity to the network
+  - `authenticated_count`: the number of live connections
+  - `pending_count`: the number of connections that are not fully established
+    yet
+- `protocol_version`: the maximum version of the protocol that this instance
+  recognizes
+- `state`: the node's synchronization status relative to the network
+- `quorum`: summarizes the state of the SCP protocol participants, the same as
+  the information returned by the `quorum` command ([see below](link)).
 
 ## Overlay information
 
 The `peers` command returns information on the peers your node is connected to.
 
-This list is the result of both inbound connections from other peers and outbound connections from this node to other peers.
+This list is the result of both inbound connections from other peers and
+outbound connections from this node to other peers.
 
 `$ stellar-core http-command 'peers'`
 
@@ -91,37 +109,37 @@ This list is the result of both inbound connections from other peers and outboun
 
 ```json
 {
-   "authenticated_peers" : {
-     "inbound" : [
-        {
-           "address" : "54.161.82.181:11625",
-           "elapsed" : 6,
-           "id" : "sdf1",
-           "olver" : 5,
-           "ver" : "v9.1.0"
-        }
-     ],
-     "outbound" : [
-       {
-          "address" : "54.211.174.177:11625",
-          "elapsed" : 2303,
-          "id" : "sdf2",
-          "olver" : 5,
-          "ver" : "v9.1.0"
-       },
-       {
-          "address" : "54.160.175.7:11625",
-          "elapsed" : 14082,
-          "id" : "sdf3",
-          "olver" : 5,
-          "ver" : "v9.1.0"
-        }
-     ]
-   },
-   "pending_peers" : {
-      "inbound" : [ "211.249.63.74:11625", "45.77.5.118:11625" ],
-      "outbound" : [ "178.21.47.226:11625", "178.131.109.241:11625" ]
-   }
+  "authenticated_peers": {
+    "inbound": [
+      {
+        "address": "54.161.82.181:11625",
+        "elapsed": 6,
+        "id": "sdf1",
+        "olver": 5,
+        "ver": "v9.1.0"
+      }
+    ],
+    "outbound": [
+      {
+        "address": "54.211.174.177:11625",
+        "elapsed": 2303,
+        "id": "sdf2",
+        "olver": 5,
+        "ver": "v9.1.0"
+      },
+      {
+        "address": "54.160.175.7:11625",
+        "elapsed": 14082,
+        "id": "sdf3",
+        "olver": 5,
+        "ver": "v9.1.0"
+      }
+    ]
+  },
+  "pending_peers": {
+    "inbound": ["211.249.63.74:11625", "45.77.5.118:11625"],
+    "outbound": ["178.21.47.226:11625", "178.131.109.241:11625"]
+  }
 }
 ```
 
@@ -129,11 +147,15 @@ This list is the result of both inbound connections from other peers and outboun
 
 ## Quorum Health
 
-To help node operators monitor their quorum sets and maintain the health of the overall network, Stellar Core also provides metrics on other nodes in your quorum set.  You should monitor them to make sure they're up and running, and that your quorum set is maintaining good overlap with the rest of the network. 
+To help node operators monitor their quorum sets and maintain the health of the
+overall network, Stellar Core also provides metrics on other nodes in your
+quorum set. You should monitor them to make sure they're up and running, and
+that your quorum set is maintaining good overlap with the rest of the network.
 
 ### Quorum set diagnostics
 
-The `quorum` command allows to diagnose problems with the quorum set of the local node.
+The `quorum` command allows to diagnose problems with the quorum set of the
+local node.
 
 If you run:
 
@@ -145,90 +167,138 @@ The output will look something like:
 
 ```json
 {
-   "node" : "GCTSFJ36M7ZMTSX7ZKG6VJKPIDBDA26IEWRGV65DVX7YVVLBPE5ZWMIO",
-   "qset" : {
-      "agree" : 6,
-      "delayed" : null,
-      "disagree" : null,
-      "fail_at" : 2,
-      "fail_with" : [ "sdf_watcher1", "sdf_watcher2" ],
-      "hash" : "d5c247",
-      "ledger" : 24311847,
-      "missing" : [ "stronghold1" ],
-      "phase" : "EXTERNALIZE",
-      "value" : {
-         "t" : 3,
-         "v" : [
-            "sdf_watcher1",
-            "sdf_watcher2",
-            "sdf_watcher3",
-            {
-               "t" : 3,
-               "v" : [ "stronghold1", "eno", "tempo.eu.com", "satoshipay" ]
-            }
-         ]
-      }
-   },
-   "transitive" : {
-      "critical": [
-         [ "GDM7M262ZJJPV4BZ5SLGYYUTJGIGM25ID2XGKI3M6IDN6QLSTWQKTXQM" ]
-      ],
-      "intersection" : true,
-      "last_check_ledger" : 24311536,
-      "node_count" : 21
-   }
+  "node": "GCTSFJ36M7ZMTSX7ZKG6VJKPIDBDA26IEWRGV65DVX7YVVLBPE5ZWMIO",
+  "qset": {
+    "agree": 6,
+    "delayed": null,
+    "disagree": null,
+    "fail_at": 2,
+    "fail_with": ["sdf_watcher1", "sdf_watcher2"],
+    "hash": "d5c247",
+    "ledger": 24311847,
+    "missing": ["stronghold1"],
+    "phase": "EXTERNALIZE",
+    "value": {
+      "t": 3,
+      "v": [
+        "sdf_watcher1",
+        "sdf_watcher2",
+        "sdf_watcher3",
+        {
+          "t": 3,
+          "v": ["stronghold1", "eno", "tempo.eu.com", "satoshipay"]
+        }
+      ]
+    }
+  },
+  "transitive": {
+    "critical": [["GDM7M262ZJJPV4BZ5SLGYYUTJGIGM25ID2XGKI3M6IDN6QLSTWQKTXQM"]],
+    "intersection": true,
+    "last_check_ledger": 24311536,
+    "node_count": 21
+  }
 }
 ```
 
 </CodeExample>
 
-This output has two main sections: `qset` and `transitive`. The former describes the node and its quorum set; the latter describes the transitive closure of the node's quorum set.
+This output has two main sections: `qset` and `transitive`. The former describes
+the node and its quorum set; the latter describes the transitive closure of the
+node's quorum set.
 
 ### Per-node Quorum-set Information
 
-Entries to watch for in the `qset` section — which describe the node and its quorum set — are:
+Entries to watch for in the `qset` section — which describe the node and its
+quorum set — are:
 
-  * `agree` : the number of nodes in the quorum set that agree with this instance.
-  * `delayed` : the nodes that are participating in consensus but seem to be behind.
-  * `disagree`: the nodes that are participating but disagreed with this instance.
-  * `fail_at` : the number of failed nodes that *would* cause this instance to halt.
-  * `fail_with`: an example of such potential failure.
-  * `missing` : the nodes that were missing during this consensus round.
-  * `value` : the quorum set used by this node (`t` is the threshold expressed as a number of nodes).
+- `agree` : the number of nodes in the quorum set that agree with this instance.
+- `delayed` : the nodes that are participating in consensus but seem to be
+  behind.
+- `disagree`: the nodes that are participating but disagreed with this instance.
+- `fail_at` : the number of failed nodes that _would_ cause this instance to
+  halt.
+- `fail_with`: an example of such potential failure.
+- `missing` : the nodes that were missing during this consensus round.
+- `value` : the quorum set used by this node (`t` is the threshold expressed as
+  a number of nodes).
 
-In the example above, 6 nodes are functioning properly, one is down (`stronghold1`), and the instance will fail if any two nodes still working (or one node and one inner-quorum-set) fail as well.
+In the example above, 6 nodes are functioning properly, one is down
+(`stronghold1`), and the instance will fail if any two nodes still working (or
+one node and one inner-quorum-set) fail as well.
 
-If a node is stuck in state `Joining SCP`, this command allows to quickly find the reason:
+If a node is stuck in state `Joining SCP`, this command allows to quickly find
+the reason:
 
-  * too many validators missing (down or without a good connectivity), solutions are:
-    * [adjust your quorum set](#crafting-a-quorum-set) based on the nodes that are not missing
-    * try to get a [better connectivity path](#quorum-and-overlay-network) to the missing validators
-  * network split would cause SCP to stick because of nodes that disagree. This would happen if either there is a bug in SCP, the network does not have quorum intersection, or the disagreeing nodes are misbehaving (compromised, etc).
+- too many validators missing (down or without a good connectivity), solutions
+  are:
+  - [adjust your quorum set](#crafting-a-quorum-set) based on the nodes that are
+    not missing
+  - try to get a [better connectivity path](#quorum-and-overlay-network) to the
+    missing validators
+- network split would cause SCP to stick because of nodes that disagree. This
+  would happen if either there is a bug in SCP, the network does not have quorum
+  intersection, or the disagreeing nodes are misbehaving (compromised, etc).
 
-Note that the node not being able to reach consensus does not mean that the network as a whole will not be able to reach consensus (and the opposite is true: the network may fail because of a different set of validators failing).
+Note that the node not being able to reach consensus does not mean that the
+network as a whole will not be able to reach consensus (and the opposite is
+true: the network may fail because of a different set of validators failing).
 
 You can get a sense of the quorum set health of a different node using using:
-`$ stellar-core http-command 'quorum?node=$sdf1` or `$ stellar-core http-command 'quorum?node=@GABCDE` 
+`$ stellar-core http-command 'quorum?node=$sdf1` or
+`$ stellar-core http-command 'quorum?node=@GABCDE`
 
-Overall network health can be evaluated by walking through all nodes and looking at their health. Note that this is only an approximation, as remote nodes may not have received the same messages (in particular: `missing` for 
-other nodes is not reliable).
+Overall network health can be evaluated by walking through all nodes and looking
+at their health. Note that this is only an approximation, as remote nodes may
+not have received the same messages (in particular: `missing` for other nodes is
+not reliable).
 
 ### Transitive Closure Summary Information
 
-When showing quorum-set information about the local node, a summary of the transitive closure of the quorum set is also provided in the `transitive` field. This has several important sub-fields:
+When showing quorum-set information about the local node, a summary of the
+transitive closure of the quorum set is also provided in the `transitive` field.
+This has several important sub-fields:
 
-  * `last_check_ledger` : the last ledger in which the transitive closure was checked for quorum intersection. This will reset when the node boots and whenever a node in the transitive quorum changes its quorum set. It may lag behind the last-closed ledger by a few ledgers depending on the computational cost of checking quorum intersection.
-  * `node_count` : the number of nodes in the transitive closure, which are considered when calculating quorum intersection.
-  * `intersection` : whether or not the transitive closure enjoyed quorum intersection at the most recent check. This is of **utmost importance** in preventing network splits. It should always be true. If it is ever false, one or more nodes in the transitive closure of the quorum set is _currently_ misconfigured, and the network is at risk of splitting. Corrective action should be taken immediately, for which two additional sub-fields will be present to help suggest remedies:
-    * `last_good_ledger` : this will note the last ledger for which the `intersection` field was evaluated as true; if some node reconfigured at or around that ledger, reverting that configuration change is the easiest corrective action to take.
-    * `potential_split` : this will contain a pair of lists of validator IDs, which is a potential pair of disjoint quorums allowed by the current configuration. In other words, a possible split in consensus allowed by the current configuration. This may help narrow down the cause of the misconfiguration: likely it involves too-low a consensus threshold in one of the two potential quorums, and/or the absence of a mandatory trust relationship that would bridge the two.
-  * `critical`: an "advance warning" field that lists nodes that _could cause_ the network to fail to enjoy quorum intersection, if they were misconfigured sufficiently badly. In a healthy transitive network configuration, this field will be `null`. If it is non-`null` then the network is essentially "one misconfiguration" (of the quorum sets of the listed nodes) away from no longer enjoying quorum intersection, and again, corrective action should be taken: careful adjustment to the quorum sets of _nodes that depend on_ the listed nodes, typically to strengthen quorums that depend on them.
+- `last_check_ledger` : the last ledger in which the transitive closure was
+  checked for quorum intersection. This will reset when the node boots and
+  whenever a node in the transitive quorum changes its quorum set. It may lag
+  behind the last-closed ledger by a few ledgers depending on the computational
+  cost of checking quorum intersection.
+- `node_count` : the number of nodes in the transitive closure, which are
+  considered when calculating quorum intersection.
+- `intersection` : whether or not the transitive closure enjoyed quorum
+  intersection at the most recent check. This is of **utmost importance** in
+  preventing network splits. It should always be true. If it is ever false, one
+  or more nodes in the transitive closure of the quorum set is _currently_
+  misconfigured, and the network is at risk of splitting. Corrective action
+  should be taken immediately, for which two additional sub-fields will be
+  present to help suggest remedies:
+  - `last_good_ledger` : this will note the last ledger for which the
+    `intersection` field was evaluated as true; if some node reconfigured at or
+    around that ledger, reverting that configuration change is the easiest
+    corrective action to take.
+  - `potential_split` : this will contain a pair of lists of validator IDs,
+    which is a potential pair of disjoint quorums allowed by the current
+    configuration. In other words, a possible split in consensus allowed by the
+    current configuration. This may help narrow down the cause of the
+    misconfiguration: likely it involves too-low a consensus threshold in one of
+    the two potential quorums, and/or the absence of a mandatory trust
+    relationship that would bridge the two.
+- `critical`: an "advance warning" field that lists nodes that _could cause_ the
+  network to fail to enjoy quorum intersection, if they were misconfigured
+  sufficiently badly. In a healthy transitive network configuration, this field
+  will be `null`. If it is non-`null` then the network is essentially "one
+  misconfiguration" (of the quorum sets of the listed nodes) away from no longer
+  enjoying quorum intersection, and again, corrective action should be taken:
+  careful adjustment to the quorum sets of _nodes that depend on_ the listed
+  nodes, typically to strengthen quorums that depend on them.
 
 ### Detailed transitive quorum analysis
 
-The quorum endpoint can also retrieve detailed information for the transitive quorum.
+The quorum endpoint can also retrieve detailed information for the transitive
+quorum.
 
-This is a format that's easier to process than what `scp` returns as it doesn't contain all SCP messages.
+This is a format that's easier to process than what `scp` returns as it doesn't
+contain all SCP messages.
 
 `$ stellar-core http-command 'quorum?transitive=true'`
 
@@ -238,115 +308,144 @@ The output looks something like:
 
 ```json
 {
- "critical": null,
- "intersection" : true,
- "last_check_ledger" : 121235,
- "node_count" : 4,
- "nodes" : [
-      {
-         "distance" : 0,
-         "heard" : 121235,
-         "node" : "GB7LI",
-         "qset" : {
-            "t" : 2,
-            "v" : [ "sdf1", "sdf2", "sdf3" ]
-         },
-         "status" : "tracking",
-         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
-         "value_id" : 1
+  "critical": null,
+  "intersection": true,
+  "last_check_ledger": 121235,
+  "node_count": 4,
+  "nodes": [
+    {
+      "distance": 0,
+      "heard": 121235,
+      "node": "GB7LI",
+      "qset": {
+        "t": 2,
+        "v": ["sdf1", "sdf2", "sdf3"]
       },
-      {
-         "distance" : 1,
-         "heard" : 121235,
-         "node" : "sdf2",
-         "qset" : {
-            "t" : 2,
-            "v" : [ "sdf1", "sdf2", "sdf3" ]
-         },
-         "status" : "tracking",
-         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
-         "value_id" : 1
+      "status": "tracking",
+      "value": "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+      "value_id": 1
+    },
+    {
+      "distance": 1,
+      "heard": 121235,
+      "node": "sdf2",
+      "qset": {
+        "t": 2,
+        "v": ["sdf1", "sdf2", "sdf3"]
       },
-      {
-         "distance" : 1,
-         "heard" : 121235,
-         "node" : "sdf3",
-         "qset" : {
-            "t" : 2,
-            "v" : [ "sdf1", "sdf2", "sdf3" ]
-         },
-         "status" : "tracking",
-         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
-         "value_id" : 1
+      "status": "tracking",
+      "value": "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+      "value_id": 1
+    },
+    {
+      "distance": 1,
+      "heard": 121235,
+      "node": "sdf3",
+      "qset": {
+        "t": 2,
+        "v": ["sdf1", "sdf2", "sdf3"]
       },
-      {
-         "distance" : 1,
-         "heard" : 121235,
-         "node" : "sdf1",
-         "qset" : {
-            "t" : 2,
-            "v" : [ "sdf1", "sdf2", "sdf3" ]
-         },
-         "status" : "tracking",
-         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
-         "value_id" : 1
-      }
-   ]
+      "status": "tracking",
+      "value": "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+      "value_id": 1
+    },
+    {
+      "distance": 1,
+      "heard": 121235,
+      "node": "sdf1",
+      "qset": {
+        "t": 2,
+        "v": ["sdf1", "sdf2", "sdf3"]
+      },
+      "status": "tracking",
+      "value": "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+      "value_id": 1
+    }
+  ]
 }
 ```
 
 </CodeExample>
 
-The output begins with the same summary information as in the `transitive` block of the non-transitive query (if queried for the local node), but also includes a `nodes` array that represents a walk of the transitive quorum centered on the query node.
+The output begins with the same summary information as in the `transitive` block
+of the non-transitive query (if queried for the local node), but also includes a
+`nodes` array that represents a walk of the transitive quorum centered on the
+query node.
 
 Fields are:
 
-* `node` : the identity of the validator
-* `distance` : how far that node is from the root node (ie. how many quorum set hops)
-* `heard` : the latest ledger sequence number that this node voted on
-* `qset` : the node's quorum set
-* `status` : one of `behind|tracking|ahead` (compared to the root node) or `missing|unknown` (when there are no recent SCP messages for that node)
-* `value_id` : a unique ID for what the node is voting for (allows to quickly tell if nodes are voting for the same thing)
-* `value` : what the node is voting for
+- `node` : the identity of the validator
+- `distance` : how far that node is from the root node (ie. how many quorum set
+  hops)
+- `heard` : the latest ledger sequence number that this node voted on
+- `qset` : the node's quorum set
+- `status` : one of `behind|tracking|ahead` (compared to the root node) or
+  `missing|unknown` (when there are no recent SCP messages for that node)
+- `value_id` : a unique ID for what the node is voting for (allows to quickly
+  tell if nodes are voting for the same thing)
+- `value` : what the node is voting for
 
 ## Using Prometheus
 
-Monitoring `stellar-core` using Prometheus is by far the simplest solution, especially if you already have a Prometheus server within your infrastructure. Prometheus is a free and open source time-series database with a simple yet incredibly powerful query language `PromQL`. Prometheus is also tightly integrated with Grafana, so you can render complex visualisations with ease.
+Monitoring `stellar-core` using Prometheus is by far the simplest solution,
+especially if you already have a Prometheus server within your infrastructure.
+Prometheus is a free and open source time-series database with a simple yet
+incredibly powerful query language `PromQL`. Prometheus is also tightly
+integrated with Grafana, so you can render complex visualisations with ease.
 
-In order for Prometheus to scrape `stellar-core` application metrics, you will need to install the stellar-core-prometheus-exporter (`apt-get install stellar-core-prometheus-exporter`) and configure your Prometheus server to scrape this exporter (default port: `9473`). On top of that grafana can be used to visualize metrics.
+In order for Prometheus to scrape `stellar-core` application metrics, you will
+need to install the stellar-core-prometheus-exporter
+(`apt-get install stellar-core-prometheus-exporter`) and configure your
+Prometheus server to scrape this exporter (default port: `9473`). On top of that
+grafana can be used to visualize metrics.
 
 [IMAGE](link)
 
 ### Install a Prometheus server within your infrastructure
 
-Installing and configuring a Prometheus server is out of scope of this document, however it is a fairly simple process: Prometheus is a single Go binary which you can download from https://prometheus.io/docs/prometheus/latest/installation/.
+Installing and configuring a Prometheus server is out of scope of this document,
+however it is a fairly simple process: Prometheus is a single Go binary which
+you can download from
+https://prometheus.io/docs/prometheus/latest/installation/.
 
 ### Install the stellar-core-prometheus-exporter
 
-The stellar-core-prometheus-exporter is an exporter that scrapes the `stellar-core` metrics endpoint (`http://localhost:11626/metrics`) and renders these metrics in the Prometheus text-based format available for Prometheus to scrape and store in its timeseries database.
+The stellar-core-prometheus-exporter is an exporter that scrapes the
+`stellar-core` metrics endpoint (`http://localhost:11626/metrics`) and renders
+these metrics in the Prometheus text-based format available for Prometheus to
+scrape and store in its timeseries database.
 
-The exporter needs to be installed on every Stellar Core node you wish to monitor.
+The exporter needs to be installed on every Stellar Core node you wish to
+monitor.
 
-* `apt-get install stellar-core-prometheus-exporter`
+- `apt-get install stellar-core-prometheus-exporter`
 
-You will need to open up port `9473` between your Prometheus server and all your Stellar Core nodes for your Prometheus server to be able to scrape metrics.
+You will need to open up port `9473` between your Prometheus server and all your
+Stellar Core nodes for your Prometheus server to be able to scrape metrics.
 
 ### Point Prometheus to stellar-core-prometheus-exporter
 
-Pointing your Prometheus instance to the exporter can be achieved by manually configuring a scrape job; however, depending on the number of hosts you need to monitor this can quickly become unwieldy. Luckily, the process can also be automated using Prometheus' various "service discovery" plugins. For example with AWS hosted instance you can use the `ec2_sd_config` plugin.
+Pointing your Prometheus instance to the exporter can be achieved by manually
+configuring a scrape job; however, depending on the number of hosts you need to
+monitor this can quickly become unwieldy. Luckily, the process can also be
+automated using Prometheus' various "service discovery" plugins. For example
+with AWS hosted instance you can use the `ec2_sd_config` plugin.
 
 #### Manual
 
 <CodeExample>
 
 ```yaml
-- job_name: 'stellar-core'
+- job_name: "stellar-core"
   scrape_interval: 10s
   scrape_timeout: 10s
   static_configs:
-    - targets: ['core-node-001.example.com:9473', 'core-node-002.example.com:9473'] # stellar-core-prometheus-exporter default port is 9473
+    - targets: [
+          "core-node-001.example.com:9473",
+          "core-node-002.example.com:9473",
+        ] # stellar-core-prometheus-exporter default port is 9473
     - labels:
-      application: 'stellar-core'
+      application: "stellar-core"
 ```
 
 </CodeExample>
@@ -360,57 +459,70 @@ Pointing your Prometheus instance to the exporter can be achieved by manually co
   scrape_interval: 10s
   scrape_timeout: 10s
   ec2_sd_configs:
-  - region: eu-west-1
-    port: 9473
+    - region: eu-west-1
+      port: 9473
   relabel_configs:
-  # ignore stopped instances
-  - source_labels: [__meta_ec2_instance_state]
-    regex: stopped
-    action: drop
-  # only keep with `core` in the Name tag
-  - source_labels: [__meta_ec2_tag_Name]
-    regex: "(.*core.*)"
-    action: keep
-  # use Name tag as instance label
-  - source_labels: [__meta_ec2_tag_Name]
-    regex: "(.*)"
-    action: replace
-    replacement: "${1}"
-    target_label: instance
-  # set application label to stellar-core
-  - source_labels: [__meta_ec2_tag_Name]
-    regex: "(.*core.*)"
-    action: replace
-    replacement: stellar-core
-    target_label: application
+    # ignore stopped instances
+    - source_labels: [__meta_ec2_instance_state]
+      regex: stopped
+      action: drop
+    # only keep with `core` in the Name tag
+    - source_labels: [__meta_ec2_tag_Name]
+      regex: "(.*core.*)"
+      action: keep
+    # use Name tag as instance label
+    - source_labels: [__meta_ec2_tag_Name]
+      regex: "(.*)"
+      action: replace
+      replacement: "${1}"
+      target_label: instance
+    # set application label to stellar-core
+    - source_labels: [__meta_ec2_tag_Name]
+      regex: "(.*core.*)"
+      action: replace
+      replacement: stellar-core
+      target_label: application
 ```
 
 </CodeExample>
 
 ### Create Alerting Rules
 
-Once Prometheus scrapes metrics we can add alerting rules. Recommended rules are [**here**](stellar-core-alerting.rules) (require Prometheus 2.0 or later). Copy rules to */etc/prometheus/stellar-core-alerting.rules* on the Prometheus server and add the following to the prometheus configuration file to include the file:
+Once Prometheus scrapes metrics we can add alerting rules. Recommended rules are
+[**here**](stellar-core-alerting.rules) (require Prometheus 2.0 or later). Copy
+rules to _/etc/prometheus/stellar-core-alerting.rules_ on the Prometheus server
+and add the following to the prometheus configuration file to include the file:
 
 <CodeExample>
 
 ```yaml
 rule_files:
-- "/etc/prometheus/stellar-core-alerting.rules"
+  - "/etc/prometheus/stellar-core-alerting.rules"
 ```
 
 </CodeExample>
 
-Rules are documented in-line,and we strongly recommend that you review and verify all of them as every environment is different.
+Rules are documented in-line,and we strongly recommend that you review and
+verify all of them as every environment is different.
 
 ### Configure Notifications Using Alertmanager
 
-Alertmanager is responsible for sending notifications. Installing and configuring an Alertmanager server is out of scope of this document, however it is a fairly simple process.  Official documentation is [here](https://github.com/prometheus/alertmanager/).
+Alertmanager is responsible for sending notifications. Installing and
+configuring an Alertmanager server is out of scope of this document, however it
+is a fairly simple process. Official documentation is
+[here](https://github.com/prometheus/alertmanager/).
 
 All recommended alerting rules have "severity" label:
-* **critical** normally require immediate attention. They indicate an ongoing or very likely outage. We recommend that critical alerts notify administrators 24x7
-* **warning** normally can wait until working hours. Warnings indicate problems that likely do not have production impact but may lead to critical alerts or outages if left unhandled
 
-The following example alertmanager configuration demonstrates how to send notifications using different methods based on severity label:
+- **critical** normally require immediate attention. They indicate an ongoing or
+  very likely outage. We recommend that critical alerts notify administrators
+  24x7
+- **warning** normally can wait until working hours. Warnings indicate problems
+  that likely do not have production impact but may lead to critical alerts or
+  outages if left unhandled
+
+The following example alertmanager configuration demonstrates how to send
+notifications using different methods based on severity label:
 
 <CodeExample>
 
@@ -425,38 +537,57 @@ route:
   group_interval: 5m
   repeat_interval: 1h
   routes:
-  - receiver: critical-alerts
-    match:
-      severity: critical
-  - receiver: warning-alerts
-    match:
-      severity: warning
+    - receiver: critical-alerts
+      match:
+        severity: critical
+    - receiver: warning-alerts
+      match:
+        severity: warning
 receivers:
-- name: critical-alerts
-  pagerduty_configs:
-  - routing_key: <PD routing key>
-- name: warning-alerts
-  slack_configs:
-  - api_url: https://hooks.slack.com/services/slack/warning/channel/webhook
-- name: default-receiver
-  email_configs:
-  - to: alerts-fallback@example.com
+  - name: critical-alerts
+    pagerduty_configs:
+      - routing_key: <PD routing key>
+  - name: warning-alerts
+    slack_configs:
+      - api_url: https://hooks.slack.com/services/slack/warning/channel/webhook
+  - name: default-receiver
+    email_configs:
+      - to: alerts-fallback@example.com
 ```
 
 </CodeExample>
 
-In the above examples alerts with severity "critical" are sent to pagerduty and warnings are sent to slack.
+In the above examples alerts with severity "critical" are sent to pagerduty and
+warnings are sent to slack.
 
 ### Useful Exporters
 
-You may find the below exporters useful for monitoring your infrastructure as they provide incredible insight into your operating system and database metrics. Installing and configuring these exporters is out of the scope of this document but should be relatively straightforward.
+You may find the below exporters useful for monitoring your infrastructure as
+they provide incredible insight into your operating system and database metrics.
+Installing and configuring these exporters is out of the scope of this document
+but should be relatively straightforward.
 
-* [node_exporter](https://prometheus.io/docs/guides/node-exporter/) can be used to track all operating system metrics.
-* [postgresql_exporter](https://github.com/wrouesnel/postgres_exporter) can be used to monitor the local stellar-core database.
+- [node_exporter](https://prometheus.io/docs/guides/node-exporter/) can be used
+  to track all operating system metrics.
+- [postgresql_exporter](https://github.com/wrouesnel/postgres_exporter) can be
+  used to monitor the local stellar-core database.
 
 ### Visualize metrics using Grafana
-Once you've configured Prometheus to scrape and store your stellar-core metrics, you will want a nice way to render this data for human consumption. Grafana offers the simplest and most effective way to achieve this.  Installing Grafana is out of scope of this document but is a very simple process, especially when using the [prebuilt apt packages] (https://grafana.com/docs/installation/debian/#apt-repository)
 
-We recommend that administrators import the following two dashboards into their grafana deployments:
-* [**Stellar Core Monitoring**](https://grafana.com/grafana/dashboards/10603) - shows the most important metrics, node status and tries to surface common problems. It's a good troubleshooting starting point
-* [**Stellar Core Full**](https://grafana.com/grafana/dashboards/10334) - shows a simple health summary as well as all metrics exposed by the `stellar-core-prometheus-exporter`. It's much more detailed than the *Stellar Core Monitoring* and might be useful during in-depth troubleshooting
+Once you've configured Prometheus to scrape and store your stellar-core metrics,
+you will want a nice way to render this data for human consumption. Grafana
+offers the simplest and most effective way to achieve this. Installing Grafana
+is out of scope of this document but is a very simple process, especially when
+using the
+[prebuilt apt packages](https://grafana.com/docs/installation/debian/#apt-repository)
+
+We recommend that administrators import the following two dashboards into their
+grafana deployments:
+
+- [**Stellar Core Monitoring**](https://grafana.com/grafana/dashboards/10603) -
+  shows the most important metrics, node status and tries to surface common
+  problems. It's a good troubleshooting starting point
+- [**Stellar Core Full**](https://grafana.com/grafana/dashboards/10334) - shows
+  a simple health summary as well as all metrics exposed by the
+  `stellar-core-prometheus-exporter`. It's much more detailed than the _Stellar
+  Core Monitoring_ and might be useful during in-depth troubleshooting

--- a/content/docs/run-core-node/network-upgrades.mdx
+++ b/content/docs/run-core-node/network-upgrades.mdx
@@ -7,39 +7,48 @@ import { CodeExample } from "components/CodeExample";
 
 The network itself has network wide settings that can be updated.
 
-This is performed by validators voting for and agreeing to new values the same way that consensus is reached for transaction sets, etc.
+This is performed by validators voting for and agreeing to new values the same
+way that consensus is reached for transaction sets, etc.
 
-A node can be configured to vote for upgrades using the `upgrades` endpoint . see [`commands.md`](commands.md) for more information.
+A node can be configured to vote for upgrades using the `upgrades` endpoint .
+see [`commands.md`](commands.md) for more information.
 
 The network settings are:
 
-  * the version of the protocol used to process transactions
-  * the maximum number of transactions that can be included in a given ledger close
-  * the cost (fee) associated with processing operations
-  * the base reserve used to calculate the lumen balance needed to store things in the ledger
+- the version of the protocol used to process transactions
+- the maximum number of transactions that can be included in a given ledger
+  close
+- the cost (fee) associated with processing operations
+- the base reserve used to calculate the lumen balance needed to store things in
+  the ledger
 
-When the network time is later than the `upgradetime` specified in
-the upgrade settings, the validator will vote to update the network
-to the value specified in the upgrade setting. If the network time 
-is passed the `upgradetime` by more than 12 hours, the upgrade will be ignored
+When the network time is later than the `upgradetime` specified in the upgrade
+settings, the validator will vote to update the network to the value specified
+in the upgrade setting. If the network time is passed the `upgradetime` by more
+than 12 hours, the upgrade will be ignored
 
-When a validator is armed to change network values, the output of `info` will contain information about the vote.
+When a validator is armed to change network values, the output of `info` will
+contain information about the vote.
 
-For a new value to be adopted, the same level of consensus between nodes needs to be reached as for transaction sets.
+For a new value to be adopted, the same level of consensus between nodes needs
+to be reached as for transaction sets.
 
 ## Important notes on network wide settings
 
 Changes to network wide settings have to be orchestrated properly between
 validators as well as non validating nodes:
 
-  * a change is vetted between operators (changes can be bundled)
-  * an effective date in the future is picked for the change to take effect (controlled by `upgradetime`)
-  * if applicable, communication is sent out to all network users
+- a change is vetted between operators (changes can be bundled)
+- an effective date in the future is picked for the change to take effect
+  (controlled by `upgradetime`)
+- if applicable, communication is sent out to all network users
 
 An improper plan may cause issues such as:
 
-  * nodes missing consensus (aka "getting stuck"), and having to use history to rejoin
-  * network reconfiguration taking effect at a non deterministic time (causing fees to change ahead of schedule for example)
+- nodes missing consensus (aka "getting stuck"), and having to use history to
+  rejoin
+- network reconfiguration taking effect at a non deterministic time (causing
+  fees to change ahead of schedule for example)
 
 For more information look at [`docs/versioning.md`](../versioning.md).
 
@@ -47,10 +56,11 @@ For more information look at [`docs/versioning.md`](../versioning.md).
 
 Example here is to upgrade the protocol version to version 9 on January-31-2018.
 
-  1. `$ stellar-core http-command 'upgrades?mode=set&upgradetime=2018-01-31T20:00:00Z&protocolversion=9'`
-  2. `$ stellar-core http-command info`
+1. `$ stellar-core http-command 'upgrades?mode=set&upgradetime=2018-01-31T20:00:00Z&protocolversion=9'`
+2. `$ stellar-core http-command info`
 
-At this point `info` will tell you that the node is setup to vote for this upgrade:
+At this point `info` will tell you that the node is setup to vote for this
+upgrade:
 
 <CodeExample>
 

--- a/content/docs/run-core-node/prerequisites.mdx
+++ b/content/docs/run-core-node/prerequisites.mdx
@@ -3,33 +3,70 @@ title: Prerequisites
 order: 20
 ---
 
-You can install Stellar Core a [number of different ways](link), and once you do, you can [configure](link) it to participate in the network on a several [different levels](link): it can be a Watcher, a Basic Validator, or a Full Validator.   No matter how you install Stellar Core or what kind of node you run, however, you need to set up to connect to the peer-to-peer network, store the state of the ledger in a SQL [database](link), and most likely connect to Horizon, the Stellar API.    
+You can install Stellar Core a [number of different ways](link), and once you
+do, you can [configure](link) it to participate in the network on a several
+[different levels](link): it can be a Watcher, a Basic Validator, or a Full
+Validator. No matter how you install Stellar Core or what kind of node you run,
+however, you need to set up to connect to the peer-to-peer network, store the
+state of the ledger in a SQL [database](link), and most likely connect to
+Horizon, the Stellar API.
 
 ## Compute Requirements
-We recently asked Stellar Core operators about their setups, and should have some updated information soon based on their responses.  So stay tuned.  In early 2018, Stellar Core with PostgreSQL running on the same machine worked well on a [m5.large](https://aws.amazon.com/ec2/instance-types/m5/) in AWS (dual core 2.5 GHz Intel Xeon, 8 GB RAM).  Storage-wise, 20 GB was enough in 2018, but the ledger has grown a lot since then, and most people seem to have at least 1TB on hand.
 
-If you are running Stellar Core in conjunction with Horizon, you will need to ensure that your setup is also equipped to handle Horizon's [compute requirements](link) as well.
+We recently asked Stellar Core operators about their setups, and should have
+some updated information soon based on their responses. So stay tuned. In early
+2018, Stellar Core with PostgreSQL running on the same machine worked well on a
+[m5.large](https://aws.amazon.com/ec2/instance-types/m5/) in AWS (dual core 2.5
+GHz Intel Xeon, 8 GB RAM). Storage-wise, 20 GB was enough in 2018, but the
+ledger has grown a lot since then, and most people seem to have at least 1TB on
+hand.
 
-Stellar Core is designed to run on relatively modest hardware so that a whole range of individuals and organizations can participate in the network, and basic nodes should be able to function pretty well without tremendous overhead.  That said, the more you ask of your node, the greater the requirements.
+If you are running Stellar Core in conjunction with Horizon, you will need to
+ensure that your setup is also equipped to handle Horizon's
+[compute requirements](link) as well.
+
+Stellar Core is designed to run on relatively modest hardware so that a whole
+range of individuals and organizations can participate in the network, and basic
+nodes should be able to function pretty well without tremendous overhead. That
+said, the more you ask of your node, the greater the requirements.
 
 ## Network access
-Stellar Core interacts with the peer-to-peer network to keep a distributed ledger in sync, which means that your node needs to make certain [TCP ports](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#TCP_ports) available for inbound and outbound communication. 
 
-  * **Inbound**: a Stellar Core node needs to allow all ips to connect to its `PEER_PORT` over TCP.  You can specify a port when you [configure Stellar Core](link), but most people use the default, which is **11625**.
-  * **Outbound**: a Stellar Core needs to connect to other nodes via thier `PEER_PORT`s TCP.  You can find information about other nodes' `PEER_PORT`s on a network explorer like [Stellarbeat](https://stellarbeat.io/), but most use the default port, which is, again, **11265**.
+Stellar Core interacts with the peer-to-peer network to keep a distributed
+ledger in sync, which means that your node needs to make certain
+[TCP ports](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#TCP_ports)
+available for inbound and outbound communication.
+
+- **Inbound**: a Stellar Core node needs to allow all ips to connect to its
+  `PEER_PORT` over TCP. You can specify a port when you
+  [configure Stellar Core](link), but most people use the default, which is
+  **11625**.
+- **Outbound**: a Stellar Core needs to connect to other nodes via thier
+  `PEER_PORT`s TCP. You can find information about other nodes' `PEER_PORT`s on
+  a network explorer like [Stellarbeat](https://stellarbeat.io/), but most use
+  the default port, which is, again, **11265**.
 
 ## Internal System Access
-Stellar Core also needs to connect to certain internal systems, though exactly how varies based on your setup. 
 
-  * **Outbound**:
-    * Stellar Core requires access to a postgreSQL database.  If that databse resides on a different machine on your network, you'll need to allow that connection.  You specify the databse when you configure Stellar Core. 
-    * You can block all other connections.
-  * **Inbound**: Stellar Core exposes an *unauthenticated* HTTP endpoint on its `HTTP_PORT`.  You can specify a port when you [configure Stellar Core](link), but most people use the default, which is **11626**.
-    * The `HTTP_PORT` is used by Horizon to submit transactions, so may have to be exposed to the rest of your internal ips
-    * It's also used to query Stellar Core [info](link) and [metrics](info)
-    * And to perform administrative commands such as [scheduling upgrades] and [changing log levels]
-    * For more on that, see [commands](link)
+Stellar Core also needs to connect to certain internal systems, though exactly
+how varies based on your setup.
 
-Note: if you need to expose your HTTP endpoint to other hosts in your local network,we recommended using an intermediate reverse proxy server to implement authentication. Don't expose the HTTP endpoint to the raw and cruel open internet.
+- **Outbound**:
+  - Stellar Core requires access to a postgreSQL database. If that databse
+    resides on a different machine on your network, you'll need to allow that
+    connection. You specify the databse when you configure Stellar Core.
+  - You can block all other connections.
+- **Inbound**: Stellar Core exposes an _unauthenticated_ HTTP endpoint on its
+  `HTTP_PORT`. You can specify a port when you [configure Stellar Core](link),
+  but most people use the default, which is **11626**.
+  - The `HTTP_PORT` is used by Horizon to submit transactions, so may have to be
+    exposed to the rest of your internal ips
+  - It's also used to query Stellar Core [info](link) and [metrics](info)
+  - And to perform administrative commands such as [scheduling upgrades] and
+    [changing log levels]
+  - For more on that, see [commands](link)
 
-
+Note: if you need to expose your HTTP endpoint to other hosts in your local
+network,we recommended using an intermediate reverse proxy server to implement
+authentication. Don't expose the HTTP endpoint to the raw and cruel open
+internet.

--- a/content/docs/run-core-node/publishing-history-archives.mdx
+++ b/content/docs/run-core-node/publishing-history-archives.mdx
@@ -5,23 +5,31 @@ order: 50
 
 import { CodeExample } from "components/CodeExample";
 
-If you want to run a [Full Validator](link) or an [Archiver](link), you need to set up your node to publish a history archive. You can host an archive using a blob store such as Amazon's s3 or Digital Ocean's spaces, or you can simply serve a local archive directly via an HTTP server such as Nginx or Apache.  If you're setting up a [Watcher](link) or a [Basic Validator](link), you can skip this section.  No matter what kind of node you're planning to run, make sure to set it up to `get` history, which is covered in [Configuration](link). 
+If you want to run a [Full Validator](link) or an [Archiver](link), you need to
+set up your node to publish a history archive. You can host an archive using a
+blob store such as Amazon's s3 or Digital Ocean's spaces, or you can simply
+serve a local archive directly via an HTTP server such as Nginx or Apache. If
+you're setting up a [Watcher](link) or a [Basic Validator](link), you can skip
+this section. No matter what kind of node you're planning to run, make sure to
+set it up to `get` history, which is covered in [Configuration](link).
 
 ## Caching and History Archives
 
-You can significantly reduce the data transfer costs associated with running a public History archive by using common caching techniques or a CDN.
+You can significantly reduce the data transfer costs associated with running a
+public History archive by using common caching techniques or a CDN.
 
 Three simple rules apply to caching the History archives:
 
-  * Do not cache the archive state file `.well-known/history-stellar.json` (**"Cache-Control: no-cache"**)
-  * Do not cache HTTP 4xx responses (**"Cache-Control: no-cache"**)
-  * Cache everything else for as long as possible (**> 1 day**)
+- Do not cache the archive state file `.well-known/history-stellar.json`
+  (**"Cache-Control: no-cache"**)
+- Do not cache HTTP 4xx responses (**"Cache-Control: no-cache"**)
+- Cache everything else for as long as possible (**> 1 day**)
 
 ## Local History Archive Using nginx
 
 To publish a local history archive using nginx:
 
- * Add a history configuration stanza to your `/etc/stellar/stellar-core.cfg`:
+- Add a history configuration stanza to your `/etc/stellar/stellar-core.cfg`:
 
 <CodeExample>
 
@@ -34,7 +42,7 @@ mkdir="mkdir -p /mnt/xvdf/stellar-core-archive/node_001/{0}"
 
 </CodeExample>
 
- * Run new-hist to create the local archive
+- Run new-hist to create the local archive
 
 `# sudo -u stellar stellar-core --conf /etc/stellar/stellar-core.cfg new-hist local`
 
@@ -59,7 +67,7 @@ This command creates the history archive structure:
 
 </CodeExample>
 
- * Configure a virtual host to serve the local archive (Nginx)
+- Configure a virtual host to serve the local archive (Nginx)
 
 <CodeExample>
 
@@ -99,7 +107,7 @@ server {
 
 To publish a history archive using Amazon S3:
 
- * Add a history configuration stanza to your `/etc/stellar/stellar-core.cfg`:
+- Add a history configuration stanza to your `/etc/stellar/stellar-core.cfg`:
 
 <CodeExample>
 
@@ -111,12 +119,12 @@ put='aws s3 cp --region us-east-1 {0} s3://bucket.name/{1}' # Direct S3 access
 
 </CodeExample>
 
- * Run new-hist to create the s3 archive
+- Run new-hist to create the s3 archive
 
 `# sudo -u stellar stellar-core --conf /etc/stellar/stellar-core.cfg new-hist s3`
 
- * Serve the archive using an Amazon S3 static site
- * Optionally place a reverse proxy and CDN in front of the S3 static site
+- Serve the archive using an Amazon S3 static site
+- Optionally place a reverse proxy and CDN in front of the S3 static site
 
 <CodeExample>
 
@@ -177,16 +185,24 @@ server {
 
 ## Backfilling a history archive
 
-Given the choice, it's best to configure your history archive prior to your node's initial synch to the network.  That way your validator's history publishes as you join/synch to the network.
+Given the choice, it's best to configure your history archive prior to your
+node's initial synch to the network. That way your validator's history publishes
+as you join/synch to the network.
 
-However, if you have *not* published an archive during the node's initial synch, it's still possible to use the [stellar-archivist](https://github.com/stellar/go/tree/master/tools/stellar-archivist) command line tool to mirror, scan, and repair existing archives.
+However, if you have _not_ published an archive during the node's initial synch,
+it's still possible to use the
+[stellar-archivist](https://github.com/stellar/go/tree/master/tools/stellar-archivist)
+command line tool to mirror, scan, and repair existing archives.
 
-Using the [SDF package repositories](link) you can install `stellar-archivist` by running `apt-get install stellar-archivist`
+Using the [SDF package repositories](link) you can install `stellar-archivist`
+by running `apt-get install stellar-archivist`
 
-The steps required to create a History archive for an existing validator — in other words, to upgrade a Basic Validator to a Full Validator — are straightforward:
+The steps required to create a History archive for an existing validator — in
+other words, to upgrade a Basic Validator to a Full Validator — are
+straightforward:
 
- * Stop your stellar-core instance (`systemctl stop stellar-core`)
- * Configure a history archive for the new node
+- Stop your stellar-core instance (`systemctl stop stellar-core`)
+- Configure a history archive for the new node
 
 <CodeExample>
 
@@ -199,7 +215,7 @@ mkdir="mkdir -p /mnt/xvdf/stellar-core-archive/node_001/{0}"
 
 </CodeExample>
 
- * Run new-hist to create the local archive
+- Run new-hist to create the local archive
 
 `# sudo -u stellar stellar-core --conf /etc/stellar/stellar-core.cfg new-hist local`
 
@@ -224,8 +240,9 @@ This command creates the History archive structure:
 
 </CodeExample>
 
- * Start your Stellar Core instance (`systemctl start stellar-core`)
- * Allow your node to join the network and watch it start publishing a few checkpoints to the newly created archive
+- Start your Stellar Core instance (`systemctl start stellar-core`)
+- Allow your node to join the network and watch it start publishing a few
+  checkpoints to the newly created archive
 
 <CodeExample>
 
@@ -235,11 +252,17 @@ This command creates the History archive structure:
 
 </CodeExample>
 
-At this stage your validator is successfully publishing its history, which enables other users to join the network using your archive (although it won't allow them to `CATCHUP_COMPLETE=true` as the archive only has partial network history).
+At this stage your validator is successfully publishing its history, which
+enables other users to join the network using your archive (although it won't
+allow them to `CATCHUP_COMPLETE=true` as the archive only has partial network
+history).
 
 ## Complete History Archive
 
-If you decide to publish a complete archive — which enables other users to join the network from the genesis ledger — it's also  possible to use `stellar-archivist` to add all missing history data to your partial archive, and to verify the state and integrity of your archive.  For example:
+If you decide to publish a complete archive — which enables other users to join
+the network from the genesis ledger — it's also possible to use
+`stellar-archivist` to add all missing history data to your partial archive, and
+to verify the state and integrity of your archive. For example:
 
 <CodeExample>
 
@@ -262,9 +285,11 @@ If you decide to publish a complete archive — which enables other users to joi
 
 </CodeExample>
 
-As you can tell from the output of the `scan` command, some history, ledger, transactions, and results are missing from the local history archive.
+As you can tell from the output of the `scan` command, some history, ledger,
+transactions, and results are missing from the local history archive.
 
-You can repair the missing data using stellar-archivist's `repair` command combined with a known full archive — such as the SDF public history archive:
+You can repair the missing data using stellar-archivist's `repair` command
+combined with a known full archive — such as the SDF public history archive:
 
 `# stellar-archivist repair http://history.stellar.org/prd/core-testnet/core_testnet_001/ file:///mnt/xvdf/stellar-core-archive/node_001/`
 
@@ -310,7 +335,8 @@ You can repair the missing data using stellar-archivist's `repair` command combi
 
 </CodeExample>
 
-A final scan of the local archive confirms that it has been successfully repaired
+A final scan of the local archive confirms that it has been successfully
+repaired
 
 `# stellar-archivist scan file:///mnt/xvdf/stellar-core-archive/node_001`
 
@@ -329,4 +355,5 @@ A final scan of the local archive confirms that it has been successfully repaire
 
 </CodeExample>
 
-Start your stellar-core instance (`systemctl start stellar-core`), and you should have a complete history archive being written to by your full validator.
+Start your stellar-core instance (`systemctl start stellar-core`), and you
+should have a complete history archive being written to by your full validator.

--- a/content/docs/run-core-node/running-node.mdx
+++ b/content/docs/run-core-node/running-node.mdx
@@ -7,22 +7,32 @@ import { CodeExample } from "components/CodeExample";
 
 ## Starting Stellar Core
 
-Once you've [set up your environment](link), [configured your node](link), set up your [quorum set](link), and selected archives to `get` [history from](link),  you're ready to start Stellar Core.
+Once you've [set up your environment](link), [configured your node](link), set
+up your [quorum set](link), and selected archives to `get` [history from](link),
+you're ready to start Stellar Core.
 
 Use a command equivalent to:
 
 `$ stellar-core run`
 
-At this point, you're ready to observe your node's activity as it joins the network.
+At this point, you're ready to observe your node's activity as it joins the
+network.
 
-You may want to skip ahead and review the [logging](#logging) section to familiarize yourself wiith Stellar Core's output.
+You may want to skip ahead and review the [logging](#logging) section to
+familiarize yourself wiith Stellar Core's output.
 
 ## Interacting With Your Instance
-When your node is running, you can interact with Stellar Core via an administrative HTTP endpoint. Commands can be submitted using command-line HTTP tools such as `curl`, or by running a command such as
+
+When your node is running, you can interact with Stellar Core via an
+administrative HTTP endpoint. Commands can be submitted using command-line HTTP
+tools such as `curl`, or by running a command such as
 
 `$ stellar-core http-command <http-command>`
 
-That HTTP endpoint is [not intended to be exposed to the public internet](#interaction-with-other-internal-systems). It's typically accessed by administrators, or by a mid-tier application to submit transactions to the Stellar network. 
+That HTTP endpoint is
+[not intended to be exposed to the public internet](#interaction-with-other-internal-systems).
+It's typically accessed by administrators, or by a mid-tier application to
+submit transactions to the Stellar network.
 
 See [commands](./commands.md) for a description of the available commands.
 
@@ -30,7 +40,7 @@ See [commands](./commands.md) for a description of the available commands.
 
 Your node will go through the following phases as it joins the network:
 
-### Establishing Connection to Other Peers.  
+### Establishing Connection to Other Peers.
 
 You should see `authenticated_count` increase.
 
@@ -57,7 +67,8 @@ Until the node sees a quorum, it will say:
 
 </CodeExample>
 
-After observing consensus, a new field `quorum` will display information about network decisions.  At this point the node will switch to "*Catching up*":
+After observing consensus, a new field `quorum` will display information about
+network decisions. At this point the node will switch to "_Catching up_":
 
 <CodeExample>
 
@@ -86,7 +97,8 @@ After observing consensus, a new field `quorum` will display information about n
 
 ### Catching up
 
-This is a phase where the node downloads data from archives. The state will start with something like:
+This is a phase where the node downloads data from archives. The state will
+start with something like:
 
 <CodeExample>
 
@@ -108,7 +120,15 @@ And then go through the various phases of downloading and applying state such as
 
 </CodeExample>
 
-You can specify how far back your node goes to catch up in your config file.  If you set`CATCHUP_COMPLETE` to `true`, your node will replay the entire history of the network, which can take a long time.  Weeks.  Satoshipay offers a [parallel catchup script](https://github.com/satoshipay/stellar-core-parallel-catchup) to speed up the process, but you only need to replay the complete network history if you're setting up a Full Validator.  Otherwise, you can specify a starting point for catchup using `CATCHUP_RECENT`.  See the [complete example configuration](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg) for more details. 
+You can specify how far back your node goes to catch up in your config file. If
+you set`CATCHUP_COMPLETE` to `true`, your node will replay the entire history of
+the network, which can take a long time. Weeks. Satoshipay offers a
+[parallel catchup script](https://github.com/satoshipay/stellar-core-parallel-catchup)
+to speed up the process, but you only need to replay the complete network
+history if you're setting up a Full Validator. Otherwise, you can specify a
+starting point for catchup using `CATCHUP_RECENT`. See the
+[complete example configuration](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg)
+for more details.
 
 ### Synced
 
@@ -124,59 +144,82 @@ When the node is done catching up, its state will change to:
 
 ## Logging
 
-Stellar Core sends logs to standard output and `stellar-core.log` by default, configurable as `LOG_FILE_PATH`.
+Stellar Core sends logs to standard output and `stellar-core.log` by default,
+configurable as `LOG_FILE_PATH`.
 
-Log messages are classified by progressive _priority levels_:`TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR` and `FATAL`. The logging system only emits those messages at or above its configured logging level. 
+Log messages are classified by progressive _priority levels_:`TRACE`, `DEBUG`,
+`INFO`, `WARNING`, `ERROR` and `FATAL`. The logging system only emits those
+messages at or above its configured logging level.
 
-The log level can be controlled by configuration, the `-ll` command-line flag, or adjusted dynamically by administrative (HTTP) commands. To do so, run:
+The log level can be controlled by configuration, the `-ll` command-line flag,
+or adjusted dynamically by administrative (HTTP) commands. To do so, run:
 
 `$ stellar-core http-command "ll?level=debug"`
 
 while your system is running.
 
-Log levels can also be adjusted on a partition-by-partition basis through the 
-administrative interface. For example the history system can be set to DEBUG-level logging by running:
+Log levels can also be adjusted on a partition-by-partition basis through the
+administrative interface. For example the history system can be set to
+DEBUG-level logging by running:
 
-`$ stellar-core http-command "ll?level=debug&partition=history"` 
+`$ stellar-core http-command "ll?level=debug&partition=history"`
 
 Against a running system.
 
-The default log level is `INFO`, which is moderately verbose and should emit progress messages every few seconds under normal operation.
+The default log level is `INFO`, which is moderately verbose and should emit
+progress messages every few seconds under normal operation.
 
 ## Validator maintenance
 
-Maintenance here refers to anything involving taking your validator temporarily out of the network (to apply security patches, system upgrade, etc).
+Maintenance here refers to anything involving taking your validator temporarily
+out of the network (to apply security patches, system upgrade, etc).
 
-As an administrator of a validator, you must ensure that the maintenance you are about to apply to the validator is safe for the overall network and for your validator.
+As an administrator of a validator, you must ensure that the maintenance you are
+about to apply to the validator is safe for the overall network and for your
+validator.
 
-Safe means that the other validators that depend on yours will not be affected too much when you turn off your validator for maintenance and that your validator will continue to operate as part of the network when it comes back up.
+Safe means that the other validators that depend on yours will not be affected
+too much when you turn off your validator for maintenance and that your
+validator will continue to operate as part of the network when it comes back up.
 
-If you are changing some settings that may impact network wide settings such as protocol version, review [the section on network configuration](#network-configuration).
+If you are changing some settings that may impact network wide settings such as
+protocol version, review
+[the section on network configuration](#network-configuration).
 
-If you're changing your quorum set configuration, also read the [section on what to do](#special-considerations-during-quorum-set-updates).
+If you're changing your quorum set configuration, also read the
+[section on what to do](#special-considerations-during-quorum-set-updates).
 
 ### Recommended steps to perform as part of a maintenance
 
-We recommend performing the following steps in order (repeat sequentially as needed if you run multiple nodes).
+We recommend performing the following steps in order (repeat sequentially as
+needed if you run multiple nodes).
 
-  1. Advertise your intention to others that may depend on you. Some coordination is required to avoid situations where too many nodes go down at the same time.
-  2. Dependencies should assess the health of their quorum, refer to the section
-     "Understanding quorum and reliability".
-  3. If there is no objection, take your instance down
-  4. When done, start your instance that should rejoin the network
-  5. The instance will be completely caught up when it's both `Synced` and *there is no backlog in uploading history*.
+1. Advertise your intention to others that may depend on you. Some coordination
+   is required to avoid situations where too many nodes go down at the same
+   time.
+2. Dependencies should assess the health of their quorum, refer to the section
+   "Understanding quorum and reliability".
+3. If there is no objection, take your instance down
+4. When done, start your instance that should rejoin the network
+5. The instance will be completely caught up when it's both `Synced` and _there
+   is no backlog in uploading history_.
 
 #### Special considerations during quorum set updates
 
 Sometimes an organization needs to make changes that impact other's quorum sets:
 
-  * taking a validator down for long period of time
-  * adding new validators to their pool
+- taking a validator down for long period of time
+- adding new validators to their pool
 
-In both cases, it's crucial to stage the changes to preserve quorum intersection and general good health of the network:
+In both cases, it's crucial to stage the changes to preserve quorum intersection
+and general good health of the network:
 
-  * removing too many nodes from your quorum set *before* the nodes are taken down : if different people remove different sets the remaining sets may not overlap between nodes and may cause network splits
-  * adding too many nodes in your quorum set at the same time : if not done carefully can cause those nodes to overpower your configuration
+- removing too many nodes from your quorum set _before_ the nodes are taken down
+  : if different people remove different sets the remaining sets may not overlap
+  between nodes and may cause network splits
+- adding too many nodes in your quorum set at the same time : if not done
+  carefully can cause those nodes to overpower your configuration
 
-Recommended steps are for the entity that adds/removes nodes to do so first between their own nodes, and then have people reflect those changes gradually (over several rounds) in their quorum configuration.
-
+Recommended steps are for the entity that adds/removes nodes to do so first
+between their own nodes, and then have people reflect those changes gradually
+(over several rounds) in their quorum configuration.

--- a/content/docs/run-core-node/tier-1-orgs.mdx
+++ b/content/docs/run-core-node/tier-1-orgs.mdx
@@ -3,66 +3,139 @@ title: Tier 1 Organizations
 order: 80
 ---
 
-To help with Stellar’s decentralization, the most reliable and advanced Stellar teams join the ranks of “Tier 1 Organizations.” These organizations run three validators, coordinate any changes to their quorumsets, and hold themselves to a higher standard of uptime and responsiveness. 
+To help with Stellar’s decentralization, the most reliable and advanced Stellar
+teams join the ranks of “Tier 1 Organizations.” These organizations run three
+validators, coordinate any changes to their quorumsets, and hold themselves to a
+higher standard of uptime and responsiveness.
 
-SDF works closely with Tier One Orgs to ensure the health of the network, maintain good quorum intersection, and build in redundancy to minimize network disruptions.  This guide outlines what it takes to be a Tier 1 Org.  
+SDF works closely with Tier One Orgs to ensure the health of the network,
+maintain good quorum intersection, and build in redundancy to minimize network
+disruptions. This guide outlines what it takes to be a Tier 1 Org.
 
 ## Why Three Validators
-The most important function of a Tier 1 Org is to set up and maintain three Full Validators. Why three? 
 
-On Stellar, validators choose to trust organizations when they build a quorum set.  If you are a trustworthy organization, you want your presence on the network to persist even if a node fails or you take it down for maintenance.  A trio of validating nodes allows that to happen: other participants can create a quorum slice for your organization that requires ⅔ of your validating nodes to agree.  If 1 has issues, no big deal: the other two still vote on your organization’s behalf, so the show goes on.  To ensure redundancy, it's also important that those three Full Validators are geographically dispersed: if they're in the same data center, they run the risk of going down at the same time.
+The most important function of a Tier 1 Org is to set up and maintain three Full
+Validators. Why three?
+
+On Stellar, validators choose to trust organizations when they build a quorum
+set. If you are a trustworthy organization, you want your presence on the
+network to persist even if a node fails or you take it down for maintenance. A
+trio of validating nodes allows that to happen: other participants can create a
+quorum slice for your organization that requires ⅔ of your validating nodes to
+agree. If 1 has issues, no big deal: the other two still vote on your
+organization’s behalf, so the show goes on. To ensure redundancy, it's also
+important that those three Full Validators are geographically dispersed: if
+they're in the same data center, they run the risk of going down at the same
+time.
 
 Here’s what else Tier 1 Orgs expect of one another:
 
 ## Publish History Archives
-In addition to participating in SCP, a full validator publishes an archive of network transactions.   To do that, you need to configure Stellar Core to record history to a publicly accessible archive, and add the location of that archive to your stellar.toml.  To be a Tier 1 Org, you should set each of your nodes to record history to a separate archive.  
 
-Public archives make the network more resilient: when new nodes come online, or when existing nodes lose synch, they need to consult an archive to figure out what they missed.  Sharing snapshots of the ledger, which detail transactions and their results, allows those nodes to catch up, and more archives mean more redundancy and greater decentralization.  Plus, sharing history keeps everyone honest. 
+In addition to participating in SCP, a full validator publishes an archive of
+network transactions. To do that, you need to configure Stellar Core to record
+history to a publicly accessible archive, and add the location of that archive
+to your stellar.toml. To be a Tier 1 Org, you should set each of your nodes to
+record history to a separate archive.
+
+Public archives make the network more resilient: when new nodes come online, or
+when existing nodes lose synch, they need to consult an archive to figure out
+what they missed. Sharing snapshots of the ledger, which detail transactions and
+their results, allows those nodes to catch up, and more archives mean more
+redundancy and greater decentralization. Plus, sharing history keeps everyone
+honest.
 
 ## Set Up a Safe Quorum Set
 
-To maximize network resilience, we’re asking every Tier 1 node to use the same quorum set configuration, which is made up of subquorums of all validators from each Tier 1 Org. 
+To maximize network resilience, we’re asking every Tier 1 node to use the same
+quorum set configuration, which is made up of subquorums of all validators from
+each Tier 1 Org.
 
-That way, the validator community can experiment with a larger quorum, and can analyze the results of those experiments without disrupting the network.  Using existing Tier 1 Orgs as a safety net, we can work together to expand the quorum methodically and deliberately.  To see what that quorum set currently looks like, check out the (example Full Validator config file) [https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg]  
-
+That way, the validator community can experiment with a larger quorum, and can
+analyze the results of those experiments without disrupting the network. Using
+existing Tier 1 Orgs as a safety net, we can work together to expand the quorum
+methodically and deliberately. To see what that quorum set currently looks like,
+check out the (example Full Validator config file)
+[https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg]
 
 ## Declare Your Node
-[SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md) is an open spec that explains how self-verification of validator nodes works.  The steps it specifies are pretty simple: you set the homedomain of your validator’s Stellar account to your website, where you publish information about your node and your organization in a stellar.toml file.  
 
-It’s an easy way to propagate information, and it harnesses the network to allow other participants to discover your node and add it to their quorum sets without the need for a centralized database.   
+[SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md)
+is an open spec that explains how self-verification of validator nodes works.
+The steps it specifies are pretty simple: you set the homedomain of your
+validator’s Stellar account to your website, where you publish information about
+your node and your organization in a stellar.toml file.
+
+It’s an easy way to propagate information, and it harnesses the network to allow
+other participants to discover your node and add it to their quorum sets without
+the need for a centralized database.
 
 ## Keep Your Nodes Up To Date
-Running a validator requires vigilance.  You need to keep an eye on your nodes, keep them up to date with the latest version of Stellar Core, and check in on public channels for information about what’s currently happening with other validators.  
 
-The best two ways to do that: 
+Running a validator requires vigilance. You need to keep an eye on your nodes,
+keep them up to date with the latest version of Stellar Core, and check in on
+public channels for information about what’s currently happening with other
+validators.
 
-* Join the validators [email list](link)
-* download Keybase and join the [#validators channel](link) on the stellar.public team  
+The best two ways to do that:
 
-We always announce new Stellar Core releases in those channels.  You can also find those releases on our github. 
+- Join the validators [email list](link)
+- download Keybase and join the [#validators channel](link) on the
+  stellar.public team
 
-It’s also critical that you pay attention to information about what those updates mean: often, you’ll need to set your validators to vote on something timely, such as when to upgrade the network as a whole, or how high to set the operations-per-ledger limit. 
+We always announce new Stellar Core releases in those channels. You can also
+find those releases on our github.
+
+It’s also critical that you pay attention to information about what those
+updates mean: often, you’ll need to set your validators to vote on something
+timely, such as when to upgrade the network as a whole, or how high to set the
+operations-per-ledger limit.
 
 ## Coordinate With Other Validators
-Whether you run a trio of validators or a single node, it’s important that you coordinate with other validators when you make a significant change or notice something wrong.  You should let them know when you plan to:
 
-* Take your node down for maintenance
-* Make changes to your quorum set
+Whether you run a trio of validators or a single node, it’s important that you
+coordinate with other validators when you make a significant change or notice
+something wrong. You should let them know when you plan to:
 
-Letting other validators know when you plan to take your node down for maintenance or to upgrade to the latest version of stellar-core prevents a critical mass of nodes from going offline at the same time.  
+- Take your node down for maintenance
+- Make changes to your quorum set
 
-Letting other validators know when you plan to change your quorum set allows them to respond, adjust, and think through the implications of expanding the quorum.  For the quorum to expand safely, we all need to coordinate to ensure we maintain good quorum intersection. 
+Letting other validators know when you plan to take your node down for
+maintenance or to upgrade to the latest version of stellar-core prevents a
+critical mass of nodes from going offline at the same time.
+
+Letting other validators know when you plan to change your quorum set allows
+them to respond, adjust, and think through the implications of expanding the
+quorum. For the quorum to expand safely, we all need to coordinate to ensure we
+maintain good quorum intersection.
 
 ## Monitor your quorum set
-We recommend using Prometheus to to scrape and store your stellar-core metrics, and Grafana to render that data for human consumption.  You can find step-by-step instructions for setting up monitoring and alerts in [Monitoring and Diagnostics](link), along with links to Grafana dashboards we’ve created to make things easier. 
 
-You can also use stellarbeat.io to view validators’ quorum configurations, and get information about their availability and uptime, and the quorum command to diagnose problems with the quorum set of the local node.
+We recommend using Prometheus to to scrape and store your stellar-core metrics,
+and Grafana to render that data for human consumption. You can find step-by-step
+instructions for setting up monitoring and alerts in
+[Monitoring and Diagnostics](link), along with links to Grafana dashboards we’ve
+created to make things easier.
 
-You should do regular check-ins on your quorum set.  If nodes have bad uptime or prove otherwise unreliable, you may need to remove them from your quorum set so that you don’t get stuck and so that the network doesn’t halt.  You may also want to add new organizations that come online and prove reliable.  If you plan to do either of those things, remember to communicate and coordinate with other validators.
+You can also use stellarbeat.io to view validators’ quorum configurations, and
+get information about their availability and uptime, and the quorum command to
+diagnose problems with the quorum set of the local node.
+
+You should do regular check-ins on your quorum set. If nodes have bad uptime or
+prove otherwise unreliable, you may need to remove them from your quorum set so
+that you don’t get stuck and so that the network doesn’t halt. You may also want
+to add new organizations that come online and prove reliable. If you plan to do
+either of those things, remember to communicate and coordinate with other
+validators.
 
 ## Get in touch
-If you think you can be a Tier 1 Org, let us know on the #validators channel on Keybase.  We can help you through the process, and once you’re up and running, we’ll work to fold you into the quorum so that you can take your rightful place as a pillar of the network.  Once you’ve proven that you are responsive, reliable, and maintain good uptime, we will adjust the quorum set recipe above to include your validators.
 
-As Stellar grows, and more and more businesses build on the network, Tier 1 Orgs will be crucial to the methodical expansion of the network. 
+If you think you can be a Tier 1 Org, let us know on the #validators channel on
+Keybase. We can help you through the process, and once you’re up and running,
+we’ll work to fold you into the quorum so that you can take your rightful place
+as a pillar of the network. Once you’ve proven that you are responsive,
+reliable, and maintain good uptime, we will adjust the quorum set recipe above
+to include your validators.
 
-
+As Stellar grows, and more and more businesses build on the network, Tier 1 Orgs
+will be crucial to the methodical expansion of the network.

--- a/content/docs/tutorials/create-account.mdx
+++ b/content/docs/tutorials/create-account.mdx
@@ -5,15 +5,29 @@ order: 10
 
 import { CodeExample } from "components/CodeExample";
 
-_Before we get started with working with Stellar in code, consider going through the following
-examples using the [Stellar Laboratory](https://www.stellar.org/laboratory/). The lab allows you
-create accounts, fund accounts on the Stellar test network, build transactions, run any operation,
-and inspect responses from Horizon via the Endpoint Explorer._
+_Before we get started with working with Stellar in code, consider going through
+the following examples using the
+[Stellar Laboratory](https://www.stellar.org/laboratory/). The lab allows you
+create accounts, fund accounts on the Stellar test network, build transactions,
+run any operation, and inspect responses from Horizon via the Endpoint
+Explorer._
 
-[Accounts](../glossary/accounts.mdx) are a fundamental building block of Stellar: they hold all your balances, allow you to send and receive payments, and let you place offers to buy and sell assets. Since pretty much everything on Stellar is in some way tied to an account, the first thing you generally need to do when you start developing is create one.  This beginner-level tutorial will show you how to do that. 
+[Accounts](../glossary/accounts.mdx) are a fundamental building block of
+Stellar: they hold all your balances, allow you to send and receive payments,
+and let you place offers to buy and sell assets. Since pretty much everything on
+Stellar is in some way tied to an account, the first thing you generally need to
+do when you start developing is create one. This beginner-level tutorial will
+show you how to do that.
 
 ## Create a Keypair
-Stellar uses public key cryptography to ensure that every transaction is secure: every Stellar account has a keypair consisting of a **public key** and a **secret secret key**.  The public key is always safe to share — other people need it to identify your account and verify that you authorized a transaction. It's like an email address. The secret key, however, is private information that proves you own — and gives you access to — your account. It's like a password, and you should never share it with anyone.
+
+Stellar uses public key cryptography to ensure that every transaction is secure:
+every Stellar account has a keypair consisting of a **public key** and a
+**secret secret key**. The public key is always safe to share — other people
+need it to identify your account and verify that you authorized a transaction.
+It's like an email address. The secret key, however, is private information that
+proves you own — and gives you access to — your account. It's like a password,
+and you should never share it with anyone.
 
 Before creating an account, you need to generate your own keypair:
 
@@ -24,10 +38,8 @@ Before creating an account, you need to generate your own keypair:
 // see more about KeyPair objects: https://stellar.github.io/js-stellar-sdk/Keypair.html
 const pair = StellarSdk.Keypair.random();
 
-pair.secret();
-// SAV76USXIJOBMEQXPANUOQM6F5LIOTLPDIDVRJBFFE2MDJXG24TAPUU7
-pair.publicKey();
-// GCFXHS4GXL6BVUCXBWXGTITROWLVYXQKQLF4YH5O5JT3YZXCYPAFBJZB
+pair.secret(); // SAV76USXIJOBMEQXPANUOQM6F5LIOTLPDIDVRJBFFE2MDJXG24TAPUU7
+pair.publicKey(); // GCFXHS4GXL6BVUCXBWXGTITROWLVYXQKQLF4YH5O5JT3YZXCYPAFBJZB
 ```
 
 ```java
@@ -80,12 +92,22 @@ print(f"Public Key: {pair.public_key}")
 </CodeExample>
 
 ## Create Account
-A valid keypair, however, does not an account make: in order to prevent unused accounts from bloating the ledger, Stellar requires accounts to hold a [minumum balance](../glossary/minimum-balance.mdx) of 1 XLM before they actually exist.  Until it gets a bit of funding, your keypair doesn't warrant space on the ledger.
 
-On the [public network](../glossary/network-passphrase.mdx), where live users make live transactions, your next step would be to acquire XLM, which you can do by consulting our [lumen buying guide](https://www.stellar.org/lumens/exchanges).  Because this tutorial runs on the [test network](../glossary/testnet.mdx), you can get 10,000 test XLM from Friendbot, which is a friendly account funding tool.
+A valid keypair, however, does not an account make: in order to prevent unused
+accounts from bloating the ledger, Stellar requires accounts to hold a
+[minumum balance](../glossary/minimum-balance.mdx) of 1 XLM before they actually
+exist. Until it gets a bit of funding, your keypair doesn't warrant space on the
+ledger.
 
-To do that, send Friendbot the public key you created. It’ll create and fund a new
-account using that public key as the account ID.
+On the [public network](../glossary/network-passphrase.mdx), where live users
+make live transactions, your next step would be to acquire XLM, which you can do
+by consulting our
+[lumen buying guide](https://www.stellar.org/lumens/exchanges). Because this
+tutorial runs on the [test network](../glossary/testnet.mdx), you can get 10,000
+test XLM from Friendbot, which is a friendly account funding tool.
+
+To do that, send Friendbot the public key you created. It’ll create and fund a
+new account using that public key as the account ID.
 
 <CodeExample>
 
@@ -100,14 +122,16 @@ account using that public key as the account ID.
 (async function main() {
   try {
     const response = await fetch(
-      `https://friendbot.stellar.org?addr=${encodeURIComponent(pair.publicKey())}`
+      `https://friendbot.stellar.org?addr=${encodeURIComponent(
+        pair.publicKey(),
+      )}`,
     );
     const responseJSON = await response.json();
     console.log("SUCCESS! You have a new account :)\n", responseJSON);
   } catch (e) {
     console.error("ERROR!", e);
   }
-})()
+})();
 ```
 
 ```java
@@ -170,8 +194,8 @@ else:
 
 </CodeExample>
 
-Now for the last step: Getting the account’s details and checking its balance. Accounts can carry
-multiple balances — one for each type of currency they hold.
+Now for the last step: Getting the account’s details and checking its balance.
+Accounts can carry multiple balances — one for each type of currency they hold.
 
 <CodeExample>
 
@@ -181,7 +205,7 @@ const server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
 // the JS SDK uses promises for most actions, such as retrieving an account
 const account = await server.loadAccount(pair.publicKey());
 console.log("Balances for account: " + pair.publicKey());
-account.balances.forEach(function(balance) {
+account.balances.forEach(function (balance) {
   console.log("Type:", balance.asset_type, ", Balance:", balance.balance);
 });
 ```
@@ -238,5 +262,8 @@ for balance in account['balances']:
 
 </CodeExample>
 
-Now that you’ve got an account, you can [start sending and receiving payments](send-and-receive-payments.mdx), or, if you're ready to hunker down, you can skip ahead and [build an wallet](../building-apps/index.mdx) or [issue a Stellar-network asset](../issuing-assets/index.mdx).
-
+Now that you’ve got an account, you can
+[start sending and receiving payments](send-and-receive-payments.mdx), or, if
+you're ready to hunker down, you can skip ahead and
+[build an wallet](../building-apps/index.mdx) or
+[issue a Stellar-network asset](../issuing-assets/index.mdx).

--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -5,72 +5,91 @@ order: 20
 
 import { CodeExample } from "components/CodeExample";
 
-Most of the time, you’ll be sending money to someone else who has their own account. For this
-tutorial, however, you'll need a second account to transact with.  So before proceeding, follow the steps outlined in [Create an Account](./create-account.mdx) to make *two* accounts: one for sending and one for receiving.
-
+Most of the time, you’ll be sending money to someone else who has their own
+account. For this tutorial, however, you'll need a second account to transact
+with. So before proceeding, follow the steps outlined in
+[Create an Account](./create-account.mdx) to make _two_ accounts: one for
+sending and one for receiving.
 
 ## About Operations and Transactions
 
-Actions that do things on Stellar — like sending payments or making
-buy or sell offers — are called [operations](../glossary/operations.mdx). To submit an operation to the network, you bundle it into a [transaction](../glossary/transactions.mdx), which is a group of anywhere from 1 to 100 operations accompanied
-by some extra information, like which account is making the transaction and a cryptographic
-signature to verify that the transaction is authentic.
+Actions that do things on Stellar — like sending payments or making buy or sell
+offers — are called [operations](../glossary/operations.mdx). To submit an
+operation to the network, you bundle it into a
+[transaction](../glossary/transactions.mdx), which is a group of anywhere from 1
+to 100 operations accompanied by some extra information, like which account is
+making the transaction and a cryptographic signature to verify that the
+transaction is authentic.
 
-Transactions are atomic, meaning that if any operation in a transaction fails, they all fail. Let’s say you have 100
-lumens and you make two payment operations of 60 lumens each. If you make two transactions (each
-with one operation), the first will succeed and the second will fail because you don’t have enough
-lumens. You’ll be left with 40 lumens. However, if you group the two payments into a single
-transaction, they will both fail and you’ll be left with the full 100 lumens still in your account.
+Transactions are atomic, meaning that if any operation in a transaction fails,
+they all fail. Let’s say you have 100 lumens and you make two payment operations
+of 60 lumens each. If you make two transactions (each with one operation), the
+first will succeed and the second will fail because you don’t have enough
+lumens. You’ll be left with 40 lumens. However, if you group the two payments
+into a single transaction, they will both fail and you’ll be left with the full
+100 lumens still in your account.
 
-Every transaction also incurs a small fee. Like the minimum balance on accounts, this fee deters spam and prevents people from overloading the system. This [base fee](../glossary/fees.mdx) is
-very small — 100 stroops per operation where a stroop equals 1 * 10 ^-7 XLM — and it's charged for each operation in a transaction. A transaction with two operations, for instance, would cost 200 stroops.
+Every transaction also incurs a small fee. Like the minimum balance on accounts,
+this fee deters spam and prevents people from overloading the system. This
+[base fee](../glossary/fees.mdx) is very small — 100 stroops per operation where
+a stroop equals 1 \* 10 ^-7 XLM — and it's charged for each operation in a
+transaction. A transaction with two operations, for instance, would cost 200
+stroops.
 
 ## Send a Payment
 
-Stellar stores and communicates transaction data in a binary format called [XDR](../glossary/xdr.mdx), which is optimized for network performance but unreadable to the human eye. Luckily, [Horizon](../../api/introduction/index.mdx), the Stellar API, and the
-[Stellar SDKs](../software-and-sdks/index.mdx) convert XDRs into friendlier formats. Here’s how you might send 10 lumens to an account:
+Stellar stores and communicates transaction data in a binary format called
+[XDR](../glossary/xdr.mdx), which is optimized for network performance but
+unreadable to the human eye. Luckily,
+[Horizon](../../api/introduction/index.mdx), the Stellar API, and the
+[Stellar SDKs](../software-and-sdks/index.mdx) convert XDRs into friendlier
+formats. Here’s how you might send 10 lumens to an account:
 
 <CodeExample>
 
 ```js
-var StellarSdk = require('stellar-sdk');
-var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
-var sourceKeys = StellarSdk.Keypair
-  .fromSecret('SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4');
-var destinationId = 'GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5';
+var StellarSdk = require("stellar-sdk");
+var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
+var sourceKeys = StellarSdk.Keypair.fromSecret(
+  "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4",
+);
+var destinationId = "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5";
 // Transaction will hold a built transaction we can resubmit if the result is unknown.
 var transaction;
 
 // First, check to make sure that the destination account exists.
 // You could skip this, but if the account does not exist, you will be charged
 // the transaction fee when the transaction fails.
-server.loadAccount(destinationId)
+server
+  .loadAccount(destinationId)
   // If the account is not found, surface a nicer error message for logging.
   .catch(function (error) {
     if (error instanceof StellarSdk.NotFoundError) {
-      throw new Error('The destination account does not exist!');
-    } else return error
+      throw new Error("The destination account does not exist!");
+    } else return error;
   })
   // If there was no error, load up-to-date information on your account.
-  .then(function() {
+  .then(function () {
     return server.loadAccount(sourceKeys.publicKey());
   })
-  .then(function(sourceAccount) {
+  .then(function (sourceAccount) {
     // Start building the transaction.
     transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
       fee: StellarSdk.BASE_FEE,
-      networkPassphrase: StellarSdk.Networks.TESTNET
+      networkPassphrase: StellarSdk.Networks.TESTNET,
     })
-      .addOperation(StellarSdk.Operation.payment({
-        destination: destinationId,
-        // Because Stellar allows transaction in many currencies, you must
-        // specify the asset type. The special "native" asset represents Lumens.
-        asset: StellarSdk.Asset.native(),
-        amount: "10"
-      }))
+      .addOperation(
+        StellarSdk.Operation.payment({
+          destination: destinationId,
+          // Because Stellar allows transaction in many currencies, you must
+          // specify the asset type. The special "native" asset represents Lumens.
+          asset: StellarSdk.Asset.native(),
+          amount: "10",
+        }),
+      )
       // A memo allows you to add your own metadata to a transaction. It's
       // optional and does not affect how Stellar treats the transaction.
-      .addMemo(StellarSdk.Memo.text('Test Transaction'))
+      .addMemo(StellarSdk.Memo.text("Test Transaction"))
       // Wait a maximum of three minutes for the transaction
       .setTimeout(180)
       .build();
@@ -79,11 +98,11 @@ server.loadAccount(destinationId)
     // And finally, send it off to Stellar!
     return server.submitTransaction(transaction);
   })
-  .then(function(result) {
-    console.log('Success! Results:', result);
+  .then(function (result) {
+    console.log("Success! Results:", result);
   })
-  .catch(function(error) {
-    console.error('Something went wrong!', error);
+  .catch(function (error) {
+    console.error("Something went wrong!", error);
     // If the result is unknown (no response body, timeout etc.) we simply resubmit
     // already built transaction:
     // server.submitTransaction(transaction);
@@ -246,38 +265,41 @@ except (BadRequestError, BadResponseError) as err:
 
 What exactly happened there? Let’s break it down.
 
-1. Confirm that the account ID (aka the *public key*)  you are sending to actually exists by loading the associated account
-data from the Stellar network. It's okay to skip this step, but
-it gives you an opportunity to avoid making a transaction that will inevitably fail. 
-    
+1. Confirm that the account ID (aka the _public key_) you are sending to
+   actually exists by loading the associated account data from the Stellar
+   network. It's okay to skip this step, but it gives you an opportunity to
+   avoid making a transaction that will inevitably fail.
+
 <CodeExample>
 
-  ```js
-  server.loadAccount(destinationId)
-    .then(function(account) { /* validate the account */ })
-  ```
+```js
+server.loadAccount(destinationId).then(function (account) {
+  /* validate the account */
+});
+```
 
-  ```java
-  server.accounts().account(destination);
-  ```
+```java
+server.accounts().account(destination);
+```
 
-  ```go
-      if _, err := horizon.DefaultTestNetClient.LoadAccount(destination); err != nil {
-          panic(err)
-      }
-  ```
+```go
+    if _, err := horizon.DefaultTestNetClient.LoadAccount(destination); err != nil {
+        panic(err)
+    }
+```
 
-  ```python
-  server.load_account(destination_id)
-  ```
+```python
+server.load_account(destination_id)
+```
 
 </CodeExample>
 
-2. Load data for the account you are sending from. An account can only perform one transaction at a
-   time and has something called a [sequence
-   number](../glossary/accounts.mdx#sequence-number), which helps Stellar verify the order of
-   transactions. A transaction’s sequence number needs to match the account’s sequence number, so
-   you need to get the account’s current sequence number from the network.
+2. Load data for the account you are sending from. An account can only perform
+   one transaction at a time and has something called a
+   [sequence number](../glossary/accounts.mdx#sequence-number), which helps
+   Stellar verify the order of transactions. A transaction’s sequence number
+   needs to match the account’s sequence number, so you need to get the
+   account’s current sequence number from the network.
 
 <CodeExample>
 
@@ -297,17 +319,17 @@ source_account = server.load_account(source_key.public_key)
 
 </CodeExample>
 
-The SDK will automatically increment the account’s sequence number when you build a
-transaction, so you won’t need to retrieve this information again if you want to perform a
-second transaction.
+The SDK will automatically increment the account’s sequence number when you
+build a transaction, so you won’t need to retrieve this information again if you
+want to perform a second transaction.
 
-3. Start building a transaction. This requires an account object, not just an account ID, because
-   it will increment the account’s sequence number.
+3. Start building a transaction. This requires an account object, not just an
+   account ID, because it will increment the account’s sequence number.
 
 <CodeExample>
 
 ```js
-var transaction = new StellarSdk.TransactionBuilder(sourceAccount)
+var transaction = new StellarSdk.TransactionBuilder(sourceAccount);
 ```
 
 ```java
@@ -330,8 +352,11 @@ transaction = TransactionBuilder(
 
 </CodeExample>
 
-4. Add the payment operation to the account. Note that you need to specify the type of asset you
-   are sending: Stellar’s network currency is the [lumen](https://www.stellar.org/lumens), but you can send any asset issued on the network.  We'll cover sending non-lumen assets [below](#transacting-in-other-currencies). For now, though, we’ll stick to
+4. Add the payment operation to the account. Note that you need to specify the
+   type of asset you are sending: Stellar’s network currency is the
+   [lumen](https://www.stellar.org/lumens), but you can send any asset issued on
+   the network. We'll cover sending non-lumen assets
+   [below](#transacting-in-other-currencies). For now, though, we’ll stick to
    lumens, which are called “native” assets in the SDK:
 
 <CodeExample>
@@ -367,15 +392,19 @@ tx, err := build.Transaction(
 
 </CodeExample>
 
-You should also note that the amount is a string rather than a number. When working with
-extremely small fractions or large values, [floating point math can introduce small
-inaccuracies](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems). Since not all
-systems have a native way to accurately represent extremely small or large decimals, Stellar
-uses strings as a reliable way to represent the exact amount across any system.
+You should also note that the amount is a string rather than a number. When
+working with extremely small fractions or large values,
+[floating point math can introduce small inaccuracies](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems).
+Since not all systems have a native way to accurately represent extremely small
+or large decimals, Stellar uses strings as a reliable way to represent the exact
+amount across any system.
 
 5. Optionally, you can add your own metadata, called a
-   [memo](../glossary/transactions.mdx#memo), to a transaction. Stellar doesn’t do anything with
-   this data, but you can use it for any purpose you’d like.  Many exchanges require memos for incoming transactions because they use a single Stellar account for all their users and rely on the memo to differentiate between internal user accounts.
+   [memo](../glossary/transactions.mdx#memo), to a transaction. Stellar doesn’t
+   do anything with this data, but you can use it for any purpose you’d like.
+   Many exchanges require memos for incoming transactions because they use a
+   single Stellar account for all their users and rely on the memo to
+   differentiate between internal user accounts.
 
 <CodeExample title="Add a Memo">
 
@@ -397,9 +426,9 @@ build.MemoText{"Test Transaction"},
 
 </CodeExample>
 
-6. Now that the transaction has all the data it needs, you have to cryptographically sign it using
-   your secret key. This proves that the data actually came from you and not someone impersonating
-   you.
+6. Now that the transaction has all the data it needs, you have to
+   cryptographically sign it using your secret key. This proves that the data
+   actually came from you and not someone impersonating you.
 
 <CodeExample>
 
@@ -438,35 +467,41 @@ server.submitTransaction(transaction);
 resp, err := horizon.DefaultTestNetClient.SubmitTransaction(txeB64)
 ```
 
-``` python
+```python
 server.submit_transaction(transaction)
 ```
 
 </CodeExample>
 
-In this example, we're submitting the transaction to the SDF-maintained public testnet instance of Horizon, the Stellar API.  When submitting transactions to a Horizon server — which is what most people do — it's possible that you will not receive a response from due to a bug, network conditions, etc. In such a situation it's impossible to determine the status of your
-transaction. That's why you should always save a built transaction (or transaction encoded in XDR
-format) in a variable or a database and resubmit it if you don't know its status. If the
-transaction has already been successfully applied to the ledger, Horizon will simply return the
-saved result and not attempt to submit the transaction again. Only in cases where a transaction’s
-status is unknown (and thus will have a chance of being included into a ledger) will a resubmission
-to the network occur.
+In this example, we're submitting the transaction to the SDF-maintained public
+testnet instance of Horizon, the Stellar API. When submitting transactions to a
+Horizon server — which is what most people do — it's possible that you will not
+receive a response from due to a bug, network conditions, etc. In such a
+situation it's impossible to determine the status of your transaction. That's
+why you should always save a built transaction (or transaction encoded in XDR
+format) in a variable or a database and resubmit it if you don't know its
+status. If the transaction has already been successfully applied to the ledger,
+Horizon will simply return the saved result and not attempt to submit the
+transaction again. Only in cases where a transaction’s status is unknown (and
+thus will have a chance of being included into a ledger) will a resubmission to
+the network occur.
 
 ## Receive a Payment
 
-You don’t actually need to do anything to receive payments into a Stellar account: if a payer makes
-a successful transaction to send assets to you, those assets will automatically be added to your
-account.
+You don’t actually need to do anything to receive payments into a Stellar
+account: if a payer makes a successful transaction to send assets to you, those
+assets will automatically be added to your account.
 
-However, you may want to keep an eye out for incoming payments.  A simple program that watches the network for payments and prints each one might look like:
+However, you may want to keep an eye out for incoming payments. A simple program
+that watches the network for payments and prints each one might look like:
 
 <CodeExample title="Receive Payments">
 
 ```js
-var StellarSdk = require('stellar-sdk');
+var StellarSdk = require("stellar-sdk");
 
-var server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
-var accountId = 'GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF';
+var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
+var accountId = "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF";
 
 // Create an API call to query payments involving the account.
 var payments = server.payments().forAccount(accountId);
@@ -481,7 +516,7 @@ if (lastToken) {
 // `stream` will send each recorded payment, one by one, then keep the
 // connection open and continue to send you new payments as they occur.
 payments.stream({
-  onmessage: function(payment) {
+  onmessage: function (payment) {
     // Record the paging token so we can start from here next time.
     savePagingToken(payment.paging_token);
 
@@ -494,19 +529,18 @@ payments.stream({
     // In Stellar’s API, Lumens are referred to as the “native” type. Other
     // asset types have more detailed information.
     var asset;
-    if (payment.asset_type === 'native') {
-      asset = 'lumens';
-    }
-    else {
-      asset = payment.asset_code + ':' + payment.asset_issuer;
+    if (payment.asset_type === "native") {
+      asset = "lumens";
+    } else {
+      asset = payment.asset_code + ":" + payment.asset_issuer;
     }
 
-    console.log(payment.amount + ' ' + asset + ' from ' + payment.from);
+    console.log(payment.amount + " " + asset + " from " + payment.from);
   },
 
-  onerror: function(error) {
-    console.error('Error in payment stream');
-  }
+  onerror: function (error) {
+    console.error("Error in payment stream");
+  },
 });
 
 function savePagingToken(token) {
@@ -662,12 +696,14 @@ for payment in payments.stream():
 
 </CodeExample>
 
-There are two main parts to this program. First, you create a query for payments involving a given
-account. Like most queries in Stellar, this could return a huge number of items, so the API returns
-paging tokens, which you can use later to start your query from the same point where you previously
-left off. In the example above, the functions to save and load paging tokens are left blank, but in
-a real application, you’d want to save the paging tokens to a file or database so you can pick up
-where you left off in case the program crashes or the user closes it.
+There are two main parts to this program. First, you create a query for payments
+involving a given account. Like most queries in Stellar, this could return a
+huge number of items, so the API returns paging tokens, which you can use later
+to start your query from the same point where you previously left off. In the
+example above, the functions to save and load paging tokens are left blank, but
+in a real application, you’d want to save the paging tokens to a file or
+database so you can pick up where you left off in case the program crashes or
+the user closes it.
 
 <CodeExample>
 
@@ -696,20 +732,21 @@ if last_token:
 
 </CodeExample>
 
-Second, the results of the query are streamed. This is the easiest way to watch for payments or
-other transactions. Each existing payment is sent through the stream, one by one. Once all existing
-payments have been sent, the stream stays open and new payments are sent as they are made.
+Second, the results of the query are streamed. This is the easiest way to watch
+for payments or other transactions. Each existing payment is sent through the
+stream, one by one. Once all existing payments have been sent, the stream stays
+open and new payments are sent as they are made.
 
-Try it out: Run this program, and then, in another window, create and submit a payment. You should
-see this program log the payment.
+Try it out: Run this program, and then, in another window, create and submit a
+payment. You should see this program log the payment.
 
 <CodeExample>
 
 ```js
 payments.stream({
-  onmessage: function(payment) {
+  onmessage: function (payment) {
     // handle a payment
-  }
+  },
 });
 ```
 
@@ -729,14 +766,14 @@ for payment in payments.stream():
 
 </CodeExample>
 
-You can also request payments in groups or pages. Once you’ve processed each page of payments,
-you’ll need to request the next one until there are none left.
+You can also request payments in groups or pages. Once you’ve processed each
+page of payments, you’ll need to request the next one until there are none left.
 
 <CodeExample>
 
 ```js
 payments.call().then(function handlePage(paymentsPage) {
-  paymentsPage.records.forEach(function(payment) {
+  paymentsPage.records.forEach(function (payment) {
     // handle a payment
   });
   return paymentsPage.next().then(handlePage);
@@ -762,9 +799,16 @@ payments_next = payments.next()
 
 ## Transacting in Other Currencies
 
-One of the amazing things about the Stellar network is that you can create, hold, send, receive, and trade any type of
-asset.  Many organizations issue assets on Stellar that represent real-world currencies such as US dollars or Nigerian naira or other cryptocurrencies such as bitcoin or ether.
+One of the amazing things about the Stellar network is that you can create,
+hold, send, receive, and trade any type of asset. Many organizations issue
+assets on Stellar that represent real-world currencies such as US dollars or
+Nigerian naira or other cryptocurrencies such as bitcoin or ether.
 
-Each of these redeemable assets — *anchored* in the Stellar vernacular — is essentially a credit issued by a particular account that represents reserves those accounts hold outside the network.  That's why the assets in the example above had both a `code` and an `issuer`: the `issuer` is the public key of the
-account that created the asset, an account owned by the organization that ultimately honors the credit that asset represents. To find out more about how that works, check out [Enable Deposits and Withdrawals](../enabling-deposit-and-withdrawal/index.mdx). 
-
+Each of these redeemable assets — _anchored_ in the Stellar vernacular — is
+essentially a credit issued by a particular account that represents reserves
+those accounts hold outside the network. That's why the assets in the example
+above had both a `code` and an `issuer`: the `issuer` is the public key of the
+account that created the asset, an account owned by the organization that
+ultimately honors the credit that asset represents. To find out more about how
+that works, check out
+[Enable Deposits and Withdrawals](../enabling-deposit-and-withdrawal/index.mdx).

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "lodash": "^4.17.15",
-    "prettier": "^1.17.0",
     "pretty-quick": "^1.10.0",
     "prismjs": "^1.17.1",
     "prop-types": "^15.7.2",
@@ -99,5 +98,8 @@
   },
   "homepage": "https://stellar.org",
   "license": "MIT",
-  "prettier": "@stellar/prettier-config"
+  "prettier": "@stellar/prettier-config",
+  "devDependencies": {
+    "prettier": "prettier/prettier"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,24 @@
 # yarn lockfile v1
 
 
+"@angular/compiler@9.1.9":
+  version "9.1.9"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-9.1.9.tgz#cbf678ee28a0811a8ef3ee7be565d4911ff28ec7"
+  integrity sha512-kjFgaTB2ckr9lgmkS1dOGRT7kmzpQueydxsxXSHWgICNVE6F/u1PHyeSOyJRpxW0GnrkLq3QM2EUFnQGGga5bg==
+
+"@babel/code-frame@7.8.3", "@babel/code-frame@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
   integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
   dependencies:
     "@babel/highlight" "^7.0.0"
-
-"@babel/code-frame@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
-  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
-  dependencies:
-    "@babel/highlight" "^7.8.3"
 
 "@babel/compat-data@^7.9.6":
   version "7.9.6"
@@ -553,6 +558,11 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.0.tgz#8eca3e71a73dd562c5222376b08253436bb4995b"
+  integrity sha512-fnDUl1Uy2gThM4IFVW4ISNHqr3cJrCsRkSCasFgx0XDO9JcttDS5ytyBc4Cu4X1+fjoo3IVvFbRD6TeFlHJlEQ==
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.7.4", "@babel/parser@^7.7.7":
   version "7.7.7"
@@ -1802,6 +1812,37 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
+"@glimmer/env@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
+"@glimmer/interfaces@^0.53.0":
+  version "0.53.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.53.0.tgz#cb519256b0b446048b4c674c4db00754d796e0d7"
+  integrity sha512-Jiq4b5XLXc3OJDPlxj+uq3Owu4rl3e6UyApc6Of6EPal48Ync1jhGcsUUOiP0TdNIm6KeFuzwA2mY6rJ7B5IfQ==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/syntax@0.53.0":
+  version "0.53.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.53.0.tgz#61f2dd848aae7644c16f649d2ed0bb1d42c1c0fe"
+  integrity sha512-j1kXXXlb1+UrmQG6J1b6lByedFEX24zZskvqBxEcrbnwfuvRYf/LYspKlV8MCJIJLbhJCzesMsDBPdYF6IcgyA==
+  dependencies:
+    "@glimmer/interfaces" "^0.53.0"
+    "@glimmer/util" "^0.53.0"
+    handlebars "^4.7.4"
+    simple-html-tokenizer "^0.5.9"
+
+"@glimmer/util@^0.53.0":
+  version "0.53.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.53.0.tgz#19375e75c5d248d77b0f751a5f1808c7a23f77a8"
+  integrity sha512-J/46gQRLe09viNS9/bAvsEOeu70ZfFqKEU4sM9TxeMjNiiWJIN+mPoC3bFG9Ub4pPrmfbIqPOr7lTtBDibB2Sw==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "^0.53.0"
+    "@simple-dom/interface" "^1.4.0"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1833,6 +1874,11 @@
   integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
     "@hapi/hoek" "^8.3.0"
+
+"@iarna/toml@2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
+  integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
@@ -2495,6 +2541,11 @@
     "@sentry/types" "5.10.0"
     tslib "^1.9.3"
 
+"@simple-dom/interface@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
+  integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -2833,6 +2884,19 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.0.1.tgz#8c0cfb7cda64bd6f54185a7b7d1923d25d36b2a8"
+  integrity sha512-FrbMdgVCeIGHKaP9OYTttFTlF8Ds7AkjMca2GzYCE7pVch10PAJc1mmAFt+DfQPgu/2TrLAprg2vI0PK/WTdcg==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@urql/core@^1.11.0":
   version "1.11.8"
   resolved "https://registry.yarnpkg.com/@urql/core/-/core-1.11.8.tgz#6a3186ac84d6b08752585f42e8ec81539338d7a9"
@@ -3123,6 +3187,21 @@ alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
+
+angular-estree-parser@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/angular-estree-parser/-/angular-estree-parser-2.0.3.tgz#9bd11af19853fdf3101a85fa71d75227885b21f1"
+  integrity sha512-IJ1X6QUZuqkk4U0F92zm3HH9kb6PedPYN7YMcCKwwsKd/GknlcJ6jn70FO80nntuaiaFHoseet6bY1oZpQ4NyQ==
+  dependencies:
+    lines-and-columns "^1.1.6"
+    tslib "^1.9.3"
+
+angular-html-parser@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/angular-html-parser/-/angular-html-parser-1.7.0.tgz#3ac852c1af4ff7719cfa9b8a199ce28f1e35b5aa"
+  integrity sha512-/yjeqDQXGblZuFMI6vpDgiIDuv816QpIqa/mCotc0I4R0F5t5sfX1ntZ8VsBVQOUYRjPw8ggYlPZto76gHtf7Q==
+  dependencies:
+    tslib "^1.9.3"
 
 ansi-align@^3.0.0:
   version "3.0.0"
@@ -4315,6 +4394,11 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
+  integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
+
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
@@ -4387,6 +4471,14 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -4554,6 +4646,10 @@ ci-info@2.0.0, ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
+ci-info@watson/ci-info#f43f6a1cefff47fb361c88cf4b943fdbcaafe540:
+  version "2.0.0"
+  resolved "https://codeload.github.com/watson/ci-info/tar.gz/f43f6a1cefff47fb361c88cf4b943fdbcaafe540"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -4561,6 +4657,14 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+cjk-regex@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cjk-regex/-/cjk-regex-2.0.0.tgz#060aa111e61092768c438ccc9c643a53e8fe1ee5"
+  integrity sha512-E4gFi2f3jC0zFVHpaAcupW+gv9OejZ2aV3DP/LlSO0dDcZJAXw7W0ivn+vN17edN/PhU4HCgs1bfx7lPK7FpdA==
+  dependencies:
+    regexp-util "^1.2.1"
+    unicode-regex "^2.0.0"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -5085,17 +5189,7 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^5.0.0, cosmiconfig@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
-  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
-  dependencies:
-    import-fresh "^2.0.0"
-    is-directory "^0.3.1"
-    js-yaml "^3.13.1"
-    parse-json "^4.0.0"
-
-cosmiconfig@^6.0.0:
+cosmiconfig@6.0.0, cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
   integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
@@ -5105,6 +5199,16 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+cosmiconfig@^5.0.0, cosmiconfig@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
+    parse-json "^4.0.0"
 
 crc@^3.5.0:
   version "3.8.0"
@@ -5755,6 +5859,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dashify@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dashify/-/dashify-2.0.0.tgz#fff270ca2868ca427fee571de35691d6e437a648"
+  integrity sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==
+
 data-urls@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -6050,6 +6159,11 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -6109,6 +6223,11 @@ diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
+
+diff@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -6374,6 +6493,21 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+editorconfig-to-prettier@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz#7391c7067dfd68ffee65afc2c4fbe4fba8d4219a"
+  integrity sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ==
+
+editorconfig@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -6600,6 +6734,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escaper@^2.5.3:
   version "2.5.3"
@@ -6868,7 +7007,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-esutils@^2.0.0, esutils@^2.0.2:
+esutils@2.0.3, esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
@@ -7224,6 +7363,18 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
+fast-glob@3.2.2, fast-glob@^3.1.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
+  integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-glob@^2.0.2:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -7478,6 +7629,16 @@ find-cache-dir@^3.2.0:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-parent-dir@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
+find-project-root@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/find-project-root/-/find-project-root-1.1.1.tgz#d242727a2d904725df5714f23dfdcdedda0b6ef8"
+  integrity sha1-0kJyei2QRyXfVxTyPf3N7doLbvg=
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -7535,6 +7696,16 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
+flatten@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
+  integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
+
+flow-parser@0.125.1:
+  version "0.125.1"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.125.1.tgz#8e6174c0ad8bce8c4e8dbe3c2cfe30235eb0d080"
+  integrity sha512-vrnK98a85yyaPqcZTQmHlrzb4PAiF/WgkI8xZCmyn5sT6/bAKAFbUB+VQqfzTpnvq2VwZ5SThi/xuz3zMLTFRw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -8292,6 +8463,13 @@ get-stream@3.0.0, get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
+get-stream@5.1.0, get-stream@^5.0.0, get-stream@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
+
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
@@ -8304,13 +8482,6 @@ get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
-
-get-stream@^5.0.0, get-stream@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
 
@@ -8432,6 +8603,18 @@ globals@^12.1.0:
   integrity sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==
   dependencies:
     type-fest "^0.8.1"
+
+globby@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
+  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 globby@^10.0.1:
   version "10.0.1"
@@ -8618,6 +8801,11 @@ graphql-type-json@^0.3.1:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.1.tgz#47fca2b1fa7adc0758d165b33580d7be7a6cf548"
   integrity sha512-1lPkUXQ2L8o+ERLzVAuc3rzc/E6pGF+6HnjihCVTK0VzR0jCuUd92FqNxoHdfILXqOn2L6b4y47TBxiPyieUVA==
 
+graphql@15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.0.0.tgz#042a5eb5e2506a2e2111ce41eb446a8e570b8be9"
+  integrity sha512-ZyVO1xIF9F+4cxfkdhOJINM+51B06Friuv4M66W7HzUOeFd+vNzUn4vtswYINPi6sysjf1M2Ri/rwZALqgwbaQ==
+
 graphql@^14.6.0:
   version "14.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
@@ -8670,6 +8858,18 @@ handlebars@^4.1.2:
     neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.7.4:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -9039,6 +9239,11 @@ html-comment-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
   integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
 
+html-element-attributes@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-2.2.1.tgz#ff397c7a3d6427064b117b6f36b45be08e79db93"
+  integrity sha512-gGTgCeQu+g1OFExZKWQ1LwbFXxLJ6cGdCGj64ByEaxatr/EPVc23D6Gxngb37ao+SNInP/sGu8FXxRsSxMm7aQ==
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -9069,7 +9274,12 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-html-tag-names@^1.1.5:
+html-styles@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/html-styles/-/html-styles-1.0.0.tgz#a18061fd651f99c6b75c45c8e0549a3bc3e01a75"
+  integrity sha1-oYBh/WUfmca3XEXI4FSaO8PgGnU=
+
+html-tag-names@1.1.5, html-tag-names@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.5.tgz#f537420c16769511283f8ae1681785fbc89ee0a9"
   integrity sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==
@@ -9256,20 +9466,25 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+ignore@4.0.6, ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
 ignore@^3.3.5, ignore@^3.3.7:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
-ignore@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
-  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
 ignore@^5.1.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
+
+ignore@^5.1.4:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.6.tgz#643194ad4bf2712f37852e386b6998eff0db2106"
+  integrity sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA==
 
 imagemin-mozjpeg@^8.0.0:
   version "8.0.0"
@@ -10337,6 +10552,13 @@ jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-docblock@26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
+  integrity sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==
+  dependencies:
+    detect-newline "^3.0.0"
+
 jest-docblock@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
@@ -10762,6 +10984,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -10903,10 +11132,15 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-leven@^3.1.0:
+leven@3.1.0, leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+  integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
 levenary@^1.1.1:
   version "1.1.1"
@@ -10923,10 +11157,15 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lines-and-columns@^1.1.6:
+lines-and-columns@1.1.6, lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+linguist-languages@7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.9.0.tgz#025b421ff3acfdf9c9b34640816041bf842b5437"
+  integrity sha512-saKTpS7BH8vOOwzrZNTkFL/DuT2JN7cg6oHWY8nAjt89+pV1qFcpbjEEcZdAv9ogc4DcxVFHkXmjeyU/DiFHQw==
 
 load-bmfont@^1.3.1, load-bmfont@^1.4.0:
   version "1.4.0"
@@ -11178,7 +11417,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -11288,7 +11527,7 @@ lru-cache@4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.1, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -11346,7 +11585,7 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-map-age-cleaner@^0.1.1:
+map-age-cleaner@^0.1.1, map-age-cleaner@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
   integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
@@ -11542,6 +11781,14 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+mem@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-6.1.0.tgz#846eca0bd4708a8f04b9c3f3cd769e194ae63c5c"
+  integrity sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==
+  dependencies:
+    map-age-cleaner "^0.1.3"
+    mimic-fn "^3.0.0"
+
 mem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
@@ -11702,6 +11949,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-fn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.0.0.tgz#76044cfa8818bbf6999c5c9acadf2d3649b14b4b"
+  integrity sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==
+
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
@@ -11764,7 +12016,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -11776,7 +12028,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.0, minimist@^1.2.5:
+minimist@1.2.5, minimist@^1.1.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -11937,6 +12189,11 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+n-readlines@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/n-readlines/-/n-readlines-1.0.0.tgz#c353797f216c253fdfef7e91da4e8b17c29a91a6"
+  integrity sha512-ISDqGcspVu6U3VKqtJZG1uR55SmNNF9uK0EMq1IvNVVZOui6MW6VR0+pIZhqz85ORAGp+4zW+5fJ/SE7bwEibA==
 
 name-all-modules-plugin@^1.0.1:
   version "1.0.1"
@@ -12520,6 +12777,11 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
+outdent@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.7.1.tgz#e9b400443622a97760b0bc74fa3223252ccd02a2"
+  integrity sha512-VjIzdUHunL74DdhcwMDt5FhNDQ8NYmTkuW0B+usIV2afS9aWT/1c9z1TsnFW349TP3nxmYeUl7Z++XpJRByvgg==
+
 p-cancelable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
@@ -12842,6 +13104,10 @@ parse-path@^4.0.0:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
+parse-srcset@ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee:
+  version "1.0.2"
+  resolved "https://codeload.github.com/ikatyang/parse-srcset/tar.gz/54eb9c1cb21db5c62b4d0e275d7249516df6f0ee"
+
 parse-url@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
@@ -13118,7 +13384,7 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-please-upgrade-node@^3.1.1:
+please-upgrade-node@3.2.0, please-upgrade-node@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
@@ -13230,6 +13496,13 @@ postcss-flexbugs-fixes@^4.2.1:
   dependencies:
     postcss "^7.0.26"
 
+postcss-less@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-3.1.4.tgz#369f58642b5928ef898ffbc1a6e93c958304c5ad"
+  integrity sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==
+  dependencies:
+    postcss "^7.0.14"
+
 postcss-load-config@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.1.0.tgz#c84d692b7bb7b41ddced94ee62e8ab31b417b003"
@@ -13247,6 +13520,11 @@ postcss-loader@^3.0.0:
     postcss "^7.0.0"
     postcss-load-config "^2.0.0"
     schema-utils "^1.0.0"
+
+postcss-media-query-parser@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+  integrity sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=
 
 postcss-merge-longhand@^4.0.11:
   version "4.0.11"
@@ -13451,6 +13729,22 @@ postcss-reduce-transforms@^4.0.2:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-scss@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-2.1.1.tgz#ec3a75fa29a55e016b90bf3269026c53c1d2b383"
+  integrity sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==
+  dependencies:
+    postcss "^7.0.6"
+
+postcss-selector-parser@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
+  integrity sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
 postcss-selector-parser@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz#4f875f4afb0c96573d5cf4d74011aee250a7e865"
@@ -13498,6 +13792,15 @@ postcss-value-parser@^4.0.3:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
+postcss-values-parser@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
+  integrity sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
 postcss@^6.0.1, postcss@^6.0.23:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
@@ -13511,6 +13814,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.5:
   version "7.0.25"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.25.tgz#dd2a2a753d50b13bed7a2009b4a18ac14d9db21e"
   integrity sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.14, postcss@^7.0.6:
+  version "7.0.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.31.tgz#332af45cb73e26c0ee2614d7c7fb02dfcc2bd6dd"
+  integrity sha512-a937VDHE1ftkjk+8/7nj/mrjtmkn69xxzJgRETXdAUU+IgOYPQNJF17haGWbeDxSyk++HA14UA98FurvPyBJOA==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -13568,15 +13880,75 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^1.17.0:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 prettier@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
+prettier@prettier/prettier:
+  version "2.1.0-dev"
+  resolved "https://codeload.github.com/prettier/prettier/tar.gz/12d379d29db3f413266528e4e4613452d887bc7f"
+  dependencies:
+    "@angular/compiler" "9.1.9"
+    "@babel/code-frame" "7.8.3"
+    "@babel/parser" "7.10.0"
+    "@glimmer/syntax" "0.53.0"
+    "@iarna/toml" "2.2.5"
+    "@typescript-eslint/typescript-estree" "3.0.1"
+    angular-estree-parser "2.0.3"
+    angular-html-parser "1.7.0"
+    camelcase "6.0.0"
+    chalk "4.0.0"
+    ci-info watson/ci-info#f43f6a1cefff47fb361c88cf4b943fdbcaafe540
+    cjk-regex "2.0.0"
+    cosmiconfig "6.0.0"
+    dashify "2.0.0"
+    diff "4.0.2"
+    editorconfig "0.15.3"
+    editorconfig-to-prettier "0.1.1"
+    escape-string-regexp "4.0.0"
+    esutils "2.0.3"
+    fast-glob "3.2.2"
+    find-parent-dir "0.3.0"
+    find-project-root "1.1.1"
+    flow-parser "0.125.1"
+    get-stream "5.1.0"
+    globby "11.0.0"
+    graphql "15.0.0"
+    html-element-attributes "2.2.1"
+    html-styles "1.0.0"
+    html-tag-names "1.1.5"
+    ignore "4.0.6"
+    jest-docblock "26.0.0"
+    json-stable-stringify "1.0.1"
+    leven "3.1.0"
+    lines-and-columns "1.1.6"
+    linguist-languages "7.9.0"
+    lodash "4.17.15"
+    mem "6.1.0"
+    minimatch "3.0.4"
+    minimist "1.2.5"
+    n-readlines "1.0.0"
+    outdent "0.7.1"
+    parse-srcset ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee
+    please-upgrade-node "3.2.0"
+    postcss-less "3.1.4"
+    postcss-media-query-parser "0.2.3"
+    postcss-scss "2.1.1"
+    postcss-selector-parser "2.2.3"
+    postcss-values-parser "2.0.1"
+    regexp-util "1.2.2"
+    remark-math "1.0.6"
+    remark-parse "5.0.0"
+    resolve "1.17.0"
+    semver "7.3.2"
+    string-width "4.2.0"
+    tslib "1.13.0"
+    typescript "3.9.3"
+    unicode-regex "3.0.0"
+    unified "9.0.0"
+    vnopts "1.0.2"
+    yaml-unist-parser "1.2.1"
 
 pretty-bytes@^5.3.0:
   version "5.3.0"
@@ -14312,6 +14684,13 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexp-util@1.2.2, regexp-util@^1.2.0, regexp-util@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/regexp-util/-/regexp-util-1.2.2.tgz#5cf599134921eb0d776e41d41e9c0da33f0fa2fc"
+  integrity sha512-5/rl2UD18oAlLQEIuKBeiSIOp1hb5wCXcakl5yvHxlY1wyWI4D5cUKKzCibBeu741PA9JKvZhMqbkDQqPusX3w==
+  dependencies:
+    tslib "^1.9.0"
+
 regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
@@ -14419,6 +14798,13 @@ remark-footnotes@1.0.0:
   resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-1.0.0.tgz#9c7a97f9a89397858a50033373020b1ea2aad011"
   integrity sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g==
 
+remark-math@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-1.0.6.tgz#49eb3dd15d298734c9ae21673115389793af4d1b"
+  integrity sha512-I43wU/QOQpXvVFXKjA4FHp5xptK65+5F6yolm8+69/JV0EqSOB64wURUZ3JK50JtnTL8FvwLiH2PZ+fvsBxviA==
+  dependencies:
+    trim-trailing-lines "^1.1.0"
+
 remark-mdx@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-1.6.1.tgz#693aa40d0c98afdd556e7e50f2ca263d0a845e19"
@@ -14432,6 +14818,27 @@ remark-mdx@^1.6.1:
     is-alphabetical "1.0.4"
     remark-parse "8.0.2"
     unified "9.0.0"
+
+remark-parse@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
 
 remark-parse@8.0.2:
   version "8.0.2"
@@ -14679,17 +15086,17 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
+resolve@1.17.0, resolve@^1.15.1:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.10.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.1.tgz#9e018c540fcf0c427d678b9931cbf45e984bcaff"
   integrity sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.15.1:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -15064,15 +15471,15 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
+semver@7.3.2, semver@^7.1.3, semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.3, semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 send@0.17.1:
   version "0.17.1"
@@ -15259,6 +15666,11 @@ sift@^5.1.0:
   resolved "https://registry.yarnpkg.com/sift/-/sift-5.1.0.tgz#1bbf2dfb0eb71e56c4cc7fb567fbd1351b65015e"
   integrity sha1-G78t+w63HlbEzH+1Z/vRNRtlAV4=
 
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -15282,6 +15694,11 @@ simple-get@^3.0.3, simple-get@^3.1.0:
     decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-html-tokenizer@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.9.tgz#1a83fe97f5a3e39b335fddf71cfe9b0263b581c2"
+  integrity sha512-w/3FEDN94r4JQ9WoYrIr8RqDIPZdyNkdpbK9glFady1CAEyD97XWCv8HFetQO21w81e7h7Nh59iYTyG1mUJftg==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -15875,6 +16292,15 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
+string-width@4.2.0, string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -15900,15 +16326,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
 
 string.prototype.matchall@^4.0.2:
   version "4.0.2"
@@ -16608,6 +17025,11 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz#d2f1e153161152e9f02fabc670fb40bec2ea2e3a"
   integrity sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==
 
+trim-trailing-lines@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
+  integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
+
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
@@ -16637,6 +17059,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tslib@1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
@@ -16718,6 +17145,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"
@@ -16809,6 +17241,20 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
+
+unicode-regex@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-regex/-/unicode-regex-3.0.0.tgz#0c20df914c6da0412b3714cd300726e0f7f24698"
+  integrity sha512-WiDJdORsqgxkZrjC8WsIP573130HNn7KsB0IDnUccW2BG2b19QQNloNhVe6DKk3Aef0UcoIHhNVj7IkkcYWrNw==
+  dependencies:
+    regexp-util "^1.2.0"
+
+unicode-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-regex/-/unicode-regex-2.0.0.tgz#ef8f6642c37dddcaa0c09af5b9456aabf6b436a3"
+  integrity sha512-5nbEG2YU7loyTvPABaKb+8B0u8L7vWCsVmCSsiaO249ZdMKlvrXlxR2ex4TUVAdzv/Cne/TdoXSSaJArGXaleQ==
+  dependencies:
+    regexp-util "^1.2.0"
 
 unified@9.0.0:
   version "9.0.0"
@@ -17361,6 +17807,15 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vnopts@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vnopts/-/vnopts-1.0.2.tgz#f6a331473de0179d1679112cc090572b695202f7"
+  integrity sha512-d2rr2EFhAGHnTlURu49G7GWmiJV80HbAnkYdD9IFAtfhmxC+kSWEaZ6ZF064DJFTv9lQZQV1vuLTntyQpoanGQ==
+  dependencies:
+    chalk "^2.4.1"
+    leven "^2.1.0"
+    tslib "^1.9.3"
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
@@ -17665,6 +18120,11 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -17886,6 +18346,20 @@ yaml-loader@^0.6.0:
   dependencies:
     loader-utils "^1.4.0"
     yaml "^1.8.3"
+
+yaml-unist-parser@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/yaml-unist-parser/-/yaml-unist-parser-1.2.1.tgz#a604dbede940ef4d0089f17c633a3c2ecbdbb86b"
+  integrity sha512-Me5rl0QMx3C4ryN+9Gqegssy+oVU2H22VtbCkGrzLdtLK2GwpEQHtNDMqJlEMFWOw5WIN1UThsiX7Dr5epBxoQ==
+  dependencies:
+    lines-and-columns "^1.1.6"
+    tslib "^1.10.0"
+    yaml "^1.10.0"
+
+yaml@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
+  integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
 yaml@^1.7.2:
   version "1.7.2"


### PR DESCRIPTION
* Removed `*.mdx` from `.prettierignore`
* Installed the latest `prettier` for [MDX support](https://github.com/prettier/prettier/issues/7041)
* It works pretty well. It removes an empty space in a blanket line (that is required in order to render JSX component) if a user adds it before the closing mark. The content writer still needs to make sure that there's an empty line in between component declaration.
* Prettified all the files **EXCEPT** the following files:
`content/api/resources/accounts/object.mdx`
`content/api/resources/effects/types.mdx`

Those files' `<AttributeTable/>` got an empty list which prettier prettify and breaks the code. I'm going to investigate whether we can use something like `null` instead of an empty list

<img width="357" alt="example" src="https://user-images.githubusercontent.com/3912060/83061397-e89e9900-a02a-11ea-9768-dbe58b4736e4.png">
