### PR TITLE
alert to throw an error if its children isn't react element aka just string

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Beyond defining title font sizes, line heights, and weights:
 Custom (React) components that are being used throughout Documentation and API
 Reference.
 
-**Make sure that there is an empty space within the wrapper**
+**Make sure that there is an empty line within the wrapper**
 
 For example,
 

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -27,12 +27,21 @@ const CustomAlertIcon = styled(AlertIcon)`
   margin-top: 0.2rem;
 `;
 
-export const Alert = ({ children }) => (
-  <AlertEl>
-    <CustomAlertIcon color={PALETTE.purpleBlue} />
-    {children}
-  </AlertEl>
-);
+export const Alert = ({ children }) => {
+  if (typeof children === "string") {
+    // eslint-disable-next-line no-console
+    throw new Error(
+      "Children is parsed as a raw string. Make sure that there is an empty line within the React component wrapper in MDX. An empty line is needed to be parsed as markdown.",
+    );
+  }
+
+  return (
+    <AlertEl>
+      <CustomAlertIcon color={PALETTE.purpleBlue} />
+      {children}
+    </AlertEl>
+  );
+};
 
 Alert.propTypes = {
   children: PropTypes.element.isRequired,

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -35,5 +35,5 @@ export const Alert = ({ children }) => (
 );
 
 Alert.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.element.isRequired,
 };


### PR DESCRIPTION
Ticket: [Investigate why spacing is needed within a component in MDX](https://app.asana.com/0/1130719348309291/1175252988955441)

For other components such as `<CodeExample/>` that is mapping its `React.Children` to do its magic would throw an error if there is an empty line with an extra space because this would result in just `string` rather than React Element.

**However**, this isn't the case for `<Alert/>` since its code isn't manipulating React Children in anyway so if a content writer accidentally uses an empty line with an extra space but also uses markdown for a link - for example, [/docs/building-apps/basic-wallet](https://developers.stellar.org/docs/building-apps/basic-wallet/) - it would still render it without an error but its linked element wouldn't appear as a link but just a string.

This:
<img width="761" alt="alert-wrong-way" src="https://user-images.githubusercontent.com/3912060/83283059-91263780-a1a8-11ea-93b7-529bc8390b44.png">

Instead of this:
<img width="749" alt="alert-correct-way" src="https://user-images.githubusercontent.com/3912060/83283057-908da100-a1a8-11ea-8d2c-022cefe79573.png">

I changed its children's `propType` to make sure that its children is `PropTypes.element.isRequired` instead of `PropTypes.node.isRequired`. This won't throw an error during its build, but throws an error in our console.
