### PR TITLE
Replaced 'window.scrollTop' with 'window.scrollY' and add an onClick even to highlight navigation

### DIFF
--- a/content/api/resources/ledgers/index.mdx
+++ b/content/api/resources/ledgers/index.mdx
@@ -7,7 +7,7 @@ import { EndpointsTable } from "components/EndpointsTable";
 
 Each ledger stores the state of the network at a point in time and contains all the changes - transactions, operations, effects, etc. - to that state.
 
-Learn more about [ledgers](../../../docs/glossary/ledgers.mdx).
+Learn more about [ledgers](../../../docs/glossary/ledger.mdx).
 
 <EndpointsTable title="Endpoints">
 

--- a/src/components/ApiRefRouting/ScrollRouter.js
+++ b/src/components/ApiRefRouting/ScrollRouter.js
@@ -48,7 +48,7 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
         isNavClicked ? true : isScrollingDown.current,
       );
 
-      if (isNavClicked) onNavClick(false);
+      if (isNavClicked) onNavClick(!isNavClicked);
 
       // If we've found an active node and it's not the same one as we had
       // before, update the route.

--- a/src/components/ApiRefRouting/ScrollRouter.js
+++ b/src/components/ApiRefRouting/ScrollRouter.js
@@ -23,6 +23,7 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
     ref: null,
     id: initialActive,
   });
+  const [isNavClicked, onNavClick] = React.useState(false);
   const trackedElementsRef = React.useRef([]);
   const isScrollingDown = React.useRef(false);
 
@@ -36,16 +37,19 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
   React.useEffect(() => {
     const handler = throttle(() => {
       // If we haven't scrolled at least 100 pixels, just bail.
-      if (Math.abs(window.scrollTop - lastScrollPosition) < 100) {
+      if (Math.abs(window.scrollY - lastScrollPosition) < 100) {
         return;
       }
-      isScrollingDown.current = window.scrollTop > lastScrollPosition;
-      lastScrollPosition = window.scrollTop;
+      isScrollingDown.current = window.scrollY > lastScrollPosition;
+      lastScrollPosition = window.scrollY;
 
       const newActiveNode = findActiveNode(
         trackedElementsRef.current,
-        isScrollingDown.current,
+        isNavClicked ? true : isScrollingDown.current,
       );
+
+      if (isNavClicked) onNavClick(false);
+
       // If we've found an active node and it's not the same one as we had
       // before, update the route.
       if (newActiveNode && newActiveNode !== activeNode) {
@@ -60,7 +64,7 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
     return () => {
       window.removeEventListener("scroll", handler);
     };
-  }, [activeNode]);
+  }, [activeNode, isNavClicked]);
 
   // Tracked sections
   const trackElement = React.useCallback((ref, route) => {
@@ -91,8 +95,15 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
       trackElement,
       onLinkClick,
       isScrollingDown,
+      onNavClick,
     }),
-    [stopTrackingElement, trackElement, onLinkClick, isScrollingDown],
+    [
+      stopTrackingElement,
+      trackElement,
+      onLinkClick,
+      isScrollingDown,
+      onNavClick,
+    ],
   );
   const sideNavContextValue = React.useMemo(
     () => ({

--- a/src/components/ApiRefRouting/ScrollRouter.js
+++ b/src/components/ApiRefRouting/ScrollRouter.js
@@ -23,7 +23,7 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
     ref: null,
     id: initialActive,
   });
-  const [isNavClicked, onNavClick] = React.useState(false);
+  const [isNavClicked, setIsNavClicked] = React.useState(false);
   const trackedElementsRef = React.useRef([]);
   const isScrollingDown = React.useRef(false);
 
@@ -48,7 +48,7 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
         isNavClicked ? true : isScrollingDown.current,
       );
 
-      if (isNavClicked) onNavClick(!isNavClicked);
+      if (isNavClicked) setIsNavClicked(!isNavClicked);
 
       // If we've found an active node and it's not the same one as we had
       // before, update the route.
@@ -95,14 +95,14 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
       trackElement,
       onLinkClick,
       isScrollingDown,
-      onNavClick,
+      setIsNavClicked,
     }),
     [
       stopTrackingElement,
       trackElement,
       onLinkClick,
       isScrollingDown,
-      onNavClick,
+      setIsNavClicked,
     ],
   );
   const sideNavContextValue = React.useMemo(

--- a/src/components/SideNav/Provider.js
+++ b/src/components/SideNav/Provider.js
@@ -17,7 +17,7 @@ export const Provider = ({ children }) => {
   const [activeContent, setActiveNode] = React.useState({ id: "", ref: null });
   const [trackedElements, setTrackedElements] = React.useState([]);
 
-  const [isNavClicked, onNavClick] = React.useState(false);
+  const [isNavClicked, setIsNavClicked] = React.useState(false);
 
   // We need to search just the refs pretty frequently, so memoize it so we
   // don't generate a ton of garbage.
@@ -75,14 +75,14 @@ export const Provider = ({ children }) => {
       stopTrackingElement,
       trackElement,
       setActiveNode,
-      onNavClick,
+      setIsNavClicked,
     }),
     [
       activeContent,
       stopTrackingElement,
       trackElement,
       setActiveNode,
-      onNavClick,
+      setIsNavClicked,
     ],
   );
 

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -45,7 +45,7 @@ export const findActiveNode = (possibleNodes, isScrollingDown) => {
       // Display the last item when scrolled all the way to the bottom
       return isReachedBottom
         ? bottom + bottomEdge > window.innerHeight - topEdge
-        : top < bottomEdge && top >= -5;
+        : top < bottomEdge && top >= 0;
     }
 
     return bottom > topEdge && bottom < window.innerHeight;

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -6,9 +6,9 @@ import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 // eslint-disable-next-line
 const scrollPlugin = ScrollToPlugin;
 
-export const smoothScrollTo = (node, onCompleteFn) => {
+export const smoothScrollTo = (node, options = {}, onCompleteFn) => {
   const offset = 0;
-  const duration = 0.55;
+  const { duration = 0.55 } = options;
 
   TweenLite.to(window, duration, {
     scrollTo: {
@@ -45,7 +45,7 @@ export const findActiveNode = (possibleNodes, isScrollingDown) => {
       // Display the last item when scrolled all the way to the bottom
       return isReachedBottom
         ? bottom + bottomEdge > window.innerHeight - topEdge
-        : top < bottomEdge && top > 0;
+        : top < bottomEdge && top >= -5;
     }
 
     return bottom > topEdge && bottom < window.innerHeight;

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -145,7 +145,7 @@ const isInViewport = (elem) => {
 const NavItem = ({ isActive, forwardedRef, children, depth }) => {
   const itemRef = React.useRef();
   const parentDom = forwardedRef;
-  const { isScrollingDown } = React.useContext(ScrollRouterContext);
+  const { isScrollingDown, onNavClick } = React.useContext(ScrollRouterContext);
   const isMobile = useMatchMedia(`(${MEDIA_QUERIES.ltLaptop})`);
 
   React.useLayoutEffect(() => {
@@ -187,7 +187,14 @@ const NavItem = ({ isActive, forwardedRef, children, depth }) => {
   }, [isActive, parentDom, isScrollingDown, isMobile]);
 
   return (
-    <NavItemEl isActive={isActive} depth={depth} ref={itemRef}>
+    <NavItemEl
+      isActive={isActive}
+      depth={depth}
+      ref={itemRef}
+      onClick={() => {
+        onNavClick(true);
+      }}
+    >
       {children}
     </NavItemEl>
   );

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -90,12 +90,13 @@ const activeStyles = `
 `;
 
 const ApiRefH1 = styled(H1)`
-  margin-top: 0.25rem;
+  padding-top: 0.25rem;
+  margin-top: 0;
   margin-bottom: 0;
 `;
 const ApiRefH2 = styled(H2)`
-  padding-top: 0;
-  margin-top: 0.25rem;
+  padding-top: 0.25rem;
+  margin-top: 0;
   margin-bottom: 0;
 `;
 const NavItemEl = styled.div`

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -146,7 +146,9 @@ const isInViewport = (elem) => {
 const NavItem = ({ isActive, forwardedRef, children, depth }) => {
   const itemRef = React.useRef();
   const parentDom = forwardedRef;
-  const { isScrollingDown, onNavClick } = React.useContext(ScrollRouterContext);
+  const { isScrollingDown, setIsNavClicked } = React.useContext(
+    ScrollRouterContext,
+  );
   const isMobile = useMatchMedia(`(${MEDIA_QUERIES.ltLaptop})`);
 
   React.useLayoutEffect(() => {
@@ -193,7 +195,7 @@ const NavItem = ({ isActive, forwardedRef, children, depth }) => {
       depth={depth}
       ref={itemRef}
       onClick={() => {
-        onNavClick(true);
+        setIsNavClicked(true);
       }}
     >
       {children}

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -124,7 +124,7 @@ const PageOutlineItem = ({ id, isActive, title }) => {
         e.preventDefault();
         onNavClick(true);
         setActiveNode(document.getElementById(id));
-        smoothScrollTo(document.getElementById(id), () => {
+        smoothScrollTo(document.getElementById(id), { duration: 0.55 }, () => {
           onNavClick(false);
         });
       }}

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -113,7 +113,7 @@ const ModifiedEl = styled.div`
 const SectionEl = styled.section``;
 
 const PageOutlineItem = ({ id, isActive, title }) => {
-  const { setActiveNode, onNavClick } = React.useContext(
+  const { setActiveNode, setIsNavClicked } = React.useContext(
     SideNavProgressContext,
   );
 
@@ -122,10 +122,10 @@ const PageOutlineItem = ({ id, isActive, title }) => {
       isActive={isActive}
       onClick={(e) => {
         e.preventDefault();
-        onNavClick(true);
+        setIsNavClicked(true);
         setActiveNode(document.getElementById(id));
         smoothScrollTo(document.getElementById(id), { duration: 0.55 }, () => {
-          onNavClick(false);
+          setIsNavClicked(false);
         });
       }}
     >


### PR DESCRIPTION
[Ticket: API Ref active section sometimes doesn't line up after clicking a link](https://app.asana.com/0/1130719348309291/1175224232695574)

On `/api`, it was using `window.scrollTop` instead of `window.scrollY` to detect its scrolling measurement. `window.scrollTop` does not exist so it was returning `undefined`. Fixing this fixed the scroll and highlighting issue.

Unlike `/docs`, when a user clicks a link on side navigation on `/api`, its behavior changes window's history state and instead of showing smooth scroll up and down, it gets a user to the section right away - which means `isScrollingDown.current` was returning `undefined` and using the logic of scrolling up instead of scrolling down from `findActiveNode` from `/helpers/dom`. 

When clicking the link, its content's top is set to `-4`, I adjusted the number value for `findActiveNode` and set it to use `isScrollingDown` logic.

`content/api/resources/ledgers/index.mdx `
- Corrected the link to the /docs for ledgers. Will go through all of the links to make sure they are linked correctly
