### PR TITLE
Implement the grid hack in <BetaNotice/> section for its column gap to be correct 

### DIFF
--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -367,7 +367,11 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
               </SideNavContainer>
             </SideNavColumn>
             <Column xs={9} xl={18}>
-              <BetaNotice />
+              <NestedRow>
+                <CustomColumn xs={9} xlColumn="2 / span 18">
+                  <BetaNotice />
+                </CustomColumn>
+              </NestedRow>
               {referenceDocs.map(({ body, id, parent, title, githubLink }) => (
                 <ReferenceSection
                   relativePath={parent.relativePath}


### PR DESCRIPTION
Implementing the grid hack in `<BetaNotice/>` for its column gap to look correct on a big screen (`>=1440px`). It's using the same implementation that we apply to `<ReferenceSection/>` (body content).

**Before the fix**
<img width="600" alt="before-on-screen" src="https://user-images.githubusercontent.com/3912060/84511459-8a152400-ac94-11ea-87f5-f1cbd0f19795.png">

**After the fix**
<img width="600" alt="after-on-screen" src="https://user-images.githubusercontent.com/3912060/84511461-8a152400-ac94-11ea-9807-0b72ebc7ff93.png">