### PR TITLE
SingleApiReference's side nav to not extend below bottom page; its footer column gap fixed

### DIFF
--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -377,7 +377,11 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                   body={body}
                 />
               ))}
-              <Footer />
+              <NestedRow>
+                <CustomColumn xs={9} xlColumn="2 / span 18">
+                  <Footer />
+                </CustomColumn>
+              </NestedRow>
             </Column>
           </ApiReferenceRow>
         </LayoutBase>

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -36,6 +36,7 @@ import {
   ApiReferenceWrapper,
   SideNavColumn,
   NestedRow,
+  CustomColumn,
 } from "components/Documentation/SharedStyles";
 import {
   AbsoluteNavFooterEl,
@@ -87,10 +88,12 @@ const NavItemEl = styled(BasicButton)`
     color: ${PALETTE.lightGrey};
   }
 `;
-
 const NavLinkEl = styled(BasicLink)`
   color: inherit;
   font-weight: unset;
+`;
+const SingleApiSideNavContainer = styled(SideNavContainer)`
+  overflow: scroll;
 `;
 
 // This is a function, not a component
@@ -160,7 +163,7 @@ const SingleApiReference = React.memo(function ApiReference({
             <SideNavProgressContext.Provider
               value={{ activeContent: { id: path } }}
             >
-              <SideNavContainer>
+              <SingleApiSideNavContainer>
                 {Object.entries(docsBySubCategory).map((nav, i) => (
                   <ExpansionContainerEl
                     // eslint-disable-next-line react/no-array-index-key
@@ -180,21 +183,31 @@ const SingleApiReference = React.memo(function ApiReference({
                 <AbsoluteNavFooterEl>
                   <BasicLink href="/docs">Documentation</BasicLink>
                 </AbsoluteNavFooterEl>
-              </SideNavContainer>
+              </SingleApiSideNavContainer>
             </SideNavProgressContext.Provider>
           </SideNavColumn>
           <Column xs={9} xl={18}>
-            <BetaNotice />
-            <section>
-              <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
-              <NestedRow>
-                <OriginalFileContext.Provider value={parent.relativePath}>
-                  <MDXRenderer>{body}</MDXRenderer>
-                </OriginalFileContext.Provider>
-              </NestedRow>
-              <HorizontalRule />
-            </section>
-            <Footer />
+            <NestedRow>
+              <CustomColumn xs={9} xlColumn="2 / span 8">
+                <BetaNotice />
+              </CustomColumn>
+            </NestedRow>
+            <NestedRow>
+              <CustomColumn xs={9} xlColumn="2 / span 8">
+                <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
+              </CustomColumn>
+            </NestedRow>
+            <NestedRow>
+              <OriginalFileContext.Provider value={parent.relativePath}>
+                <MDXRenderer>{body}</MDXRenderer>
+              </OriginalFileContext.Provider>
+            </NestedRow>
+            <HorizontalRule />
+            <NestedRow>
+              <CustomColumn xs={9} xlColumn="2 / span 18">
+                <Footer />
+              </CustomColumn>
+            </NestedRow>
           </Column>
         </ApiReferenceRow>
       </LayoutBase>

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -94,6 +94,11 @@ const NavLinkEl = styled(BasicLink)`
 `;
 const SingleApiSideNavContainer = styled(SideNavContainer)`
   overflow: scroll;
+  height: calc(100vh - 8.75rem);
+`;
+const FixedNavFooterEl = styled(AbsoluteNavFooterEl)`
+  position: fixed;
+  bottom: 0;
 `;
 
 // This is a function, not a component
@@ -180,11 +185,11 @@ const SingleApiReference = React.memo(function ApiReference({
                     </Expansion>
                   </ExpansionContainerEl>
                 ))}
-                <AbsoluteNavFooterEl>
-                  <BasicLink href="/docs">Documentation</BasicLink>
-                </AbsoluteNavFooterEl>
               </SingleApiSideNavContainer>
             </SideNavProgressContext.Provider>
+            <FixedNavFooterEl>
+              <BasicLink href="/docs">Documentation</BasicLink>
+            </FixedNavFooterEl>
           </SideNavColumn>
           <Column xs={9} xl={18}>
             <NestedRow>


### PR DESCRIPTION
Added `overflow: hidden;` in `<SideNavContaienr/>` for `<SingleApiReference/>` so it won't extend below bottom the page.

I also noticed footer is missing its column gap on a big screen (`>=1440px`), added the `<CustomColumn/>` to surround `<Footer/>` in both `<SingleApiReference/>` and `<ApiReference/>`.

**Before the fix**
![before-the-fix](https://user-images.githubusercontent.com/3912060/84513391-5a1b5000-ac97-11ea-8f0c-09cd24d89864.png)

**After the fix**
<img width="600" alt="after-the-fix" src="https://user-images.githubusercontent.com/3912060/84513371-538cd880-ac97-11ea-86f1-0caae967920b.png">