### PR TITLE
Welcome page > to have Read More link instead of having H2 to be linked

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Welcome
 order: -100
 ---
 
-import { CodeExample } from "components/CodeExample";
+import { ReadMore } from "components/ReadMore";
 
 Right now, you're looking at the **new Stellar docs**, which are a work in progress. These new docs will live alongside the [existing Stellar docs](https://www.stellar.org/developers/guides/) until we complete the content, do some polish passes, root out and squash any bugs in the interface, and get feedback from the SDF and the Stellar community at large.
 
@@ -15,34 +15,50 @@ In addition to the docs here, which are guides to building on Stellar, you'll al
 
 A rundown of what's here:
 
-## [Tutorials](./tutorials/create-account.mdx)
+## Tutorials
 
 If you’re new to Stellar and want to get an overview of the network, this is where to start. The early tutorials will show you how to do some basic things like create an account and make payments. The later tutorials cover more advanced topics like Stellar smart contracts. If you want to issue an asset or build an app, you're better served checking the sections dedicated to those paths.
 
-## [Issue Assets](./issuing-assets/index.mdx)
+<ReadMore url="./tutorials/create-account" />
+
+## Issue Assets
 
 Stellar is a multi-currency network by design. The ability to issue assets is fundamental to Stellar, and it's something you can do quickly, safely, and in a few lines of code. Once you've issued an asset, you can also publish canonical information about it for wallets and consumers, control access to it by setting simple flags, and make it available for trade on the Stellar decentralized exchange. This section will show you how.
 
-## [Enable Deposit and Withdrawal](./enabling-deposit-and-withdrawal/index.mdx)
+<ReadMore url="./issuing-assets/index" />
+
+## Enable Deposit and Withdrawal
 
 Many Stellar assets represent real-world currencies such as dollars, euros, or naira. Companies that accept deposits and honor withdrawals of those currencies — **anchors** in Stellar terminology — set up standard infrastructure connecting Stellar to banking rails so Stellar interfaces can initiate transactions on behalf of users. If you want to set up an on/off ramp that interoperates with Stellar wallets, this section is for you.
 
-## [Build Apps](./building-apps/index.mdx)
+<ReadMore url="./enabling-deposit-and-withdrawal/index" />
+
+## Build Apps
 
 Stellar is a self-serve distributed ledger that you can use as a backend to power all kinds of apps and services. Any app built on Stellar relies on the same basic functions: key storage, account creation, transaction signing, and queries to the Stellar database. This section of the docs will walk you through the process of building a basic wallet that does all those things, and will show you how to add features to it like the support for in-app deposits and withdrawals from anchors.
 
-## [Run a Core Node](./run-core-node/index.mdx)
+<ReadMore url="./building-apps/index" />
+
+## Run a Core Node
 
 This section explains the technical and operational aspects of installing, configuring, and maintaining a Stellar Core node, which is a server that connects to the Stellar peer-to-peer network to keep a common distributed ledger. You don’t have to run a node to get started on Stellar, but you will likely want to if you're in production, need high-availability access network, or want to help increase network health and decentralization.
 
-## [Run an API Server](./run-api-server/index.mdx)
+<ReadMore url="./run-core-node/index" />
+
+## Run an API Server
 
 Most developers access the network using Horizon, the Stellar API. It takes the performance-oriented data structures from Stellar Core and converts them into a friendlier format. If you're running your own Stellar Core node and using it to submit transactions or get network data, you will likely also want to run your own Horizon instance, and this section will show you how. If you're just looking to use Horizon (vs. setting up a Horizon server), consult the API Reference.
 
-## [Software and SDKs](./software-and-sdks/index.mdx)
+<ReadMore url="./run-api-server/index" />
+
+## Software and SDKs
 
 This is where you'll find all the Stellar SDKs. There are a lot of them, and they're all pretty well maintained and documented, so you should be able to build on Stellar in your language of choice. This section is also home to some tools and reference implementations created and maintained by the Stellar Development Foundation to kickstart development.
 
-## [Glossary](./glossary/accounts.mdx)
+<ReadMore url="./software-and-sdks/index" />
+
+## Glossary
 
 This section defines all the terms and explains all the concepts germane to Stellar. Use it to look up a word, or to dig deeper into nitty-gritty details.
+
+<ReadMore url="./glossary/accounts" />

--- a/src/assets/icons/arrow.svg
+++ b/src/assets/icons/arrow.svg
@@ -1,1 +1,0 @@
-<svg viewBox="-2 -4 91 91" xmlns="http://www.w3.org/2000/svg"><path d="M40.5 80.7l40.2-40.2L40.5.3M.3 40.5h80.4" fill="none" fill-rule="evenodd"/></svg>

--- a/src/assets/icons/icon-arrow.svg
+++ b/src/assets/icons/icon-arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 10"><path d="M4.5 8.3L7.8 5 4.5 1.7M1.2 5h6.6" fill="none" stroke-miterlimit="10"/></svg>

--- a/src/basics/Icons.js
+++ b/src/basics/Icons.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { THEME } from "constants/styles";
 
+import ArrowSVG from "assets/icons/icon-arrow.svg";
 import CloseSVG from "assets/icons/icon-close.svg";
 import ChevronSVG from "assets/icons/icon-chevron.svg";
 import CheckmarkSVG from "assets/icons/icon-checkmark.svg";
@@ -100,7 +101,7 @@ CheckmarkIcon.propTypes = {
   className: PropTypes.string,
 };
 
-const ArrowEl = styled.div`
+const ChevronEl = styled.div`
   position: relative;
 
   svg {
@@ -111,9 +112,30 @@ const ArrowEl = styled.div`
   }
 `;
 
+export const ChevronIcon = ({ direction, className }) => (
+  <ChevronEl direction={direction} className={className}>
+    <ChevronSVG />
+  </ChevronEl>
+);
+
+ChevronIcon.propTypes = {
+  direction: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+const ArrowEl = styled(ChevronEl)`
+  display: flex;
+  align-items: center;
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
 export const ArrowIcon = ({ direction, className }) => (
   <ArrowEl direction={direction} className={className}>
-    <ChevronSVG />
+    <ArrowSVG />
   </ArrowEl>
 );
 

--- a/src/basics/Inputs.js
+++ b/src/basics/Inputs.js
@@ -4,9 +4,9 @@ import styled from "styled-components";
 
 import { FONT_WEIGHT, PALETTE } from "constants/styles";
 
-import { ArrowIcon } from "basics/Icons";
+import { ChevronIcon } from "basics/Icons";
 
-const WhiteArrowIcon = styled(ArrowIcon)`
+const WhiteChevronIcon = styled(ChevronIcon)`
   position: absolute;
   top: 50%;
   right: 0;
@@ -45,7 +45,7 @@ export const Select = React.forwardRef(
     <SelectWrapperEl className={className}>
       <LabelEl>
         {label}
-        <WhiteArrowIcon direction="down" />
+        <WhiteChevronIcon direction="down" />
         <SelectEl {...props} ref={ref}>
           {children}
         </SelectEl>

--- a/src/components/Documentation/Articles.js
+++ b/src/components/Documentation/Articles.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import { FONT_WEIGHT, PALETTE } from "constants/styles";
 
 import { BasicButton } from "basics/Buttons";
-import { ArrowIcon } from "basics/Icons";
+import { ChevronIcon } from "basics/Icons";
 import { ListItem, List } from "basics/Text";
 import { BasicLink } from "basics/Links";
 
@@ -32,7 +32,7 @@ const ArticleLink = styled(({ isActive, ...props }) => (
   font-weight: ${(props) =>
     props.isActive ? FONT_WEIGHT.bold : FONT_WEIGHT.normal};
 `;
-const ModifiedArrowIcon = styled(ArrowIcon)`
+const ModifiedChevronIcon = styled(ChevronIcon)`
   position: absolute;
   right: 0;
 `;
@@ -173,7 +173,7 @@ const Articles = ({
           onClick={() => topicToggleHandler(topicPath)}
         >
           {title}
-          <ModifiedArrowIcon direction="right" />
+          <ModifiedChevronIcon direction="right" />
         </TopicExpander>
       )}
 

--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -10,11 +10,11 @@ import { Link } from "basics/Links";
 const ReadMoreLinkEl = styled(Link)`
   display: flex;
   color: ${PALETTE.purple};
-  padding-top: 1rem;
+  padding-top: 0.4rem;
 `;
 
 const InlineArrowIconEl = styled(ArrowIcon)`
-  padding-left: 1rem;
+  padding-left: 0.4rem;
 
   svg {
     stroke: ${PALETTE.purple};

--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import { PALETTE } from "constants/styles";
+
+import { ArrowIcon } from "basics/Icons";
+import { Link } from "basics/Links";
+
+const ReadMoreLinkEl = styled(Link)`
+  display: flex;
+  color: ${PALETTE.purple};
+  padding-top: 1rem;
+`;
+
+const InlineArrowIconEl = styled(ArrowIcon)`
+  padding-left: 1rem;
+
+  svg {
+    stroke: ${PALETTE.purple};
+  }
+`;
+
+export const ReadMore = ({ url }) => (
+  <ReadMoreLinkEl href={url}>
+    Read More <InlineArrowIconEl direction="right" />
+  </ReadMoreLinkEl>
+);
+
+ReadMore.propTypes = { url: PropTypes.string.isRequired };

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -25,7 +25,7 @@ import { useMatchMedia } from "helpers/useMatchMedia";
 
 import { Column } from "basics/Grid";
 import { H1, H2, H3, H4, H5, H6, HorizontalRule } from "basics/Text";
-import { ArrowIcon, EditIcon } from "basics/Icons";
+import { ChevronIcon, EditIcon } from "basics/Icons";
 import { Link, BasicLink } from "basics/Links";
 import { PrismStyles } from "basics/Prism";
 
@@ -348,8 +348,8 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                       <Expansion
                         title={<NavTitleEl>{nav[0]}</NavTitleEl>}
                         expandedModeTitle={<NavTitleEl>{nav[0]}</NavTitleEl>}
-                        collapseIcon={<ArrowIcon direction="up" />}
-                        expandIcon={<ArrowIcon direction="down" />}
+                        collapseIcon={<ChevronIcon direction="up" />}
+                        expandIcon={<ChevronIcon direction="down" />}
                         isDefaultExpanded={true}
                       >
                         <SideNavBody

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -23,7 +23,7 @@ import { buildPathFromFile, normalizeRoute } from "helpers/routes";
 import { BasicButton } from "basics/Buttons";
 import { H1, H2, H3, H4, H5, H6, HorizontalRule } from "basics/Text";
 import { Column } from "basics/Grid";
-import { ArrowIcon } from "basics/Icons";
+import { ChevronIcon } from "basics/Icons";
 import { OriginalFileContext, BasicLink } from "basics/Links";
 
 import { Footer } from "components/Documentation/Footer";
@@ -177,8 +177,8 @@ const SingleApiReference = React.memo(function ApiReference({
                     <Expansion
                       title={<NavTitleEl>{nav[0]}</NavTitleEl>}
                       expandedModeTitle={<NavTitleEl>{nav[0]}</NavTitleEl>}
-                      collapseIcon={<ArrowIcon direction="up" />}
-                      expandIcon={<ArrowIcon direction="down" />}
+                      collapseIcon={<ChevronIcon direction="up" />}
+                      expandIcon={<ChevronIcon direction="down" />}
                       isDefaultExpanded={true}
                     >
                       <SideNavBody items={nav[1]} renderItem={renderItem} />


### PR DESCRIPTION
Our [docs](https://developers.stellar.org/docs/)' `Welcome Page` is the only page with H2 that has a link. I spoke to Charles about its styling and Charles suggested to have a **Read More** CTA button at the bottom instead of H2 with a link

**Preview:**
Old way
<img width="835" alt="old-h2-links" src="https://user-images.githubusercontent.com/3912060/84943612-9ba26580-b0b2-11ea-9e20-d6105211af31.png">

New way
<img width="790" alt="new-readmore" src="https://user-images.githubusercontent.com/3912060/84943609-9b09cf00-b0b2-11ea-8faa-49c9cbc46a89.png">
