### PR TITLE
Fix too-dense text, inability to scroll over short code snippets

### DIFF
--- a/src/basics/GlobalStyles.js
+++ b/src/basics/GlobalStyles.js
@@ -35,7 +35,6 @@ const Styles = createGlobalStyle`
   /* http://tachyons.io/docs/layout/box-sizing/ */
   body * {
     box-sizing: border-box;
-    overscroll-behavior: contain;
   }
   twitter-widget {
     margin: auto;

--- a/src/basics/Text.js
+++ b/src/basics/Text.js
@@ -167,9 +167,10 @@ export const Small = styled.small`
 `;
 export const Table = styled.table`
   display: block;
-  position: relative;
   word-break: normal;
   width: 100%;
+  font-size: 0.875rem;
+  line-height: 1.375;
   overflow: auto;
   padding: 0 1px;
   margin: 0;
@@ -178,7 +179,6 @@ export const Table = styled.table`
 export const TableHead = styled.thead``;
 export const TableHeadCell = styled.th`
   text-transform: uppercase;
-  font-size: 0.875rem;
   font-weight: ${FONT_WEIGHT.bold};
   text-align: left;
   border-bottom: none;
@@ -191,9 +191,7 @@ export const TableHeadCell = styled.th`
   line-height: 1.5;
   vertical-align: middle;
 `;
-export const TableBody = styled.tbody`
-  font-size: 0.875rem;
-`;
+export const TableBody = styled.tbody``;
 export const TableRow = styled.tr`
   &:nth-child(even) {
     background-color: ${PALETTE.white80};

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -23,6 +23,7 @@ export const H2 = styled(BasicH2)`
 export const NavAbsoluteEl = styled.div`
   overflow-y: scroll;
   flex-grow: 1;
+  overscroll-behavior: contain;
 
   // Suppress scrollbar on nav
   @media (${MEDIA_QUERIES.canHover}) {


### PR DESCRIPTION
Text before:
![developers stellar org_docs_start_list-of-operations_](https://user-images.githubusercontent.com/1551487/84949261-f3dd6580-b0ba-11ea-859d-89634cc441bd.png)
after:
![localhost_8000_docs_start_list-of-operations_](https://user-images.githubusercontent.com/1551487/84949281-fb047380-b0ba-11ea-87fe-e07465d4f431.png)

The other is harder to demonstrate, but e.g. when scrolling on [the create account tutorial](https://developers.stellar.org/docs/tutorials/create-account/), all code snippets block scroll if you're hovering them. I think the only situation where it's strongly appropriate to block overscroll is the left nav, so I moved it there.