### PR TITLE
Use setTimeout instead of rAF in syntax highlighting

### DIFF
--- a/src/helpers/useHighlighting.js
+++ b/src/helpers/useHighlighting.js
@@ -3,8 +3,8 @@ import Prism from "prismjs";
 
 export const useHighlighting = (ref) => {
   React.useEffect(() => {
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       Prism.highlightAllUnder(ref.current);
-    });
+    }, 0);
   });
 };


### PR DESCRIPTION
I wrapped the prism call in `requestAnimationFrame` to avoid blocking the main thread, but it doesn't appear to have worked
<img width="609" alt="Screen Shot 2020-06-22 at 8 09 52 AM" src="https://user-images.githubusercontent.com/1551487/85286096-01e70980-b460-11ea-9a71-6c41c381319a.png">
With setTimeout, the main thread is blocked for much smaller chunks
<img width="603" alt="Screen Shot 2020-06-22 at 8 10 39 AM" src="https://user-images.githubusercontent.com/1551487/85286127-0dd2cb80-b460-11ea-80bf-6dd3f907d716.png">
(This is dev mode, so the perf timing is much slower than production)
