### PR TITLE
bugfix/design-grid-h4 > H4 styling and grid fix

### DIFF
--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -216,7 +216,6 @@ export const NavItem = styled.div`
 export const SideNavContainer = styled.div`
   height: calc(100vh - 4.5rem);
   width: 100%;
-  /* max-width: 18rem; */
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/src/components/Navigation/SharedStyles.js
+++ b/src/components/Navigation/SharedStyles.js
@@ -216,7 +216,7 @@ export const NavItem = styled.div`
 export const SideNavContainer = styled.div`
   height: calc(100vh - 4.5rem);
   width: 100%;
-  max-width: 18rem;
+  /* max-width: 18rem; */
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/src/constants/docsComponentMapping.js
+++ b/src/constants/docsComponentMapping.js
@@ -72,7 +72,12 @@ export const components = {
       }
     }
   `,
-  h4: TextComponents.H4,
+  h4: styled(TextComponents.H4)`
+    color: ${PALETTE.darkGrey};
+    font-weight: ${FONT_WEIGHT.medium};
+    font-size: 1.125rem;
+    line-height: 1.5;
+  `,
   h5: TextComponents.H5,
   h6: TextComponents.H6,
   blockquote: TextComponents.Quote,

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -382,7 +382,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                 />
               ))}
               <NestedRow>
-                <CustomColumn xs={9} xlColumn="2 / span 18">
+                <CustomColumn xs={9} xlColumn="2 / span 10">
                   <Footer />
                 </CustomColumn>
               </NestedRow>


### PR DESCRIPTION
**Bug 1: `<H4/>` tags appeared inconsistent after `<H3/>`**
<img width="768" alt="h4-before-fix" src="https://user-images.githubusercontent.com/3912060/85466897-82009280-b578-11ea-9754-010baf89ad20.png">

**Bug 1: After fixing**
<img width="827" alt="h4-after-fix" src="https://user-images.githubusercontent.com/3912060/85466892-8167fc00-b578-11ea-8205-d06905724525.png">

**Bug 2: Grid wasn't aligned on a big screen. Reported by Charles**
On API before the fix. The same problem appeared on `/docs` as well
<img width="1000" alt="api-grid-bug" src="https://user-images.githubusercontent.com/3912060/85466890-80cf6580-b578-11ea-87cc-d94d36533197.png">

**Bug 2: After fixing**
/docs:
<img width="1440" alt="docs-grid-after-fix" src="https://user-images.githubusercontent.com/3912060/85466893-8167fc00-b578-11ea-8bbd-e155594ae1ba.png">

/api:
<img width="1429" alt="api-grid-after-fix" src="https://user-images.githubusercontent.com/3912060/85466894-82009280-b578-11ea-9c1c-96420ffcb31e.png">