### PR TITLE
Fix Safari and metrics emission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY content /app/src/content
 COPY plugins /app/src/plugins
 COPY src /app/src/src
 
+ARG AMPLITUDE_KEY
 RUN yarn build
 
 FROM nginx:1.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,12 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 
 WORKDIR /app/src
 
-ADD package.json /app/src
-ADD yarn.lock /app/src
+ADD package.json yarn.lock /app/src/
 
 RUN yarn
 
 # Enumerate specific files for better docker build caching
-COPY .eslintrc.js /app/src
-COPY .babelrc /app/src
-COPY gatsby-browser.js /app/src
-COPY gatsby-config.js /app/src
-COPY gatsby-node.js /app/src
-COPY gatsby-ssr.js /app/src
-COPY jsconfig.json /app/src
+COPY .eslintrc.js .babelrc gatsby-browser.js gatsby-config.js gatsby-node.js gatsby-ssr.js jsconfig.json /app/src/
 COPY buildHelpers /app/src/buildHelpers
 COPY content /app/src/content
 COPY plugins /app/src/plugins

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 TAG ?= stellar/developers:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 
 docker-build:
-	$(SUDO) docker build -t $(TAG) .
+	$(SUDO) docker build --build-arg AMPLITUDE_KEY=$(AMPLITUDE_KEY) -t $(TAG) .
 
 docker-push:
 	$(SUDO) docker push $(TAG)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ yarn prod:build
 yarn prod:serve
 ```
 
+To run a complete simulation of a production build, make sure to set an
+`AMPLITUDE_KEY` environment variable.
+
 # Structure
 
 - `/content` contains

--- a/buildHelpers/env.js
+++ b/buildHelpers/env.js
@@ -1,14 +1,5 @@
 const NODE_ENV = process.env.NODE_ENV;
-const BETA_FLAG = process.env.IS_BETA || "false";
-
-const IS_LOCAL = process.env.PWD !== "/app/src";
-const IS_BUILD = process.env.npm_lifecycle_event === "build";
-const IS_BETA = BETA_FLAG === "true";
-const IS_PRODUCTION = !IS_BETA && NODE_ENV === "production";
-
-const SITE_URL = IS_LOCAL
-  ? "http://localhost:8000"
-  : process.env.URL || "https://developers.stellar.org";
+const IS_PRODUCTION = NODE_ENV === "production";
 
 const FEATURES = {
   redesign: "isRedesign",
@@ -20,11 +11,6 @@ const FEATURE_FLAGS = {
   [FEATURES.docs]: !IS_PRODUCTION,
 };
 
-exports.AMPLITUDE_KEY = process.env.AMPLITUDE_KEY;
-exports.IS_LOCAL = IS_LOCAL;
 exports.IS_PRODUCTION = IS_PRODUCTION;
-exports.IS_BETA = IS_BETA;
-exports.IS_BUILD = IS_BUILD;
-exports.SITE_URL = SITE_URL;
 exports.FEATURES = FEATURES;
 exports.FEATURE_FLAGS = FEATURE_FLAGS;

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,7 @@
 import React from "react";
 import * as Sentry from "@sentry/browser";
 
-import { IS_BUILD } from "constants/env";
+import { IS_PRODUCTION } from "constants/env";
 import { GlobalStyles } from "basics/GlobalStyles";
 import Providers from "components/Providers";
 
@@ -14,7 +14,7 @@ export const wrapRootElement = ({ element }) => (
 );
 
 export const onInitialClientRender = () => {
-  if (IS_BUILD) {
+  if (IS_PRODUCTION) {
     // Set up Sentry
     Sentry.init({
       dsn: "https://efc31f19f9c54082b8d993bfb62eee57@sentry.io/1531056",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,11 @@ const {
 } = require("./buildHelpers/serializeSitemap");
 
 // Determine what environment we're running in and what the URL is.
-const { IS_BUILD, SITE_URL } = require("./buildHelpers/env");
+const IS_BUILD = process.env.npm_lifecycle_event === "build";
+const IS_LOCAL = process.env.PWD !== "/app/src";
+const SITE_URL = IS_LOCAL
+  ? "http://localhost:8000"
+  : process.env.URL || "https://developers.stellar.org";
 
 // Gatsby config
 module.exports = {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -57,10 +57,7 @@ exports.onCreateWebpackConfig = ({ actions, plugins }) => {
       plugins.define({
         "process.env": {
           NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-          IS_BETA: JSON.stringify(process.env.IS_BETA),
-          CONTEXT: JSON.stringify(process.env.CONTEXT),
-          URL: JSON.stringify(process.env.URL),
-          DEPLOY_PRIME_URL: JSON.stringify(process.env.DEPLOY_PRIME_URL),
+          AMPLITUDE_KEY: JSON.stringify(process.env.AMPLITUDE_KEY),
         },
       }),
     ],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest",
     "build": "gatsby build",
     "check-not-master": "[ \"$(git rev-parse --abbrev-ref HEAD)\" = \"master\" ] && echo \"\\033[31mDon't commit to master\" && exit 1 || exit 0",
-    "prod:build": "docker image build -t new-docs:localbuild .",
+    "prod:build": "cross-env TAG=new-docs:localbuild AMPLITUDE_KEY=$AMPLITUDE_KEY make docker-build",
     "prod:serve": "docker run -p 8000:80 new-docs:localbuild",
     "production": "yarn prod:build && yarn prod:serve"
   },
@@ -42,6 +42,7 @@
     "babel-preset-gatsby": "^0.4.2",
     "concurrently": "^4.1.0",
     "core-js": "2",
+    "cross-env": "^7.0.2",
     "dotenv": "^7.0.0",
     "eslint": "6.x",
     "eslint-config-prettier": "^6.9.0",

--- a/src/components/layout/LayoutBase.js
+++ b/src/components/layout/LayoutBase.js
@@ -42,9 +42,9 @@ export const LayoutBase = ({
   children,
   viewport = "width=device-width, initial-scale=1",
 }) => {
-  mark(PERFORMANCE_MARKS.layout);
+  mark(PERFORMANCE_MARKS.renderLayout);
   React.useEffect(() => {
-    const timing = measure(PERFORMANCE_MARKS.layout);
+    const timing = measure(PERFORMANCE_MARKS.renderLayout);
     emitMetric("page rendered", {
       ...timing,
       page: window.location.pathname,

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -1,5 +1,4 @@
 import throttle from "lodash/throttle";
-import { AMPLITUDE_KEY } from "constants/env";
 
 const METRICS_ENDPOINT = "https://api.amplitude.com/2/httpapi";
 let cache = [];
@@ -7,7 +6,7 @@ let cache = [];
 const uploadMetrics = throttle(() => {
   const toUpload = cache;
   cache = [];
-  if (!AMPLITUDE_KEY) {
+  if (!process.env.AMPLITUDE_KEY) {
     // eslint-disable-next-line no-console
     console.log("No metrics API key present, not uploading events", toUpload);
     return;
@@ -18,7 +17,7 @@ const uploadMetrics = throttle(() => {
       "Content-Type": "application/json",
     },
     body: {
-      apiKey: AMPLITUDE_KEY,
+      apiKey: process.env.AMPLITUDE_KEY,
       events: toUpload,
     },
   });

--- a/src/helpers/metrics.js
+++ b/src/helpers/metrics.js
@@ -16,16 +16,16 @@ const uploadMetrics = throttle(() => {
     headers: {
       "Content-Type": "application/json",
     },
-    body: {
-      apiKey: process.env.AMPLITUDE_KEY,
+    body: JSON.stringify({
+      api_key: process.env.AMPLITUDE_KEY,
       events: toUpload,
-    },
+    }),
   });
 }, 500);
 
 export const emitMetric = (name, body) => {
   cache.push({
-    event_name: name,
+    event_type: name,
     event_properties: body,
     // user_id is required
     user_id: "00000",

--- a/src/helpers/performance.js
+++ b/src/helpers/performance.js
@@ -6,11 +6,18 @@ export const hasHighPrecision = Boolean(performance);
 // lower precision form of it if not available.
 let clear = (perfMark) => {
   performance.clearMarks(perfMark);
-  performance.clearMeasures(perfMark);
+  performance.clearMarks(`${perfMark} end`);
+  performance.clearMeasures(`${perfMark} measure`);
 };
 let internalMark = performance?.mark.bind(performance);
 let internalMeasure = (perfMark) => {
-  const { duration } = performance.measure(null, perfMark);
+  const endMark = `${perfMark} end`;
+  const measureName = `${perfMark} measure`;
+  performance.mark(endMark);
+  performance.measure(measureName, perfMark, endMark);
+  const results = performance.getEntriesByName(measureName);
+  // Get the duration off the last (most recent measurement)
+  const { duration } = results[results.length - 1];
   clear(perfMark);
   return { time: duration, hasHighPrecision };
 };

--- a/src/html.js
+++ b/src/html.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { PORTAL_TARGETS } from "constants/domNodes";
-import { IS_BUILD } from "constants/env";
+import { IS_PRODUCTION } from "constants/env";
 
 export default function HTML(props) {
   return (
@@ -9,7 +9,7 @@ export default function HTML(props) {
       <head>
         <meta charSet="utf-8" />
         <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-        {IS_BUILD && (
+        {IS_PRODUCTION && (
           <script async src="https://www.google-analytics.com/analytics.js" />
         )}
         {props.headComponents}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5160,6 +5160,13 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
@@ -5192,6 +5199,15 @@ cross-spawn@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
Chrome exposes a nonstandard form of the Performance API, whose behavior I relied upon. This broke the page in other browsers. This fixes that issue by using only the standard (and more complex) behavior.

There were also issues with metrics emission, with the environment variable not being passed through the build correctly, and Google analytics not being loaded correctly due to Gatsby's behavior around env vars. 

This also improves the local production build by bringing it more closely in line with how Jenkins runs builds, which should lead to fewer shipped bugs that appear okay locally.