### PR TITLE
Fix GA sessions, remove /api from sitemap, update landing page

### DIFF
--- a/buildHelpers/serializeSitemap.js
+++ b/buildHelpers/serializeSitemap.js
@@ -38,7 +38,7 @@ const serializeLocale = (locale) => {
       .map(({ node }) => getPathInfo(node))
       // Technically "/api" doesn't have any content, it's just a filler page for
       // other content to live on. Strip it from the sitemap.
-      .filter(({ originalPath }) => originalPath !== "/api");
+      .filter(({ originalPath }) => originalPath !== "/api/");
     const byPath = groupBy(pages, "path");
     const pagesWithAlternates = Object.values(byPath).reduce(
       (accum, pageVersions) => {

--- a/buildHelpers/serializeSitemap.js
+++ b/buildHelpers/serializeSitemap.js
@@ -34,7 +34,11 @@ const checkIsBlogPostRegex = /blog\/.+/;
 const serializeLocale = (locale) => {
   return ({ site, allSitePage }) => {
     const { edges } = allSitePage;
-    const pages = edges.map(({ node }) => getPathInfo(node));
+    const pages = edges
+      .map(({ node }) => getPathInfo(node))
+      // Technically "/api" doesn't have any content, it's just a filler page for
+      // other content to live on. Strip it from the sitemap.
+      .filter(({ originalPath }) => originalPath !== "/api");
     const byPath = groupBy(pages, "path");
     const pagesWithAlternates = Object.values(byPath).reduce(
       (accum, pageVersions) => {

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -23,8 +23,14 @@ export const onInitialClientRender = () => {
     // Set up Google Analytics
     /* eslint-disable */
     if (typeof ga === "function") {
-      ga("create", "UA-53373928-1", "auto", {});
+      ga("create", "UA-53373928-1", "auto");
       ga("set", "anonymizeIp", true);
+
+      // We want developers.stellar.org and www.stellar.org to use the same
+      // session
+      ga("require", "linker");
+      ga("linker:autolink", ["www.stellar.org", "stellar.org"]);
+
       ga("send", "pageview");
     }
     /* eslint-enable */

--- a/nginx/includes/server.conf
+++ b/nginx/includes/server.conf
@@ -2,11 +2,9 @@ root /usr/share/nginx/html/new-docs/;
 
 # FYI: Redirect breaks
 location = / {
-  # `$scheme://$http_host` is because otherwise, it adds the port nginx is
-  # listening on. Since we listen on 80 but expose 8000 by default from docker
-  # locally, the redirect was going to `localhost/docs` which doesn't have a
-  # server listening.
-  return 302 $scheme://$http_host/docs;
+  proxy_pass https://proxy.stellar.org/developers;
+  proxy_ssl_server_name on;
+
 }
 
 location / {


### PR DESCRIPTION
* Change `developers.stellar.org/` (no pathname) to point to the Webflow landing page at `stellar.org/developers`. 
* Set up Google Analytics autolinker so cross-domain sessions work correctly.
* Remove /api from sitemap to (maybe) fix SEO issues