### PR TITLE
Attempt to fix SEO issues on /api/* pages

### DIFF
--- a/nginx/includes/server.conf
+++ b/nginx/includes/server.conf
@@ -14,6 +14,10 @@ location / {
 # SEO optimization for API Reference. This lets crawlers only see the content
 # from each individual section.
 set $no-js false;
+# UA check sourced from https://gist.github.com/thoop/8165802
+if ($http_user_agent ~* "googlebot|bingbot|yandex|baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp") {
+  set $no-js true;
+}
 if ($arg_javascript = 'false') {
   set $no-js true;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,7 +3,7 @@ http {
   include mime.types;
   server {
     listen 80 default_server;
-    server_name docs.stellar.org;
+    server_name developers.stellar.org;
     include includes/server.conf;
 
     location /robots.txt {

--- a/src/basics/Links.js
+++ b/src/basics/Links.js
@@ -116,11 +116,18 @@ export const Link = ({ href, newTab, ...props }) => {
         destination.pathname || "",
       );
     }
-    // If the page is being generated with a /no-js url, then we need to make
-    // sure the links render with the right querystring so they load correctly
-    // when clicked.
-    if (destination.path?.startsWith("/no-js")) {
+    // If the page is being generated with a /no-js url, or if we're currently on
+    // an /api page and `javascript=false` is in the query string, then we need
+    // to make sure the links render with the right path and querystring so they
+    // load correctly when clicked.
+    const fromNoJs = destination.path?.startsWith("/no-js");
+    const fromApiNoJs =
+      location.pathname.startsWith("/api") &&
+      location.search.includes("javascript=false");
+    if (fromNoJs) {
       destination.pathname = destination.path.split("/no-js")[1];
+    }
+    if (fromNoJs || fromApiNoJs) {
       destination.search = destination.search
         ? `${destination.query}&javascript=false`
         : "javascript=false";
@@ -130,7 +137,7 @@ export const Link = ({ href, newTab, ...props }) => {
       url: finalUrl,
       destinationType: getLinkTarget(finalUrl),
     };
-  }, [href, originalFilePath]);
+  }, [href, originalFilePath, location.pathname, location.search]);
 
   switch (destinationType) {
     case LINK_DESTINATIONS.api:
@@ -142,9 +149,13 @@ export const Link = ({ href, newTab, ...props }) => {
             {({ onLinkClick }) => (
               <BasicLink
                 onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onLinkClick(url);
+                  // Only use the scroll router logic if the visitor hasn't
+                  // opted-out of JS. This is only expected for search crawlers.
+                  if (!url.includes("javascript=false")) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onLinkClick(url);
+                  }
                 }}
                 href={url}
                 {...props}

--- a/src/basics/Links.js
+++ b/src/basics/Links.js
@@ -119,8 +119,9 @@ export const Link = ({ href, newTab, ...props }) => {
     // If the page is being generated with a /no-js url, then we need to make
     // sure the links render with the right querystring so they load correctly
     // when clicked.
-    if (destination.pathname?.startsWith("/no-js")) {
-      destination.query = destination.query
+    if (destination.path?.startsWith("/no-js")) {
+      destination.pathname = destination.path.split("/no-js")[1];
+      destination.search = destination.search
         ? `${destination.query}&javascript=false`
         : "javascript=false";
     }

--- a/src/components/ApiReference/ReferenceSection.js
+++ b/src/components/ApiReference/ReferenceSection.js
@@ -13,15 +13,46 @@ import { Link } from "basics/Links";
 import { Route } from "components/ApiReference/Route";
 import { CustomColumn, NestedRow } from "components/ApiReference/SharedStyles";
 import { TrackedContent } from "components/SideNav";
+import { useLocation } from "@reach/router";
+import { Context as ScrollRouterContext } from "./ScrollRouter";
 
 const { h1: H1, h2: H2 } = apiReferenceComponents;
 
-const SectionEl = styled.article`
+const MainEl = styled.main`
+  display: block;
+`;
+const ArticleEl = styled.article`
   display: block;
   &:first-child {
     margin-top: 5rem;
   }
 `;
+
+const Article = ({ children, path }) => {
+  // The scroll router overrules Reach Router once the page loads, but we need
+  // Reach router's location to get initial path
+  const { pathname } = useLocation();
+  const [isActive, setIsActive] = React.useState(pathname);
+  const { subscribe } = React.useContext(ScrollRouterContext);
+
+  React.useEffect(
+    () =>
+      subscribe((newPath) => {
+        setIsActive(path === newPath);
+      }),
+    [subscribe, path],
+  );
+
+  return (
+    <MainEl name={path} hidden={!isActive}>
+      <ArticleEl>{children}</ArticleEl>
+    </MainEl>
+  );
+};
+Article.propTypes = {
+  children: PropTypes.node.isRequired,
+  path: PropTypes.string.isRequired,
+};
 
 export const ReferenceSection = React.memo(
   ({ body, relativePath, title, githubLink, path }) => {
@@ -39,7 +70,7 @@ export const ReferenceSection = React.memo(
     );
 
     return (
-      <SectionEl>
+      <Article path={path}>
         <Route originalFilePath={relativePath} path={path}>
           <TrackedContent identifier={path}>
             <NestedRow>
@@ -62,7 +93,7 @@ export const ReferenceSection = React.memo(
             <HorizontalRule />
           </TrackedContent>
         </Route>
-      </SectionEl>
+      </Article>
     );
   },
 );
@@ -71,5 +102,4 @@ ReferenceSection.propTypes = {
   relativePath: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   githubLink: PropTypes.string,
-  path: PropTypes.string.isRequired,
 };

--- a/src/components/ApiReference/ReferenceSection.js
+++ b/src/components/ApiReference/ReferenceSection.js
@@ -1,0 +1,75 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { MDXRenderer } from "gatsby-plugin-mdx";
+
+import { apiReferenceComponents } from "constants/docsComponentMapping";
+import { PALETTE } from "constants/styles";
+
+import { HorizontalRule } from "basics/Text";
+import { EditIcon } from "basics/Icons";
+import { Link } from "basics/Links";
+
+import { Route } from "components/ApiReference/Route";
+import { CustomColumn, NestedRow } from "components/ApiReference/SharedStyles";
+import { TrackedContent } from "components/SideNav";
+
+const { h1: H1, h2: H2 } = apiReferenceComponents;
+
+const SectionEl = styled.article`
+  display: block;
+  &:first-child {
+    margin-top: 5rem;
+  }
+`;
+
+export const ReferenceSection = React.memo(
+  ({ body, relativePath, title, githubLink, path }) => {
+    const splitRelativePath = relativePath.split("/");
+
+    /* Check to see if a section is a nested item */
+    const isNestedSection =
+      relativePath.split("/").length > 3 &&
+      splitRelativePath[splitRelativePath.length - 1] !== "index.mdx";
+
+    const SectionHeader = isNestedSection ? (
+      <H2 id={path}>{title}</H2>
+    ) : (
+      <H1 id={path}>{title}</H1>
+    );
+
+    return (
+      <SectionEl>
+        <Route originalFilePath={relativePath} path={path}>
+          <TrackedContent identifier={path}>
+            <NestedRow>
+              {/* Hack to make it look appear as if we had a column-gap 4rem in
+              between <CustomColumn/> on a large screen (min-width: 1440px). Skip
+              the 1st column to use it as column-gap, start at the 2nd column and
+              span through then next 8 columns (ends at column 9) */}
+              <CustomColumn xs={9} xlColumn="2 / span 8">
+                {SectionHeader}
+                {githubLink && (
+                  <Link href={githubLink} newTab>
+                    <EditIcon color={PALETTE.purpleBlue} />
+                  </Link>
+                )}
+              </CustomColumn>
+            </NestedRow>
+            <NestedRow>
+              <MDXRenderer>{body}</MDXRenderer>
+            </NestedRow>
+            <HorizontalRule />
+          </TrackedContent>
+        </Route>
+      </SectionEl>
+    );
+  },
+);
+ReferenceSection.propTypes = {
+  body: PropTypes.node.isRequired,
+  relativePath: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  githubLink: PropTypes.string,
+  path: PropTypes.string.isRequired,
+};

--- a/src/components/ApiReference/ScrollRouter.js
+++ b/src/components/ApiReference/ScrollRouter.js
@@ -60,7 +60,11 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
       // before, update the route.
       if (newActiveNode && newActiveNode !== activeNode) {
         setActiveNode(newActiveNode);
-        window.history.replaceState(null, null, routeMap.get(newActiveNode));
+        window.history.replaceState(
+          null,
+          null,
+          `${routeMap.get(newActiveNode)}${window.location.search}`,
+        );
       }
     }, 60);
 

--- a/src/components/SideNav/Provider.js
+++ b/src/components/SideNav/Provider.js
@@ -11,7 +11,13 @@ const sortByPosition = (a, b) => {
 };
 let lastScrollPosition = 0;
 
-export const SideNavProgressContext = React.createContext({});
+export const SideNavProgressContext = React.createContext({
+  activeContent: null,
+  stopTrackingElement: () => {},
+  trackElement: () => {},
+  setActiveNode: () => {},
+  setIsNavClicked: () => {},
+});
 
 export const Provider = ({ children }) => {
   const [activeContent, setActiveNode] = React.useState({ id: "", ref: null });

--- a/src/components/WrapperApiReference.js
+++ b/src/components/WrapperApiReference.js
@@ -36,7 +36,7 @@ export const WrapperApiReference = ({ children, ...props }) => {
       4rem in between <CustomColumn/> on a large screen (min-width: 1440px)
       skip the 10th column to use it as column-gap, start at the 11th column and
       span through the next 8 columns (ends at column 18) */}
-      <CustomColumn xs={4} xl={9} xlColumn="11 / span 8">
+      <CustomColumn forwardedAs="aside" xs={4} xl={9} xlColumn="11 / span 8">
         {rightColumnContent}
       </CustomColumn>
     </React.Fragment>

--- a/src/components/layout/LayoutBase.js
+++ b/src/components/layout/LayoutBase.js
@@ -35,12 +35,14 @@ const SkipToContentEl = styled(BasicLink).attrs({
 `;
 
 export const LayoutBase = ({
-  pageContext,
+  path,
   title,
   description = "",
   previewImage,
   children,
   viewport = "width=device-width, initial-scale=1",
+  omitSeoHeadersPredicate,
+  seo = {},
 }) => {
   mark(PERFORMANCE_MARKS.renderLayout);
   React.useEffect(() => {
@@ -69,7 +71,10 @@ export const LayoutBase = ({
         title={title}
         description={description}
         previewImage={previewImage}
-        path={pageContext.urlPath}
+        path={path}
+        omitPredicate={omitSeoHeadersPredicate}
+        link={seo.link}
+        meta={seo.meta}
       />
       <SkipToContentEl />
       <ContentEl>{children}</ContentEl>
@@ -83,8 +88,10 @@ LayoutBase.propTypes = {
   previewImage: PropTypes.string,
   viewport: PropTypes.string,
   description: PropTypes.node,
-  pageContext: PropTypes.shape({
-    locale: PropTypes.string.isRequired,
-    urlPath: PropTypes.string.isRequired,
-  }).isRequired,
+  path: PropTypes.string.isRequired,
+  omitSeoHeadersPredicate: PropTypes.func,
+  seo: PropTypes.shape({
+    link: PropTypes.array,
+    meta: PropTypes.array,
+  }),
 };

--- a/src/components/layout/Seo.js
+++ b/src/components/layout/Seo.js
@@ -12,7 +12,14 @@ import favicon192 from "assets/favicon/android-chrome-192x192.png";
 import favicon512 from "assets/favicon/android-chrome-512x512.png";
 import StellarDocsImage from "assets/images/og_developers.jpg";
 
-export const Seo = ({ title, description = "", path }) => {
+export const Seo = ({
+  title,
+  description = "",
+  path,
+  omitPredicate = () => true,
+  meta = [],
+  link = [],
+}) => {
   const data = useStaticQuery(graphql`
     query Metadata {
       site {
@@ -49,7 +56,9 @@ export const Seo = ({ title, description = "", path }) => {
         { name: "twitter:card", content: "summary" },
         { property: "twitter:site", content: "@StellarOrg" },
         { property: "twitter:creator", content: "@StellarOrg" },
-      ]}
+      ]
+        .filter(omitPredicate)
+        .concat(meta)}
       link={[
         { rel: "canonical", href: url },
         {
@@ -67,7 +76,9 @@ export const Seo = ({ title, description = "", path }) => {
         },
         { rel: "icon", href: favicon192, type: "image/x-icon" },
         { rel: "icon", href: favicon512, type: "image/x-icon" },
-      ]}
+      ]
+        .filter(omitPredicate)
+        .concat(link)}
     />
   );
 };
@@ -76,4 +87,7 @@ Seo.propTypes = {
   path: PropTypes.string.isRequired,
   title: PropTypes.node,
   description: PropTypes.node,
+  omitPredicate: PropTypes.func,
+  link: PropTypes.arrayOf(PropTypes.object),
+  meta: PropTypes.arrayOf(PropTypes.object),
 };

--- a/src/helpers/useSubscription.js
+++ b/src/helpers/useSubscription.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+/**
+ * useSubscription makes it easy to make a simple event emitter.
+ * @returns {object} An object with functions `subscribe` and `emit`. The
+ * `subscribe` method accepts a callback function and returns an `unsubscribe`
+ * function, and `emit` will broadcast a value to all subscribers
+ */
+export const useSubscription = () => {
+  const subscribersRef = React.useRef([]);
+  const subscribe = React.useCallback((cb) => {
+    subscribersRef.current.push(cb);
+
+    return function unsubscribe() {
+      const index = subscribersRef.current.indexOf(cb);
+      subscribersRef.current.splice(index, 1);
+    };
+  }, []);
+  const emit = React.useCallback((value) => {
+    subscribersRef.current.forEach((subscriber) => subscriber(value));
+  }, []);
+
+  return React.useMemo(() => ({ subscribe, emit }), [subscribe, emit]);
+};

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -159,6 +159,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
           description="The complete API reference for the Stellar network. Includes descriptions of Horizon endpoints, network concepts, and example code for some languages."
           pageContext={pageContext}
           viewport="width=1366, initial-scale=.1"
+          omitSeoHeadersPredicate={(header) => !header.rel === "canonical"}
         >
           <PrismStyles />
           <ApiReferenceRow>

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -100,7 +100,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
         >
           <PrismStyles />
           <ApiReferenceRow>
-            <NavColumn xs={3} lg={3} xl={4}>
+            <NavColumn forwardedAs="nav" xs={3} lg={3} xl={4}>
               <NavLogo pageName={docType.api} />
               <SideNavBackground />
               <SideNavContainer>
@@ -151,7 +151,7 @@ const ApiReference = React.memo(function ApiReference({ data, pageContext }) {
                   // to happen. This is our latest attempt at forcing SEO to
                   // properly associate the content for an /api/* URL with
                   // _exclusively_ that URL.
-                  needsSingle ? normalizeRoute(doc.path) === loadedPath : true,
+                  needsSingle ? doc.path === loadedPath : true,
                 )
                 .map(({ body, id, parent, title, githubLink, path }) => (
                   <ReferenceSection

--- a/src/templates/ApiReference.js
+++ b/src/templates/ApiReference.js
@@ -1,13 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { graphql } from "gatsby";
-import styled from "styled-components";
-import { MDXRenderer } from "gatsby-plugin-mdx";
 import { MDXProvider } from "@mdx-js/react";
 import Helmet from "react-helmet";
 import { useLocation } from "@reach/router";
 
-import { PALETTE } from "constants/styles";
 import { apiReferenceComponents } from "constants/docsComponentMapping";
 import { docType } from "constants/docType";
 
@@ -17,13 +14,11 @@ import { normalizeMdx } from "helpers/mdx";
 import { buildPathFromFile, normalizeRoute } from "helpers/routes";
 
 import { Column } from "basics/Grid";
-import { HorizontalRule } from "basics/Text";
-import { ChevronIcon, EditIcon } from "basics/Icons";
-import { Link } from "basics/Links";
+import { ChevronIcon } from "basics/Icons";
 import { PrismStyles } from "basics/Prism";
 
 import { NavItem } from "components/ApiReference/NavItem";
-import { Route } from "components/ApiReference/Route";
+import { ReferenceSection } from "components/ApiReference/ReferenceSection";
 import { ScrollRouter } from "components/ApiReference/ScrollRouter";
 import {
   ApiReferenceRow,
@@ -44,16 +39,10 @@ import {
   SideNavBackground,
   NavColumn,
 } from "components/Navigation/SharedStyles";
-import { SideNavBody, TrackedContent } from "components/SideNav";
+import { SideNavBody } from "components/SideNav";
 import { Expansion } from "components/Expansion";
 
 import DevelopersPreview from "assets/images/og_developers.jpg";
-
-const SectionEl = styled.section`
-  &:first-child {
-    margin-top: 5rem;
-  }
-`;
 
 // This is a function, not a component
 const renderItem = ({
@@ -78,59 +67,7 @@ const renderItem = ({
   );
 };
 
-const { h1: H1, h2: H2, a: StyledLink } = apiReferenceComponents;
-
-const ReferenceSection = React.memo(
-  ({ body, relativePath, title, githubLink, path }) => {
-    const splitRelativePath = relativePath.split("/");
-
-    /* Check to see if a section is a nested item */
-    const isNestedSection =
-      relativePath.split("/").length > 3 &&
-      splitRelativePath[splitRelativePath.length - 1] !== "index.mdx";
-
-    const SectionHeader = isNestedSection ? (
-      <H2 id={path}>{title}</H2>
-    ) : (
-      <H1 id={path}>{title}</H1>
-    );
-
-    return (
-      <SectionEl>
-        <Route originalFilePath={relativePath} path={path}>
-          <TrackedContent identifier={path}>
-            <NestedRow>
-              {/* Hack to make it look appear as if we had a column-gap
-              4rem in between <CustomColumn/> on a large screen (min-width: 1440px)
-              skip the 1st column to use it as column-gap, start at the 2nd column and
-              span through then next 8 columns (ends at column 9)
-              */}
-              <CustomColumn xs={9} xlColumn="2 / span 8">
-                {SectionHeader}
-                {githubLink && (
-                  <Link href={githubLink} newTab>
-                    <EditIcon color={PALETTE.purpleBlue} />
-                  </Link>
-                )}
-              </CustomColumn>
-            </NestedRow>
-            <NestedRow>
-              <MDXRenderer>{body}</MDXRenderer>
-            </NestedRow>
-            <HorizontalRule />
-          </TrackedContent>
-        </Route>
-      </SectionEl>
-    );
-  },
-);
-
-ReferenceSection.propTypes = {
-  body: PropTypes.node.isRequired,
-  relativePath: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  githubLink: PropTypes.string,
-};
+const { a: StyledLink } = apiReferenceComponents;
 
 // eslint-disable-next-line react/no-multi-comp
 const ApiReference = React.memo(function ApiReference({ data, pageContext }) {

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -12,7 +12,6 @@ import { groupByCategory } from "helpers/documentation";
 import { getDescriptionFromAst, normalizeMdx } from "helpers/mdx";
 import { buildPathFromFile, normalizeRoute } from "helpers/routes";
 
-import { H1 } from "basics/Text";
 import { Column } from "basics/Grid";
 import { ChevronIcon } from "basics/Icons";
 
@@ -42,10 +41,6 @@ import { BetaNotice } from "components/BetaNotice";
 
 import DevelopersPreview from "assets/images/og_developers.jpg";
 
-const ApiRefH1 = styled(H1)`
-  margin-top: 0.25rem;
-  margin-bottom: 0;
-`;
 const SingleApiSideNavContainerEl = styled(SideNavContainer)`
   overflow: scroll;
   height: calc(100vh - 8.75rem);

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { graphql } from "gatsby";
 import styled from "styled-components";
-import { MDXRenderer } from "gatsby-plugin-mdx";
 import { MDXProvider } from "@mdx-js/react";
 
 import { apiReferenceComponents } from "constants/docsComponentMapping";
@@ -13,16 +12,16 @@ import { groupByCategory } from "helpers/documentation";
 import { getDescriptionFromAst, normalizeMdx } from "helpers/mdx";
 import { buildPathFromFile, normalizeRoute } from "helpers/routes";
 
-import { H1, HorizontalRule } from "basics/Text";
+import { H1 } from "basics/Text";
 import { Column } from "basics/Grid";
 import { ChevronIcon } from "basics/Icons";
-import { OriginalFileContext } from "basics/Links";
 
 import { Footer } from "components/Footer";
 import { LayoutBase } from "components/layout/LayoutBase";
 import { Expansion } from "components/Expansion";
 
 import { NavItem } from "components/ApiReference/NavItem";
+import { ReferenceSection } from "components/ApiReference/ReferenceSection";
 import {
   ApiReferenceRow,
   CustomColumn,
@@ -82,7 +81,14 @@ const SingleApiReference = React.memo(function ApiReference({
   );
   const docsBySubCategory = groupByCategory(referenceDocs);
 
-  const { parent, frontmatter, body, mdxAST: mdxAst } = data.doc;
+  const {
+    parent,
+    frontmatter,
+    body,
+    mdxAST: mdxAst,
+    title,
+    githubLink,
+  } = normalizeMdx(data.doc);
   const path = buildPathFromFile(parent.relativePath);
   const description = React.useMemo(
     () => frontmatter.description || getDescriptionFromAst(mdxAst),
@@ -132,17 +138,13 @@ const SingleApiReference = React.memo(function ApiReference({
                 <BetaNotice />
               </CustomColumn>
             </NestedRow>
-            <NestedRow>
-              <CustomColumn xs={9} xlColumn="2 / span 8">
-                <ApiRefH1 id={path}>{frontmatter.title}</ApiRefH1>
-              </CustomColumn>
-            </NestedRow>
-            <NestedRow>
-              <OriginalFileContext.Provider value={parent.relativePath}>
-                <MDXRenderer>{body}</MDXRenderer>
-              </OriginalFileContext.Provider>
-            </NestedRow>
-            <HorizontalRule />
+            <ReferenceSection
+              relativePath={parent.relativePath}
+              title={title}
+              githubLink={githubLink}
+              body={body}
+              path={path}
+            />
             <NestedRow>
               <CustomColumn xs={9} xlColumn="2 / span 18">
                 <Footer />


### PR DESCRIPTION
We added "single" pages for each section of the API Reference so that crawlers know to associate them with that URL, but it assumes that crawlers won't execute javascript. Per [Google's recommendations](https://developers.google.com/search/docs/guides/dynamic-rendering#cloaking), this adds a user agent check to redirect all crawlers to the JS-less form of the page.

HOWEVER we know that some of these crawlers execute JS, and the existing page will overwrite that single page's worth of content with the entirety of the /api/* pages, so this adds a check to only client-render a single section if `javascript=false` is present in the querystring.

It also tries to encourage crawlers to find the right content by adding multiple `<main>` tags, with a `hidden` attribute if it's not referred to by the active path.