### PR TITLE
Fix mismatched JS-less render

### DIFF
--- a/src/components/ApiReference/ReferenceSection.js
+++ b/src/components/ApiReference/ReferenceSection.js
@@ -21,12 +21,7 @@ const { h1: H1, h2: H2 } = apiReferenceComponents;
 const MainEl = styled.main`
   display: block;
 `;
-const ArticleEl = styled.article`
-  display: block;
-  &:first-child {
-    margin-top: 5rem;
-  }
-`;
+const ArticleEl = styled.article``;
 
 const Article = ({ children, path }) => {
   // The scroll router overrules Reach Router once the page loads, but we need

--- a/src/components/BetaNotice.js
+++ b/src/components/BetaNotice.js
@@ -14,9 +14,6 @@ const BetaNoticeEl = styled(Text)`
     display: none;
   }
 `;
-const HrEl = styled(HorizontalRule)`
-  margin-bottom: 0;
-`;
 const LinkEl = styled(Link)`
   color: ${PALETTE.purpleBlue};
 `;
@@ -30,6 +27,6 @@ export const BetaNotice = () => (
       </LinkEl>
       .
     </BetaNoticeEl>
-    <HrEl />
+    <HorizontalRule />
   </>
 );

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -70,6 +70,7 @@ const { a: StyledLink } = apiReferenceComponents;
 const SingleApiReference = React.memo(function ApiReference({
   data,
   pageContext,
+  isClientRendered = false,
 }) {
   const referenceDocs = sortReference(
     data.referenceDocs.edges.map(({ node }) => normalizeMdx(node)),
@@ -85,10 +86,15 @@ const SingleApiReference = React.memo(function ApiReference({
     githubLink,
   } = normalizeMdx(data.doc);
   const path = buildPathFromFile(parent.relativePath);
-  const description = React.useMemo(
-    () => frontmatter.description || getDescriptionFromAst(mdxAst),
-    [mdxAst, frontmatter.description],
-  );
+  const description = React.useMemo(() => {
+    // If the page is loaded as `/api/…?javascript=false`, then we won't have the
+    // MDX AST from which to pull a description, but we also don't need it -- the
+    // description is only for metadata.
+    if (isClientRendered) {
+      return "";
+    }
+    return frontmatter.description || getDescriptionFromAst(mdxAst);
+  }, [mdxAst, frontmatter.description, isClientRendered]);
 
   return (
     <MDXProvider components={apiReferenceComponents}>


### PR DESCRIPTION
Single API reference pages (loaded with `?javscript=false` were visually broken due to a server/client mismatch. This corrects that to ensure the content is identical, but I wish Gatsby would just trash the HTML in the event of a mismatch!