### PR TITLE
Add 301 redirect on /no-js pages

### DIFF
--- a/nginx/includes/server.conf
+++ b/nginx/includes/server.conf
@@ -4,7 +4,14 @@ root /usr/share/nginx/html/new-docs/;
 location = / {
   proxy_pass https://proxy.stellar.org/developers;
   proxy_ssl_server_name on;
+}
 
+location ~ ^/no-js/(.*)$ {
+  # `$scheme://$http_host` is because otherwise, it adds the port nginx is
+  # listening on. Since we listen on 80 but expose 8000 by default from docker
+  # locally, the redirect was going to `localhost/…` which doesn't have a
+  # server listening.
+  return 301 $scheme://$http_host/$1;
 }
 
 location / {

--- a/src/constants/docsComponentMapping.js
+++ b/src/constants/docsComponentMapping.js
@@ -179,12 +179,8 @@ const OrangeTableCell = styled.td`
 export const apiReferenceComponents = {
   ...components,
   wrapper: WrapperApiReference,
-  h1: styled(components.h1).attrs(() => ({
-    as: makeLinkedHeader(ApiRefH1, headerOptions),
-  }))``,
-  h2: styled(components.h2).attrs(() => ({
-    as: makeLinkedHeader(ApiRefH2, headerOptions),
-  }))``,
+  h1: makeLinkedHeader(ApiRefH1, headerOptions),
+  h2: makeLinkedHeader(ApiRefH2, headerOptions),
   h3: TextComponents.H3,
   h4: TextComponents.H4,
   h5: TextComponents.H5,

--- a/src/templates/SingleApiReference.js
+++ b/src/templates/SingleApiReference.js
@@ -102,6 +102,7 @@ const SingleApiReference = React.memo(function ApiReference({
         previewImage={DevelopersPreview}
         description={description}
         pageContext={pageContext}
+        path={path}
       >
         <ApiReferenceRow>
           <NavColumn xs={3} lg={3} xl={4}>


### PR DESCRIPTION
Final (🤞) SEO adjustment tweak. Search results are starting to point to the right material, but some of the results include the `/no-js` segment, which is intended to be invisible. The 301 should help direct to the right place.