### PR TITLE
Fix redundant scroll, weird header margin on /docs/*

### DIFF
--- a/src/basics/Text.js
+++ b/src/basics/Text.js
@@ -54,7 +54,6 @@ export const H1 = styled.h1`
   display: inline-block;
   font-size: 2rem;
   margin-bottom: 0.5rem;
-  margin-top: 5.25rem;
   line-height: 1.25;
   letter-spacing: normal;
 `;

--- a/src/components/ApiReference/ScrollRouter.js
+++ b/src/components/ApiReference/ScrollRouter.js
@@ -27,7 +27,6 @@ const elementMap = new Map();
 
 export const ScrollRouter = ({ children, initialActive = "" }) => {
   const { subscribe, emit } = useSubscription();
-  const initialLoadCheck = React.useRef(false);
   const [activeNode, setActiveNode] = React.useState({
     ref: null,
     id: initialActive,
@@ -84,23 +83,12 @@ export const ScrollRouter = ({ children, initialActive = "" }) => {
   }, [activeNode, isNavClicked, emit]);
 
   // Tracked sections
-  const trackElement = React.useCallback(
-    (ref, route) => {
-      routeMap.set(ref, route);
-      elementMap.set(route, ref);
-      trackedElementsRef.current.push(ref);
-      trackedElementsRef.current.sort(sortByPosition);
-
-      // We want to scroll to the element associated with the route _once_.
-      if (!initialLoadCheck.current && window.location.pathname === route) {
-        emit(route);
-        initialLoadCheck.current = true;
-        // Our navbar is 90px tall
-        smoothScrollTo(ref.current, { duration: 0 });
-      }
-    },
-    [emit],
-  );
+  const trackElement = React.useCallback((ref, route) => {
+    routeMap.set(ref, route);
+    elementMap.set(route, ref);
+    trackedElementsRef.current.push(ref);
+    trackedElementsRef.current.sort(sortByPosition);
+  }, []);
   const stopTrackingElement = React.useCallback((ref) => {
     const route = routeMap.get(ref);
     routeMap.delete(ref);


### PR DESCRIPTION
Scrolling to the right section is handled [when the page initially loads](https://github.com/stellar/new-docs/blob/daa27caedecb0da30b9b4e0b4b17d3243ad1d962/src/html.js#L27-L32), this logic is redundant and causes content to scroll twice, which is a little disruptive. The downside of removing this is that it won't scroll when the page is loaded in dev mode (`yarn start`) because Gatsby doesn't serve any HTML in that case.

Headers before/after:
![Screen Shot 2020-07-14 at 2 20 01 PM](https://user-images.githubusercontent.com/1551487/87462013-45571280-c5dd-11ea-81be-e5529ee34f04.png)
![Screen Shot 2020-07-14 at 2 20 05 PM](https://user-images.githubusercontent.com/1551487/87462016-45efa900-c5dd-11ea-898f-58db5109c0f5.png)

Loading scroll before/after:
Before: https://gfycat.com/shrillregularaardvark
After: https://gfycat.com/energeticverifiableewe