### PR TITLE
Fix redirect loop for crawlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,3 +580,9 @@ and return timing information—an object with a `duration` and
 `hasHighPrecision`. Some browsers don't expose the high-precision APIs, and we
 definitely want to know if they're used (especially if not usable). Make sure to
 use a `constants/performanceMarks` constant, not just a raw string.
+
+### Testing requests as a crawler
+
+Chrome allows you to
+[override the user agent](https://developers.google.com/web/tools/chrome-devtools/device-mode/override-user-agent)
+with DevTools, which enables us to test how Google will see pages.

--- a/nginx/includes/server.conf
+++ b/nginx/includes/server.conf
@@ -6,31 +6,36 @@ location = / {
   proxy_ssl_server_name on;
 }
 
-location ~ ^/no-js/(.*)$ {
-  # `$scheme://$http_host` is because otherwise, it adds the port nginx is
-  # listening on. Since we listen on 80 but expose 8000 by default from docker
-  # locally, the redirect was going to `localhost/…` which doesn't have a
-  # server listening.
-  return 301 $scheme://$http_host/$1;
-}
-
 location / {
   try_files /public/$uri /public/$uri/index.html /static/$uri =404;
 }
 
-# SEO optimization for API Reference. This lets crawlers only see the content
-# from each individual section.
-set $no-js false;
-# UA check sourced from https://gist.github.com/thoop/8165802
-if ($http_user_agent ~* "googlebot|bingbot|yandex|baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp") {
-  set $no-js true;
-}
-if ($arg_javascript = 'false') {
-  set $no-js true;
-}
-if ($no-js = false) {
-  rewrite ^/api/.*$ /api/;
-}
-if ($no-js = true) {
-  rewrite ^/api/(.*) /no-js/api/$1;
+# .+ (vs .*) is important to avoid a redirect loop when rewriting all
+# non-crawler requests to `/api/`
+location ~* ^/api/(?<path>.+)$ {
+  set $noJs false;
+  set $needsCrawlerRedirect '';
+
+  if ($arg_javascript = 'false') {
+    set $noJs true;
+  }
+  if ($noJs = true) {
+    rewrite ^/api/(.*) /no-js/api/$1;
+  }
+  if ($noJs = false) {
+    rewrite ^/api/.*$ /api/;
+  }
+  # SEO optimization for API Reference. This lets crawlers only see the content
+  # from each individual section.
+  # UA check sourced from https://gist.github.com/thoop/8165802
+  if ($http_user_agent ~* "googlebot|bingbot|yandex|baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp") {
+    # Goofy variable value because nginx doesn't allow for checking multiple
+    # conditions in an `if` block.
+    set $needsCrawlerRedirect 'true $noJs';
+  }
+  # To avoid a redirect loop, we only redirect if it's not already on the no-js
+  # request path.
+  if ($needsCrawlerRedirect = 'true false') {
+    return 302 $scheme://$http_host/api/$path?javascript=false;
+  }
 }


### PR DESCRIPTION
Unfortunately this leaves /no-JS pages accessible by directly navigating to them, which isn't what we want. I can't manage to get nginx to do a rewrite for crawlers and a redirect for visitor, though, it always ends in either a 404 (because it stopped looking for fields after the rewrite) or a redirect loop.

I've been flying a little blind so far, but dev tools let's you change the user agent to simulate crawler requests, so I'm more confident that this is going to be what we need. 