### PR TITLE
bugfix/codeexample > Added missing component <CodeExample/> in content and styling adjustment

### DIFF
--- a/content/docs/glossary/lumen-supply.mdx
+++ b/content/docs/glossary/lumen-supply.mdx
@@ -11,6 +11,8 @@ import { CodeExample } from "components/CodeExample";
 
 As of December 12, 2019, the Dashboard API shows:
 
+<CodeExample>
+
 ```json
 {
   "updatedAt": "2019-12-12T21:07:23.480Z",
@@ -25,6 +27,8 @@ As of December 12, 2019, the Dashboard API shows:
   "_details": "https://www.stellar.org/developers/guides/lumen-supply-metrics.html"
 }
 ```
+
+</CodeExample>
 
 ## Definitions
 

--- a/content/docs/glossary/multisig.mdx
+++ b/content/docs/glossary/multisig.mdx
@@ -93,6 +93,8 @@ Multisig allows you to do all of this without exposing the master key of your an
 
 Your account setup:
 
+<CodeExample>
+
 ```
   Master Key Weight: 2
   Additional Signing Key Weight: 1
@@ -101,11 +103,15 @@ Your account setup:
   High Threshold: 2
 ```
 
+</CodeExample>
+
 ### Example 2: Joint Accounts
 
 > You want to set up a joint account with Bilal and Carina such that any of you can authorize a payment. You also want to set up the account so that, if you choose to change signers (e.g., remove or add someone), a high-threshold operation, all 3 of you must agree. You add Bilal and Carina as signers to the joint account. You also ensure that it takes all of your key weights to clear the high threshold but only one to clear the medium threshold.
 
 Joint account setup:
+
+<CodeExample>
 
 ```
   Master Key Weight: 1
@@ -116,11 +122,15 @@ Joint account setup:
   Carina's Signing Key Weight: 1
 ```
 
+</CodeExample>
+
 ### Example 3: Expense Accounts
 
 > You fully control an expense account, but you want your two coworkers Diyuan and Emil to be able to authorize transactions from this account. You add Diyuan and Emil's signing keys to the expense account. If either Diyuan or Emil leave the company, you can remove their signing key, a high-threshold operation.
 
 Expense account setup:
+
+<CodeExample>
 
 ```
   Master Key Weight: 3
@@ -130,6 +140,8 @@ Expense account setup:
   Diyuan's Key Weight: 1
   Emil's Key Weight: 1
 ```
+
+</CodeExample>
 
 <Alert>
 
@@ -142,6 +154,8 @@ The next two examples involve setting the master key weight of an account to 0. 
 > Your company wants to set up an account that requires 3 of 6 employees to agree to _any_ transaction from that account.
 
 Company account setup:
+
+<CodeExample>
 
 ```
   Master Key Weight: 0 (Turned off so this account can't do anything without an employee)
@@ -156,11 +170,15 @@ Company account setup:
   Employee 6 Key Weight: 1
 ```
 
+</CodeExample>
+
 ### Example 5: Custom Currencies
 
 > You want to issue a custom currency and ensure that no more will ever be created. You make a source account and issue the maximum amount of currency to a holding account. Then you set the master weight of the source account to below the medium threshold--the source account can no longer issue currency.
 
 Source account setup:
+
+<CodeExample>
 
 ```
   Master Key Weight: 0
@@ -168,5 +186,7 @@ Source account setup:
   Medium Threshold: 0
   High Threshold: 0
 ```
+
+</CodeExample>
 
 Note that even though the thresholds are 0 here, the master key cannot successfully sign a transaction because its own weight is 0.

--- a/content/docs/glossary/payment-channels.mdx
+++ b/content/docs/glossary/payment-channels.mdx
@@ -3,6 +3,8 @@ title: Channels
 order:
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 Payment channels provide a method for submitting transactions to the network at a high rate.
 
 If you are submitting [transactions](./transactions.mdx) to the network at a high rate or from different processes you must be careful that the transactions are submitted in the correct order of their sequence numbers. This can be problematic since typically you are submitting through Horizon and there is no guarantee that a given transaction is received by [Stellar Core](https://github.com/stellar/stellar-core) until ledger close. This means that they can reach stellar-core out of order and will bounce with a bad sequence error. If you do wait for ledger close to avoid this issue that will greatly reduce the rate you can submit transactions to the network.
@@ -16,6 +18,8 @@ Channels take advantage of the fact that the "source" account of a transaction c
 You will, of course, have to sign the transaction with both the base account key and the channel account key.
 
 For example:
+
+<CodeExample>
 
 ```js
 StellarSdk.Network.useTestNetwork();
@@ -42,3 +46,5 @@ var transaction = new StellarSdk.TransactionBuilder(
 transaction.sign(baseAccountKey); // base account must sign to approve the payment
 transaction.sign(channelKeys[channelIndex]); // channel must sign to approve it being the source of the transaction
 ```
+
+</CodeExample>

--- a/content/docs/tutorials/exchange.mdx
+++ b/content/docs/tutorials/exchange.mdx
@@ -27,10 +27,14 @@ The two main integration points to Stellar for an exchange are:<br/>
 
 It's recommended, though not strictly necessary, to run your own instances of Stellar Core and Horizon - [this doc](../run-core-node/index.mdx#types-of-nodes) explains the types of node you can run, and the advantages to running each. If you choose not to, it's possible to use the Stellar.org public-facing Horizon servers. Our test and live networks are listed below:
 
+<CodeExample>
+
 ```
-  test net: {hostname:'horizon-testnet.stellar.org', secure:true, port:443};
-  live: {hostname:'horizon.stellar.org', secure:true, port:443};
+test net: {hostname:'horizon-testnet.stellar.org', secure:true, port:443};
+live: {hostname:'horizon.stellar.org', secure:true, port:443};
 ```
+
+</CodeExample>
 
 ### Issuing account
 
@@ -47,16 +51,22 @@ A base account contains a more limited amount of funds than an issuing account. 
 - Need to add a row to your users table that creates a unique `customerID` for each user.
 - Need to populate the customerID row.
 
+<CodeExample>
+
 ```
 CREATE TABLE StellarTransactions (UserID INT, Destination varchar(56), XLMAmount INT, state varchar(8));
 CREATE TABLE StellarCursor (id INT, cursor varchar(50)); // id - AUTO_INCREMENT field
 ```
+
+</CodeExample>
 
 Possible values for `StellarTransactions.state` are "pending", "done", "error".
 
 ### Code
 
 Use this code framework to integrate Stellar into your exchange. For this guide, we use placeholder functions for reading/writing to the exchange database. Each database library connects differently, so we abstract away those details. The following sections describe each step:
+
+<CodeExample>
 
 ```js
 // Config your server
@@ -98,11 +108,15 @@ server.loadAccount(config.baseAccount).then(function (account) {
 });
 ```
 
+</CodeExample>
+
 ## Listening for deposits
 
 When a user wants to deposit lumens in your exchange, instruct them to send XLM to your base account address with the customerID in the memo field of the transaction.
 
 You must listen for payments to the base account and credit any user that sends XLM there. Here's code that listens for these payments:
+
+<CodeExample>
 
 ```js
 // Start listening for payments from where you last stopped
@@ -119,6 +133,8 @@ if (lastToken) {
 callBuilder.stream({ onmessage: handlePaymentResponse });
 ```
 
+</CodeExample>
+
 For every payment received by the base account, you must:<br/>
 
 - check the memo field to determine which user sent the deposit.<br/>
@@ -126,6 +142,8 @@ For every payment received by the base account, you must:<br/>
 - credit the user's account in the DB with the number of XLM they sent to deposit.
 
 So, you pass this function as the `onmessage` option when you stream payments:
+
+<CodeExample>
 
 ```js
 function handlePaymentResponse(record) {
@@ -168,11 +186,15 @@ function handlePaymentResponse(record) {
 }
 ```
 
+</CodeExample>
+
 ## Submitting withdrawals
 
 When a user requests a lumen withdrawal from your exchange, you must generate a Stellar transaction to send them XLM. See [building transactions](https://github.com/stellar/js-stellar-base/blob/master/docs/reference/building-transactions.md) for more information.
 
 The function `handleRequestWithdrawal` will queue up a transaction in the exchange's `StellarTransactions` table whenever a withdrawal is requested.
+
+<CodeExample>
 
 ```js
 function handleRequestWithdrawal(userID, amountLumens, destinationAddress) {
@@ -197,7 +219,11 @@ function handleRequestWithdrawal(userID, amountLumens, destinationAddress) {
 }
 ```
 
+</CodeExample>
+
 Then, you should run `submitPendingTransactions`, which will check `StellarTransactions` for pending transactions and submit them.
+
+<CodeExample>
 
 ```js
 StellarSdk.Network.useTestNetwork();
@@ -284,6 +310,8 @@ function submitPendingTransactions(exchangeAccount) {
 }
 ```
 
+</CodeExample>
+
 ## Going further...
 
 ### Federation
@@ -304,6 +332,8 @@ If you'd like to accept other non-lumen tokens follow these instructions.
 
 First, open a [trustline](../issuing-assets/anatomy-of-an-asset.mdx#trustlines) with the issuing account of the token you'd like to list — without this you cannot begin to accept the token.
 
+<CodeExample>
+
 ```js
 var someAsset = new StellarSdk.Asset("ASSET_CODE", issuingKeys.publicKey());
 
@@ -314,6 +344,8 @@ transaction.addOperation(
 );
 ```
 
+</CodeExample>
+
 If the token issuer has `authorization_required` set to true, you will need to wait for the trustline to be authorized before you can begin accepting this token. Read more about [trustline authorization here](../issuing-assets/control-asset-access.mdx).
 
 Then, make a few changes to the example code above:
@@ -323,6 +355,8 @@ Then, make a few changes to the example code above:
 _Note_: the user cannot send us tokens whose issuing account we have not explicitly opened a trustline with.
 
 - In the `withdraw` function, when we add an operation to the transaction, we must specify the details of the token we are sending. For example:
+
+<CodeExample>
 
 ```js
 var someAsset = new StellarSdk.Asset("ASSET_CODE", issuingKeys.publicKey());
@@ -335,6 +369,8 @@ transaction.addOperation(
   }),
 );
 ```
+
+</CodeExample>
 
 - In the `withdraw` function your customer must have opened a trustline with the issuing account of the token they are withdrawing. So you must take the following into consideration: _ Confirm the user receiving the token has a trustline _ Parse the [Horizon error](../start/list-of-operations.mdx#payment) that will occur after sending a token to an account without a trustline
 

--- a/src/constants/docsComponentMapping.js
+++ b/src/constants/docsComponentMapping.js
@@ -100,7 +100,9 @@ const components = {
   ol: TextComponents.OrderedList,
   li: ListItem,
   section: TextComponents.Section,
-  table: TextComponents.Table,
+  table: styled(TextComponents.Table)`
+    margin: 1rem 0;
+  `,
   thead: TextComponents.TableHead,
   th: TextComponents.TableHeadCell,
   tbody: TextComponents.TableBody,

--- a/src/templates/Documentation.js
+++ b/src/templates/Documentation.js
@@ -76,7 +76,6 @@ const OutlineTitleEl = styled.div`
   font-weight: ${FONT_WEIGHT.bold};
   padding: 0.75rem 0;
 `;
-
 const NextUpEl = styled.div`
   font-weight: ${FONT_WEIGHT.bold};
   font-size: 0.875rem;
@@ -84,8 +83,11 @@ const NextUpEl = styled.div`
   border-radius: 2px;
   background-color: rgba(62, 27, 219, 0.04);
   padding: 1em;
-`;
 
+  a {
+    color: ${PALETTE.purpleBlue};
+  }
+`;
 const ModifiedEl = styled.div`
   color: ${THEME.lightGrey};
   font-size: 0.875rem;


### PR DESCRIPTION
Added missing component `<CodeExample/>` for content on `/docs`

Styling Adjustment for `Table` and `NextUpEl`'s link

**Before:**
Link Color:
<img width="263" alt="color-before" src="https://user-images.githubusercontent.com/3912060/87797183-58a1f200-c818-11ea-9404-8cbcf374c8d9.png">

Table:
<img width="317" alt="table-before" src="https://user-images.githubusercontent.com/3912060/87797184-58a1f200-c818-11ea-9495-d62c1b9fc815.png">

**After:**
Link Color:
<img width="308" alt="color-after" src="https://user-images.githubusercontent.com/3912060/87797180-58095b80-c818-11ea-8924-70e8496f014c.png">

Table:
<img width="271" alt="table-after" src="https://user-images.githubusercontent.com/3912060/87797182-58095b80-c818-11ea-88df-ba16ea6ca8ff.png">