### PR TITLE
Add last modified time to sitemap

### DIFF
--- a/buildHelpers/createDocsPages.js
+++ b/buildHelpers/createDocsPages.js
@@ -45,6 +45,7 @@ const createDocsPages = ({ actions, docs }) => {
         urlPath: docPath,
         locale: defaultLocale,
         name: doc.name,
+        lastModified: doc.modifiedTime,
         relativeDirectory: doc.relativeDirectory,
         rootDir: DOCS_ROOT,
         // None of these have translations set up. If we translate them in
@@ -79,6 +80,7 @@ const createDocsPages = ({ actions, docs }) => {
         urlPath: refPath,
         docId: ref.childMdx.id,
         ids: apiRefDocIds,
+        lastModified: ref.modifiedTime,
         locale: defaultLocale,
       },
     });
@@ -95,6 +97,7 @@ const queryFragment = `
         childMdx {
           id
         }
+        modifiedTime(formatString: "YYYY-MM-DD")
         name
         relativePath
         relativeDirectory

--- a/buildHelpers/serializeSitemap.js
+++ b/buildHelpers/serializeSitemap.js
@@ -74,6 +74,7 @@ const serializeLocale = (locale) => {
         // so highlighting them in the sitemap isn't what we want.
         url:
           site.siteMetadata.siteUrl + main.originalPath.replace("no-js/", ""),
+        lastmod: main.context.lastModified,
         links: alternates.map((a) => ({
           lang: a.locale,
           url: site.siteMetadata.siteUrl + a.originalPath,
@@ -94,6 +95,9 @@ const query = `
     edges {
       node {
         path
+        context {
+          lastModified
+        }
       }
     }
   }


### PR DESCRIPTION
Google doesn't appear to be re-crawling pages automatically when I resubmit the sitemap, and it looks to be because the `lastmod` time hasn't changed.