### PR TITLE
Minor typo fixes.

### DIFF
--- a/content/docs/building-apps/basic-wallet.mdx
+++ b/content/docs/building-apps/basic-wallet.mdx
@@ -552,7 +552,7 @@ export function handleError(err: any) {
 
 </CodeExample>
 
-Nothing fancy, just a clean little error handler we’!ll make use of later when processing API requests.
+Nothing fancy, just a clean little error handler we’ll make use of later when processing API requests.
 
 ## Set Up Key Storage
 

--- a/content/docs/enabling-deposit-and-withdrawal/setting-up-test-server.mdx
+++ b/content/docs/enabling-deposit-and-withdrawal/setting-up-test-server.mdx
@@ -16,7 +16,7 @@ Note: the testnet is reset every three months, so when building on it, make sure
 
 At the end of this section, you should have a sandboxed system capable of interfacing with the Stellar testnet that you can easily convert into a production-ready deployment on the main Stellar network. You should always keep a testnet deployment up and running — even once you have a production version — so that wallets can test your implementation without the risk of losing real user funds.
 
-You can also find an outline of the basic steps issuers need to complete in the [intro to SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#basic-anchor-implementation), the interactive deposit and and withdrawal specification.
+You can also find an outline of the basic steps issuers need to complete in the [intro to SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#basic-anchor-implementation), the interactive deposit and withdrawal specification.
 
 ## Prerequisites
 
@@ -87,7 +87,7 @@ To provide a simpler experience for wallet users, anchors (aka on/off ramps) can
 
 Stellar Web Authentication is a protocol for verifying that a user controls a Stellar private key for a given account, and for creating a persistent session for that user. It relies on a variation of mutual challenge-response, and uses Stellar transactions to encode challenges and responses: an asset issuer provides a 'challenge' transaction; the client signs it on behalf of the user and returns it to the issuer; the issuer checks that the signature is valid, and if it is, issues a JWT.
 
-The JWT then acts as a re-usable key for a client to perform an action on behalf of a user. It can contain an arbitrary amount of information, and is signed by the provider — in this case the asset issuer — to ensure validity. You can read the full spec [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md).
+The JWT then acts as a reusable key for a client to perform an action on behalf of a user. It can contain an arbitrary amount of information, and is signed by the provider — in this case the asset issuer — to ensure validity. You can read the full spec [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md).
 
 ### Requesting a Challenge
 
@@ -191,7 +191,7 @@ The `/transaction` endpoint should return a single JSON object representing the 
 
 ## Withdrawal Flow
 
-The withdrawal flow is the off-ramp from the Stellar Network. In it, a user makes a payment on the Stellar network to return digital assets to an anchor, and receives the equivalent value as fiat currency from the anchor in their bank account in return. This section will go through all the steps necessary to implement a working withdrawal functionality
+The withdrawal flow is the off-ramp from the Stellar Network. In it, a user makes a payment on the Stellar network to return digital assets to an anchor, and receives the equivalent value as fiat currency from the anchor in their bank account in return. This section will go through all the steps necessary to implement working withdrawal functionality.
 
 Like deposit flows, withdraw flows involve a back-and-forth between an anchor’s server and a wallet’s client that starts with the wallet polling the `/info` endpoint and setting up an authenticated user session as described in the previous sections. The general sequence of deposit events looks like this:
 

--- a/content/docs/start/introduction.mdx
+++ b/content/docs/start/introduction.mdx
@@ -33,7 +33,7 @@ If you are new, you may want to start with the early [Tutorials](../tutorials/cr
 
 
 ## Developer Channels
-Stellar has an active developer community, and it's often helpful to interact with other devs who are working on Stellar-based projects. They're great at answering questions, giving feedback, and sharing information about the best ways to use the network.  For general information on our community channels, check out the stellar.org [Community Page](https://www.stellar.org/community)
+Stellar has an active developer community, and it's often helpful to interact with other devs who are working on Stellar-based projects. They're great at answering questions, giving feedback, and sharing information about the best ways to use the network.  For general information on our community channels, check out the stellar.org [Community Page](https://www.stellar.org/community).
 
 There are also several channels dedicated to developers, and it's a good idea to join them to keep abreast of important plans, developments, and events:
 

--- a/content/docs/tutorials/create-account.mdx
+++ b/content/docs/tutorials/create-account.mdx
@@ -11,7 +11,7 @@ _Before we get started with working with Stellar in code, consider going through
 
 ## Create a Keypair
 
-Stellar uses public key cryptography to ensure that every transaction is secure: every Stellar account has a keypair consisting of a **public key** and a **secret secret key**. The public key is always safe to share — other people need it to identify your account and verify that you authorized a transaction. It's like an email address. The secret key, however, is private information that proves you own — and gives you access to — your account. It's like a password, and you should never share it with anyone.
+Stellar uses public key cryptography to ensure that every transaction is secure: every Stellar account has a keypair consisting of a **public key** and a **secret key**. The public key is always safe to share — other people need it to identify your account and verify that you authorized a transaction. It's like an email address. The secret key, however, is private information that proves you own — and gives you access to — your account. It's like a password, and you should never share it with anyone.
 
 Before creating an account, you need to generate your own keypair:
 
@@ -170,7 +170,7 @@ else:
 
 </CodeExample>
 
-Now for the last step: Getting the account’s details and checking its balance. Accounts can carry multiple balances — one for each type of currency they hold.
+Now for the last step: getting the account’s details and checking its balance. Accounts can carry multiple balances — one for each type of currency they hold.
 
 <CodeExample>
 
@@ -237,4 +237,4 @@ for balance in account['balances']:
 
 </CodeExample>
 
-Now that you’ve got an account, you can [start sending and receiving payments](send-and-receive-payments.mdx), or, if you're ready to hunker down, you can skip ahead and [build an wallet](../building-apps/index.mdx) or [issue a Stellar-network asset](../issuing-assets/index.mdx).
+Now that you’ve got an account, you can [start sending and receiving payments](send-and-receive-payments.mdx), or, if you're ready to hunker down, you can skip ahead and [build a wallet](../building-apps/index.mdx) or [issue a Stellar-network asset](../issuing-assets/index.mdx).

--- a/content/docs/tutorials/follow-received-payments.mdx
+++ b/content/docs/tutorials/follow-received-payments.mdx
@@ -5,13 +5,13 @@ order: 30
 
 import { CodeExample } from "components/CodeExample";
 
-This tutorial shows how easy it is to use Horizon to watch for incoming payments on an [account](../glossary/accounts.mdx) using JavaScript and `EventSource`. We will eschew using [`js-stellar-sdk`](https://github.com/stellar/js-stellar-sdk), the high-level helper library, to show that it is possible for you to perform this task on your own, with whatever programming language you would like to use.
+This tutorial shows how easy it is to use Horizon to watch for incoming payments on an [account](../glossary/accounts.mdx) using JavaScript and `EventSource`. We will eschew using [`js-stellar-sdk`](https://github.com/stellar/js-stellar-sdk), the high-level helper library, to show that it is possible for you to perform this task on your own with whatever programming language you would like to use.
 
 This tutorial assumes that you:
 
 - Have node.js installed locally on your machine.
 - Have curl installed locally on your machine.
-- Are running on Linux, OS X, or any other system that has access to a bash-like shell.
+- Are running on Linux, macOS, or any other system that has access to a bash-like shell.
 - Are familiar with launching and running commands in a terminal.
 
 In this tutorial we will learn:
@@ -45,7 +45,7 @@ $ node -e "require('stellar-base')"
 
 </CodeExample>
 
-Everything was successful if no output it generated from the above command. Now let's write a script to create a new account.
+Everything was successful if no output was generated from the above command. Now let's write a script to create a new account.
 
 ## Creating an account
 
@@ -111,7 +111,7 @@ After a few seconds, the Stellar network will perform consensus, close the ledge
 
 ## Following payments using `curl`
 
-To follow new payments connected to your account you simply need to send `Accept: text/event-stream` header to the [/payments](../.././api/resources/operations/object/payment.mdx) endpoint.
+To follow new payments connected to your account you simply need to send the `Accept: text/event-stream` header to the [/payments](../.././api/resources/operations/object/payment.mdx) endpoint.
 
 <CodeExample>
 
@@ -215,9 +215,9 @@ $ curl "https://horizon-testnet.stellar.org/accounts/GB7JFK56QXQ4DVJRNPDBXABNG3I
 
 </CodeExample>
 
-Sequence number can be found under the `sequence` field. The current sequence number is `713226564141056`. Save this value somewhere.
+Sequence number can be found under the `sequence` field. For our example, the current sequence number is `713226564141056`. Save your value somewhere.
 
-Now, create `make_payment.js` file and paste the following code into it:
+Now, create `make_payment.js` file and paste the following code into it, replacing the sequence number accordingly:
 
 <CodeExample>
 


### PR DESCRIPTION
As I went through the docs I found & fixed some minor typos:
  - [Basic Wallet] fix `we'!ll` to `we'll`
  - [Introduction] add period at end of paragraph
  - [Create Account] `secret secret key` to just `secret key` (felt like a typo, but might be intentional??)
  - [Create Account] `step: Getting` to just `getting` (not a complete sentence after `:`, so no capital)
  - [Create Account] `an wallet` to `a wallet`