### PR TITLE
Update Create Account's balance retrieval example Go code

### DIFF
--- a/content/docs/tutorials/create-account.mdx
+++ b/content/docs/tutorials/create-account.mdx
@@ -205,19 +205,22 @@ for (AccountResponse.Balance balance : account.getBalances()) {
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/stellar/go/clients/horizonclient"
 )
 
 func main() {
-	account, err := horizon.DefaultTestNetClient.LoadAccount(pair.Address())
+	// Replace this with the output from earlier, or use pair.Address()
+	address := "GCFXHS4GXL6BVUCXBWXGTITROWLVYXQKQLF4YH5O5JT3YZXCYPAFBJZB"
+
+	request := horizonclient.AccountRequest{AccountID: address}
+	account, err := horizonclient.DefaultTestNetClient.AccountDetail(request)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println("Balances for account:", pair.Address())
+	log.Println("Balances for account:", address)
 
 	for _, balance := range account.Balances {
 		log.Println(balance)


### PR DESCRIPTION
The Go code in the example on the [Create Account](https://developers.stellar.org/docs/tutorials/create-account/) page in which you retrieve an account's balances seems outdated.

There are a number of oddities about the snippet: `pair` is undefined, so `pair.Address()` wouldn't work anyway. Furthermore, the clients do not have a `LoadAccount(...)` method defined at all. Instead, it seems like you first need to prepare a request and then submit it (see demo.go in stellar/go, [here](https://github.com/stellar/go/blob/master/txnbuild/cmd/demo/operations/demo.go#L437)).

I also replaced the one `fmt` with `log` for consistency.