### PR TITLE
Fix API reference sections vanishing

### DIFF
--- a/src/basics/GlobalStyles.js
+++ b/src/basics/GlobalStyles.js
@@ -39,6 +39,9 @@ const Styles = createGlobalStyle`
   twitter-widget {
     margin: auto;
   }
+  [hidden] {
+    display: block !important;
+  }
   ${expansionStyles}
 `;
 

--- a/src/helpers/dom.js
+++ b/src/helpers/dom.js
@@ -1,16 +1,16 @@
-import { TweenLite } from "gsap";
+import gsap from "gsap";
 import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 
 // We have to include this so that Webpack doesn't tree-shake the plugin out of
 // the production bundle.
-// eslint-disable-next-line
-const scrollPlugin = ScrollToPlugin;
+gsap.registerPlugin(ScrollToPlugin);
 
 export const smoothScrollTo = (node, options = {}, onCompleteFn) => {
   const offset = 0;
   const { duration = 0.55 } = options;
 
-  TweenLite.to(window, duration, {
+  gsap.to(window, {
+    duration,
     scrollTo: {
       y: node.offsetTop + offset,
     },


### PR DESCRIPTION
When updating our deps, we seem to have gotten a new style tagging along, one that broke API reference rendering