### PR TITLE
Fix mis-rendered link on Timeout Errors page.

### DIFF
--- a/content/api/errors/http-status-codes/horizon-specific/timeout.mdx
+++ b/content/api/errors/http-status-codes/horizon-specific/timeout.mdx
@@ -6,7 +6,7 @@ order: 50
 import { ExampleResponse } from "components/ExampleResponse";
 import { AttributeTable } from "components/AttributeTable";
 
-The `timeout` error returns a `[504` error code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) and occurs when either:
+The `timeout` error returns a [`504` error code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) and occurs when either:
 - Horizon has not received a confirmation from the Stellar Core server that the transaction you are trying to submit to the network was included in a ledger in a timely manner, or
 - Horizon has not sent a response to a reverse-proxy before a specified amount of time has elapsed. 
 


### PR DESCRIPTION
On the API reference page describing [timeout errors](https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/timeout/), the link to MDN about 504 errors is rendered incorrectly. 