### PR TITLE
Update Send a Payment golang example to use correct method

### DIFF
--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -140,7 +140,7 @@ func main () {
 
     // Make sure destination account exists
     destAccountRequest := horizonclient.AccountRequest{AccountID: destination}
-    destinationAccount, err := client.Accounts(destAccountRequest)
+    destinationAccount, err := client.AccountData(destAccountRequest)
     if err != nil {
         panic(err)
     }
@@ -148,7 +148,7 @@ func main () {
     // Load the source account
     sourceKP := keypair.MustParseFull(source)
     sourceAccountRequest := horizonclient.AccountRequest{AccountID: sourceKP.Address()}
-    sourceAccount, err := client.Accounts(sourceAccountRequest)
+    sourceAccount, err := client.AccountData(sourceAccountRequest)
     if err != nil {
         panic(err)
     }

--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -140,7 +140,7 @@ func main () {
 
     // Make sure destination account exists
     destAccountRequest := horizonclient.AccountRequest{AccountID: destination}
-    destinationAccount, err := client.AccountData(destAccountRequest)
+    destinationAccount, err := client.AccountDetail(destAccountRequest)
     if err != nil {
         panic(err)
     }
@@ -148,7 +148,7 @@ func main () {
     // Load the source account
     sourceKP := keypair.MustParseFull(source)
     sourceAccountRequest := horizonclient.AccountRequest{AccountID: sourceKP.Address()}
-    sourceAccount, err := client.AccountData(sourceAccountRequest)
+    sourceAccount, err := client.AccountDetail(sourceAccountRequest)
     if err != nil {
         panic(err)
     }

--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -267,7 +267,7 @@ server.accounts().account(destination.getAccountId());
 
 ```go
 destAccountRequest := horizonclient.AccountRequest{AccountID: destination}
-destinationAccount, err := client.Accounts(destAccountRequest)
+destinationAccount, err := client.AccountDetail(destAccountRequest)
 if err != nil {
     panic(err)
 }
@@ -296,7 +296,7 @@ AccountResponse sourceAccount = server.accounts().account(source.getAccountId())
 ```go
 sourceKP := keypair.MustParseFull(source)
 sourceAccountRequest := horizonclient.AccountRequest{AccountID: sourceKP.Address()}
-sourceAccount, err := client.Accounts(sourceAccountRequest)
+sourceAccount, err := client.AccountDetail(sourceAccountRequest)
 if err != nil {
   panic(err)
 }


### PR DESCRIPTION
**Summary**
For the example code of "Send a Payment" in the main() function lines 16 and 24 are not using the correct method, this should be client.AccountDetail() not client.Accounts()

**Explanation**
```
15:  destAccountRequest := horizonclient.AccountRequest{AccountID: destination}
16:  destinationAccount, err := client.Accounts(destAccountRequest)
17:  if err != nil { 
18:      panic(err)
19:  }
```


I'll use one of the two code blocks since they both have the same issue.  In the code block above line 15 creates an endpoint for a single account using the horizonclient.AccountRequest() method.  The following line 16 then sends a query to fetch accounts who have a signer.  Problem is this is an endpoint for multiple accounts, not a single account.  line 15 creates an endpoint for a single account, so line 16 is expecting horizonclient.AccountsRequest() not horizonclient.AccountRequest.

**Solution**
Change line 16 to call client.AccountDetail() rather than client.Accounts()