### PR TITLE
Replace pseudocode CAP-33 examples with real SDK code.

### DIFF
--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -216,10 +216,13 @@ Suppose that now Signer 1 wants to transfer responsibility of sponsoring reserve
 }
 ```
 
+</CodeExample>
+
 At this point, Signer 1 is only sponsoring the first asset (arbitrarily coded as `ABCD`), while Signer 2 is sponsoring the other two assets.
 
 ### Sponsorship Revocation
 Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2 removes themselves from all responsibility over the two asset trustlines. Notice that Account A is not involved at all, since revocation should be performable purely at the sponsor's discretion.
+
 
 <CodeExample>
 
@@ -249,6 +252,9 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 	SignAndSend(client, &s2Account, []*keypair.Full{S2}, revokeOps...)
 	fmt.Println("Revoked sponsorship for", A.Address())
 ```
+
+</CodeExample>
+
 
 
 ### Other Examples

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -3,6 +3,8 @@ title: Sponsored Reserves
 order:
 ---
 
+import { CodeExample } from "components/CodeExample";
+
 Protocol 14 introduces operations that allow an account to pay the base reserves for another account. This is done by using the [Begin Sponsoring Future Reserves](../start/list-of-operations.mdx#begin-sponsoring-future-reserves) and [End Sponsoring Future Reserves](../start/list-of-operations.mdx#end-sponsoring-future-reserves) operations.
 
 The sponsoring account establishes the is-sponsoring-future-reserves-for relationship, and the sponsored account terminates it. While this relationship exists, reserve requirements that would normally accumulate on the sponsored account will now accumulate on the sponsoring account. Both operations must appear in a single transaction, which guarantees that both the sponsoring and sponsored accounts agree to every sponsorship.

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -63,7 +63,7 @@ Each example builds on itself, referencing variables from previous snippets. We'
  - Transfer sponsorship responsibility from one account to another.
  - Revoke sponsorship by an account entirely.
 
-(For brevity, we'll assume the existence of a `SignAndSend(account, []signers, operations...)` method exists which will create a transaction containing `operations...` and sign it with each of the `signers`.)
+(For brevity, we'll assume the existence of a `SignAndSend(...)` method (defined [below](#footnote)) which will creates and submits a transaction with the proper parameters and error-checking.
 
 ### Preamble
 We'll start by including the boilerplate of account and asset creation.
@@ -120,9 +120,9 @@ func main() {
 
 </CodeExample>
 
+
 ### Sponsoring a Trustline
 Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` operation is sandwiched between the begin and end sponsoring operations and that all relevant accounts need to sign the transaction.
-
 
 <CodeExample>
 
@@ -183,6 +183,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 
 </CodeExample>
 
+
 ### Transferring Sponsorship
 Suppose that now Signer 1 wants to transfer responsibility of sponsoring reserves for the trustline to Sponsor 2. This is accomplished by sandwiching the transfer between the `BEGIN/END_SPONSORING_FUTURE_RESERVES` operations. Both of the participants must sign the transaction, though either can submit it.
 
@@ -213,7 +214,6 @@ Suppose that now Signer 1 wants to transfer responsibility of sponsoring reserve
 	// must *approve* the transfer.
 	SignAndSend(client, &s1Account, []*keypair.Full{S1, S2}, transferOps...)
 	fmt.Println("Transferred sponsorship for", A.Address())
-}
 ```
 
 </CodeExample>
@@ -222,7 +222,6 @@ At this point, Signer 1 is only sponsoring the first asset (arbitrarily coded as
 
 ### Sponsorship Revocation
 Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2 removes themselves from all responsibility over the two asset trustlines. Notice that Account A is not involved at all, since revocation should be performable purely at the sponsor's discretion.
-
 
 <CodeExample>
 
@@ -256,9 +255,8 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 </CodeExample>
 
 
-
 ### Other Examples
-If you'd like other examples, or want to view a more-generic pseudocode breakdown of these sponsorship scenarios, you can refer to [CAP-0033](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship).
+If you'd like other examples, or want to view a more-generic pseudocode breakdown of these sponsorship scenarios, you can refer to [CAP-0033](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship) directly.
 
 
 ### Footnote

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -33,35 +33,6 @@ Anything that increases the minimum balance can be sponsored (Accounts, Offers, 
 
 At the end of any transaction, there must be no ongoing is-sponsoring-future-reserves-for relationships. This is why these two operations must be used together in a single transaction.
 
-### Simple Example
-
-In the example below, `A` is sponsoring a trustline for `B`. Notice how the `CHANGE_TRUST` operation is sandwiched between the begin and end sponsoring operations.
-
-```
-sourceAccount: B
-operations[0]:
-    sourceAccount: A
-    body:
-        type: BEGIN_SPONSORING_FUTURE_RESERVES
-        sponsoredID: B
-operations[1]:
-    sourceAccount: B
-    body:
-        type: CHANGE_TRUST
-        line: X
-        limit: INT64_MAX
-operations[2]:
-    sourceAccount: B
-    body:
-        type: END_SPONSORING_FUTURE_RESERVES
-```
-
-#### Other Examples
-
-https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-sponsoring-account-creation
-
-https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-two-trust-lines-with-different-sponsors
-
 ### Revoke Sponsorship
 
 [Revoke Sponsorship](../start/list-of-operations.mdx#revoke-sponsorship) is the third and final operation relevant to sponsorships. It allows the sponsoring account to remove/transfer sponsorships of existing ledgerEntries and signers. If the ledgerEntry/signer is not sponsored, the owner of the ledgerEntry/signer can establish a sponsorship if it is the beneficiary of a is-sponsoring-future-reserves-for relationship.
@@ -85,8 +56,130 @@ See [Revoke Sponsorship](../start/list-of-operations.mdx#revoke-sponsorship) for
 
 The logic above does not detail any of the error cases, which are specified [here](../start/list-of-operations.mdx#revoke-sponsorship).
 
-#### Examples
+## Examples
+### Simple Example
 
-https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship
+In the example below, `A` is sponsoring a trustline for `B`. Notice how the `CHANGE_TRUST` operation is sandwiched between the begin and end sponsoring operations.
 
-https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-transfer-sponsorship
+```
+sourceAccount: B
+operations[0]:
+    sourceAccount: A
+    body:
+        type: BEGIN_SPONSORING_FUTURE_RESERVES
+        sponsoredID: B
+operations[1]:
+    sourceAccount: B
+    body:
+        type: CHANGE_TRUST
+        line: X
+        limit: INT64_MAX
+operations[2]:
+    sourceAccount: B
+    body:
+        type: END_SPONSORING_FUTURE_RESERVES
+```
+
+### Transferring and Revoking Sponsorship
+The below code uses the [Go SDK](../software-and-sdks/index.mdx) to demonstrate both the **transfer** and subsequent **revocation** of a sponsorship; refer to [CAP-0033](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship) for more-generic pseudocode for this process.
+
+
+<CodeExample>
+
+```go
+package sdk
+
+import (
+	sdk "github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild"
+)
+
+func revocation() {
+	client := sdk.DefaultTestNetClient
+
+	// Suppose that these accounts exist and are funded accordingly:
+	A, B, C := keypair.MustRandom(), keypair.MustRandom(), keypair.MustRandom()
+	sponsoredAccount := B.Address()
+
+	// NOTE: Error checks are omitted for brevity; always check return values!
+
+	// Load the corresponding account for both A and C.
+	aAccount, err := client.AccountDetail(sdk.AccountRequest{AccountID: A.Address()})
+	cAccount, err := client.AccountDetail(sdk.AccountRequest{AccountID: B.Address()})
+
+	// We presuppose that Account B has previously been sponsored for some
+	// operation by Account A (here, we refer to a `ManageData` operation).
+
+	//
+	// 1. Transfer sponsorship of B from A to C.
+	//
+
+	transferOps := []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SourceAccount: &cAccount,
+			SponsoredID:   sponsoredAccount,
+		},
+		&txnbuild.RevokeSponsorship{
+			SponsorshipType: txnbuild.RevokeSponsorshipTypeData,
+			Account:         &sponsoredAccount,
+		},
+		&txnbuild.RevokeSponsorship{
+			SourceAccount:   &aAccount,
+			SponsorshipType: txnbuild.RevokeSponsorshipTypeAccount,
+			Account:         &sponsoredAccount,
+		},
+		&txnbuild.EndSponsoringFutureReserves{},
+	}
+
+	// Build, sign, and submit the transaction
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &cAccount,
+			IncrementSequenceNum: true,
+			BaseFee:              txnbuild.MinBaseFee,
+			// As always, use a real timeout in production!
+			Timebounds: txnbuild.NewInfiniteTimeout(),
+			Operations: transferOps,
+		},
+	)
+
+	// Notice that *both* A and C have to approve the sponsorship transfer.
+	tx, err = tx.Sign(network.TestNetworkPassphrase, A)
+	tx, err = tx.Sign(network.TestNetworkPassphrase, C)
+	client.SubmitTransaction(tx)
+
+	//
+	// 2. Revoke sponsorship of B entirely.
+	//
+	revokeOp := txnbuild.RevokeSponsorship{
+		SponsorshipType: txnbuild.RevokeSponsorshipTypeData,
+		Account:         &sponsoredAccount,
+	}
+
+	// Build, sign, and submit the transaction
+	tx, err = txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        &cAccount,
+			IncrementSequenceNum: true,
+			BaseFee:              txnbuild.MinBaseFee,
+			Timebounds:           txnbuild.NewInfiniteTimeout(),
+			Operations:           []txnbuild.Operation{&revokeOp},
+		},
+	)
+
+	// Notice that *both* A and C have to approve the sponsorship transfer.
+	tx, err = tx.Sign(network.TestNetworkPassphrase, C)
+	client.SubmitTransaction(tx)
+}
+```
+
+</CodeExample>
+
+
+### Other Examples
+
+https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-sponsoring-account-creation
+
+https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-two-trust-lines-with-different-sponsors

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -57,129 +57,243 @@ See [Revoke Sponsorship](../start/list-of-operations.mdx#revoke-sponsorship) for
 The logic above does not detail any of the error cases, which are specified [here](../start/list-of-operations.mdx#revoke-sponsorship).
 
 ## Examples
-### Simple Example
+Each example builds on itself, referencing variables from previous snippets. We'll demonstrate a few different things you can do with sponsoring:
+ - Sponsor creation of a trustline for another account.
+ - Sponsor **two** trustlines for an account via two *different* sponsors.
+ - Transfer sponsorship responsibility from one account to another.
+ - Revoke sponsorship by an account entirely.
 
-In the example below, `A` is sponsoring a trustline for `B`. Notice how the `CHANGE_TRUST` operation is sandwiched between the begin and end sponsoring operations.
+(For brevity, we'll assume the existence of a `SignAndSend(account, []signers, operations...)` method exists which will create a transaction containing `operations...` and sign it with each of the `signers`.)
 
-```
-sourceAccount: B
-operations[0]:
-    sourceAccount: A
-    body:
-        type: BEGIN_SPONSORING_FUTURE_RESERVES
-        sponsoredID: B
-operations[1]:
-    sourceAccount: B
-    body:
-        type: CHANGE_TRUST
-        line: X
-        limit: INT64_MAX
-operations[2]:
-    sourceAccount: B
-    body:
-        type: END_SPONSORING_FUTURE_RESERVES
-```
-
-### Transferring and Revoking Sponsorship
-The below code uses the [Go SDK](../software-and-sdks/index.mdx) to demonstrate both the **transfer** and subsequent **revocation** of a sponsorship; refer to [CAP-0033](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship) for more-generic pseudocode for this process.
-
+### Preamble
+We'll start by including the boilerplate of account and asset creation.
 
 <CodeExample>
 
 ```go
-package sdk
+package main
 
 import (
+	"fmt"
+	"net/http"
+
 	sdk "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/txnbuild"
 )
 
-func revocation() {
+func main() {
 	client := sdk.DefaultTestNetClient
 
-	// Suppose that these accounts exist and are funded accordingly:
-	A, B, C := keypair.MustRandom(), keypair.MustRandom(), keypair.MustRandom()
-	sponsoredAccount := B.Address()
+	// Both S1 and S2 will be sponsors for A at various points in time.
+	S1, A, S2 := keypair.MustRandom(), keypair.MustRandom(), keypair.MustRandom()
+	sponsoredAccount := A.Address()
 
+	for _, pair := range []*keypair.Full{S1, A, S2} {
+		resp, err := http.Get("https://friendbot.stellar.org/?addr=" + pair.Address())
+		if err != nil {
+			panic(err)
+		}
+		resp.Body.Close()
+		fmt.Println("Funded", pair.Address())
+	}
+
+	//
 	// NOTE: Error checks are omitted for brevity; always check return values!
+	//
 
 	// Load the corresponding account for both A and C.
+	s1Account, err := client.AccountDetail(sdk.AccountRequest{AccountID: S1.Address()})
 	aAccount, err := client.AccountDetail(sdk.AccountRequest{AccountID: A.Address()})
-	cAccount, err := client.AccountDetail(sdk.AccountRequest{AccountID: B.Address()})
+	s2Account, err := client.AccountDetail(sdk.AccountRequest{AccountID: S2.Address()})
 
-	// We presuppose that Account B has previously been sponsored for some
-	// operation by Account A (here, we refer to a `ManageData` operation).
-
-	//
-	// 1. Transfer sponsorship of B from A to C.
-	//
-
-	transferOps := []txnbuild.Operation{
-		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &cAccount,
-			SponsoredID:   sponsoredAccount,
-		},
-		&txnbuild.RevokeSponsorship{
-			SponsorshipType: txnbuild.RevokeSponsorshipTypeData,
-			Account:         &sponsoredAccount,
-		},
-		&txnbuild.RevokeSponsorship{
-			SourceAccount:   &aAccount,
-			SponsorshipType: txnbuild.RevokeSponsorshipTypeAccount,
-			Account:         &sponsoredAccount,
-		},
-		&txnbuild.EndSponsoringFutureReserves{},
+	// Arbitrary assets to sponsor trustlines for. Let's assume they make sense.
+	assets := []txnbuild.CreditAsset{
+		txnbuild.CreditAsset{Code: "ABCD", Issuer: S1.Address()},
+		txnbuild.CreditAsset{Code: "EFGH", Issuer: S1.Address()},
+		txnbuild.CreditAsset{Code: "IJKL", Issuer: S2.Address()},
 	}
-
-	// Build, sign, and submit the transaction
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &cAccount,
-			IncrementSequenceNum: true,
-			BaseFee:              txnbuild.MinBaseFee,
-			// As always, use a real timeout in production!
-			Timebounds: txnbuild.NewInfiniteTimeout(),
-			Operations: transferOps,
-		},
-	)
-
-	// Notice that *both* A and C have to approve the sponsorship transfer.
-	tx, err = tx.Sign(network.TestNetworkPassphrase, A)
-	tx, err = tx.Sign(network.TestNetworkPassphrase, C)
-	client.SubmitTransaction(tx)
-
-	//
-	// 2. Revoke sponsorship of B entirely.
-	//
-	revokeOp := txnbuild.RevokeSponsorship{
-		SponsorshipType: txnbuild.RevokeSponsorshipTypeData,
-		Account:         &sponsoredAccount,
-	}
-
-	// Build, sign, and submit the transaction
-	tx, err = txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        &cAccount,
-			IncrementSequenceNum: true,
-			BaseFee:              txnbuild.MinBaseFee,
-			Timebounds:           txnbuild.NewInfiniteTimeout(),
-			Operations:           []txnbuild.Operation{&revokeOp},
-		},
-	)
-
-	// Notice that *both* A and C have to approve the sponsorship transfer.
-	tx, err = tx.Sign(network.TestNetworkPassphrase, C)
-	client.SubmitTransaction(tx)
 }
 ```
 
 </CodeExample>
 
+### Sponsoring a Trustline
+Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` operation is sandwiched between the begin and end sponsoring operations and that all relevant accounts need to sign the transaction.
+
+
+<CodeExample>
+
+```go
+	//
+	// 1. S1 will sponsor a trustline for Account A.
+	//
+	sponsorTrustline := []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SourceAccount: &s1Account,
+			SponsoredID:   sponsoredAccount,
+		},
+		&txnbuild.ChangeTrust{
+			SourceAccount: &aAccount,
+			Line:          &assets[0],
+			Limit:         txnbuild.MaxTrustlineLimit,
+		},
+		&txnbuild.EndSponsoringFutureReserves{
+			SourceAccount: &aAccount,
+		},
+	}
+
+	// Note that while A can submit this transaction, both sign it.
+	SignAndSend(client, &aAccount, []*keypair.Full{S1, A}, sponsorTrustline...)
+	fmt.Println("Sponsored a trustline of", A.Address())
+
+	//
+	// 2. Both S1 and S2 sponsor trustlines for Account A for different assets.
+	//
+	sponsorTrustline = []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SourceAccount: &s1Account,
+			SponsoredID:   sponsoredAccount,
+		},
+		&txnbuild.ChangeTrust{
+			SourceAccount: &aAccount,
+			Line:          &assets[1],
+			Limit:         txnbuild.MaxTrustlineLimit,
+		},
+		&txnbuild.EndSponsoringFutureReserves{},
+
+		&txnbuild.BeginSponsoringFutureReserves{
+			SourceAccount: &s2Account,
+			SponsoredID:   sponsoredAccount,
+		},
+		&txnbuild.ChangeTrust{
+			SourceAccount: &aAccount,
+			Line:          &assets[2],
+			Limit:         txnbuild.MaxTrustlineLimit,
+		},
+		&txnbuild.EndSponsoringFutureReserves{},
+	}
+
+	// Note that all 3 accounts must approve/sign this transaction.
+	SignAndSend(client, &aAccount, []*keypair.Full{S1, S2, A}, sponsorTrustline...)
+	fmt.Println("Sponsored two trustlines of", A.Address())
+```
+
+</CodeExample>
+
+### Transferring Sponsorship
+Suppose that now Signer 1 wants to transfer responsibility of sponsoring reserves for the trustline to Sponsor 2. This is accomplished by sandwiching the transfer between the `BEGIN/END_SPONSORING_FUTURE_RESERVES` operations. Both of the participants must sign the transaction, though either can submit it.
+
+<CodeExample>
+
+```go
+	//
+	// 3. Transfer sponsorship of B's second trustline from S1 to S2.
+	//
+	transferOps := []txnbuild.Operation{
+		&txnbuild.BeginSponsoringFutureReserves{
+			SourceAccount: &s2Account,
+			SponsoredID:   S1.Address(),
+		},
+		&txnbuild.RevokeSponsorship{
+			SourceAccount:   &s1Account,
+			SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
+			Account:         &sponsoredAccount,
+			TrustLine: &txnbuild.TrustLineID{
+				Account: sponsoredAccount,
+				Asset:   assets[1],
+			},
+		},
+		&txnbuild.EndSponsoringFutureReserves{},
+	}
+
+	// Notice that while either sponsor *sends* the transaction, both sponsors
+	// must *approve* the transfer.
+	SignAndSend(client, &s1Account, []*keypair.Full{S1, S2}, transferOps...)
+	fmt.Println("Transferred sponsorship for", A.Address())
+}
+```
+
+At this point, Signer 1 is only sponsoring the first asset (arbitrarily coded as `ABCD`), while Signer 2 is sponsoring the other two assets.
+
+### Sponsorship Revocation
+Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2 removes themselves from all responsibility over the two asset trustlines. Notice that Account A is not involved at all, since revocation should be performable purely at the sponsor's discretion.
+
+<CodeExample>
+
+```go
+	//
+	// 4. S2 revokes sponsorship of B's trustlines entirely.
+	//
+	revokeOps := []txnbuild.Operation{
+		&txnbuild.RevokeSponsorship{
+			SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
+			Account:         &sponsoredAccount,
+			TrustLine: &txnbuild.TrustLineID{
+				Account: sponsoredAccount,
+				Asset:   assets[1],
+			},
+		},
+		&txnbuild.RevokeSponsorship{
+			SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
+			Account:         &sponsoredAccount,
+			TrustLine: &txnbuild.TrustLineID{
+				Account: sponsoredAccount,
+				Asset:   assets[2],
+			},
+		},
+	}
+
+	SignAndSend(client, &s2Account, []*keypair.Full{S2}, revokeOps...)
+	fmt.Println("Revoked sponsorship for", A.Address())
+```
+
 
 ### Other Examples
+If you'd like other examples, or want to view a more-generic pseudocode breakdown of these sponsorship scenarios, you can refer to [CAP-0033](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship).
 
-https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-sponsoring-account-creation
 
-https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-two-trust-lines-with-different-sponsors
+### Footnote
+An implementation of `SignAndSend` might look something like this:
+
+<CodeExample>
+
+```go
+// Builds a transaction containing `operations...`, signed (by `signers`), and
+// submitted using the given `client` on behalf of `account`.
+func SignAndSend(
+	client *sdk.Client,
+	account txnbuild.Account,
+	signers []*keypair.Full,
+	operations ...txnbuild.Operation,
+) protocol.Transaction {
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        account,
+			Operations:           operations,
+			BaseFee:              txnbuild.MinBaseFee,
+			Timebounds:           txnbuild.NewInfiniteTimeout(),
+			IncrementSequenceNum: true,
+		},
+	)
+
+	for _, signer := range signers {
+		tx, err = tx.Sign(network.TestNetworkPassphrase, signer)
+	}
+
+	txResp, err := client.SubmitTransaction(tx)
+	if err != nil {
+		if prob := sdk.GetError(err); prob != nil {
+			fmt.Printf("  problem: %s\n", prob.Problem.Detail)
+			fmt.Printf("  extras: %s\n", prob.Problem.Extras["result_codes"])
+		}
+		panic(err)
+	}
+
+	return txResp
+}
+```
+
+</CodeExample>

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -91,25 +91,22 @@ func main() {
 
 	// Both S1 and S2 will be sponsors for A at various points in time.
 	S1, A, S2 := keypair.MustRandom(), keypair.MustRandom(), keypair.MustRandom()
-	sponsoredAccount := A.Address()
+	addressA := A.Address()
 
 	for _, pair := range []*keypair.Full{S1, A, S2} {
 		resp, err := http.Get("https://friendbot.stellar.org/?addr=" + pair.Address())
-		if err != nil {
-			panic(err)
-		}
+		check(err)
 		resp.Body.Close()
 		fmt.Println("Funded", pair.Address())
 	}
 
-	//
-	// NOTE: Error checks are omitted for brevity; always check return values!
-	//
-
 	// Load the corresponding account for both A and C.
 	s1Account, err := client.AccountDetail(sdk.AccountRequest{AccountID: S1.Address()})
-	aAccount, err := client.AccountDetail(sdk.AccountRequest{AccountID: A.Address()})
+	check(err)
+	aAccount, err := client.AccountDetail(sdk.AccountRequest{AccountID: addressA})
+	check(err)
 	s2Account, err := client.AccountDetail(sdk.AccountRequest{AccountID: S2.Address()})
+	check(err)
 
 	// Arbitrary assets to sponsor trustlines for. Let's assume they make sense.
 	assets := []txnbuild.CreditAsset{
@@ -117,7 +114,8 @@ func main() {
 		txnbuild.CreditAsset{Code: "EFGH", Issuer: S1.Address()},
 		txnbuild.CreditAsset{Code: "IJKL", Issuer: S2.Address()},
 	}
-}
+
+	// ...
 ```
 
 </CodeExample>
@@ -135,16 +133,14 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	sponsorTrustline := []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
 			SourceAccount: &s1Account,
-			SponsoredID:   sponsoredAccount,
+			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
 			SourceAccount: &aAccount,
 			Line:          &assets[0],
 			Limit:         txnbuild.MaxTrustlineLimit,
 		},
-		&txnbuild.EndSponsoringFutureReserves{
-			SourceAccount: &aAccount,
-		},
+		&txnbuild.EndSponsoringFutureReserves{},
 	}
 
 	// Note that while A can submit this transaction, both sign it.
@@ -157,10 +153,9 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	sponsorTrustline = []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
 			SourceAccount: &s1Account,
-			SponsoredID:   sponsoredAccount,
+			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
-			SourceAccount: &aAccount,
 			Line:          &assets[1],
 			Limit:         txnbuild.MaxTrustlineLimit,
 		},
@@ -168,10 +163,9 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 
 		&txnbuild.BeginSponsoringFutureReserves{
 			SourceAccount: &s2Account,
-			SponsoredID:   sponsoredAccount,
+			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
-			SourceAccount: &aAccount,
 			Line:          &assets[2],
 			Limit:         txnbuild.MaxTrustlineLimit,
 		},
@@ -203,16 +197,16 @@ Suppose that now Signer 1 wants to transfer responsibility of sponsoring reserve
 		&txnbuild.RevokeSponsorship{
 			SourceAccount:   &s1Account,
 			SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
-			Account:         &sponsoredAccount,
+			Account:         &addressA,
 			TrustLine: &txnbuild.TrustLineID{
-				Account: sponsoredAccount,
+				Account: addressA,
 				Asset:   assets[1],
 			},
 		},
 		&txnbuild.EndSponsoringFutureReserves{},
 	}
 
-	// Notice that while either sponsor *sends* the transaction, both sponsors
+	// Notice that while the old sponsor *sends* the transaction, both sponsors
 	// must *approve* the transfer.
 	SignAndSend(client, &s1Account, []*keypair.Full{S1, S2}, transferOps...)
 	fmt.Println("Transferred sponsorship for", A.Address())
@@ -234,17 +228,17 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 	revokeOps := []txnbuild.Operation{
 		&txnbuild.RevokeSponsorship{
 			SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
-			Account:         &sponsoredAccount,
+			Account:         &addressA,
 			TrustLine: &txnbuild.TrustLineID{
-				Account: sponsoredAccount,
+				Account: addressA,
 				Asset:   assets[1],
 			},
 		},
 		&txnbuild.RevokeSponsorship{
 			SponsorshipType: txnbuild.RevokeSponsorshipTypeTrustLine,
-			Account:         &sponsoredAccount,
+			Account:         &addressA,
 			TrustLine: &txnbuild.TrustLineID{
-				Account: sponsoredAccount,
+				Account: addressA,
 				Asset:   assets[2],
 			},
 		},
@@ -252,6 +246,7 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 
 	SignAndSend(client, &s2Account, []*keypair.Full{S2}, revokeOps...)
 	fmt.Println("Revoked sponsorship for", A.Address())
+} // ends main()
 ```
 
 </CodeExample>
@@ -275,18 +270,21 @@ func SignAndSend(
 	signers []*keypair.Full,
 	operations ...txnbuild.Operation,
 ) protocol.Transaction {
+	// Build, sign, and submit the transaction
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
 			SourceAccount:        account,
-			Operations:           operations,
+			IncrementSequenceNum: true,
 			BaseFee:              txnbuild.MinBaseFee,
 			Timebounds:           txnbuild.NewInfiniteTimeout(),
-			IncrementSequenceNum: true,
+			Operations:           operations,
 		},
 	)
+	check(err)
 
 	for _, signer := range signers {
 		tx, err = tx.Sign(network.TestNetworkPassphrase, signer)
+		check(err)
 	}
 
 	txResp, err := client.SubmitTransaction(tx)
@@ -295,10 +293,16 @@ func SignAndSend(
 			fmt.Printf("  problem: %s\n", prob.Problem.Detail)
 			fmt.Printf("  extras: %s\n", prob.Problem.Extras["result_codes"])
 		}
-		panic(err)
+		check(err)
 	}
 
 	return txResp
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
 }
 ```
 


### PR DESCRIPTION
This adds code samples for the following:
  - sponsoring a trustline
  - transferring sponsorship to another account
  - revoking sponsorships

(as with #251, cc @sisuresh and @stellar/horizon-committers)

