### PR TITLE
Update allow-trust.mdx

### DIFF
--- a/content/api/resources/operations/object/allow-trust.mdx
+++ b/content/api/resources/operations/object/allow-trust.mdx
@@ -26,7 +26,7 @@ See the [`Allow Trust` errors](../../../errors/result-codes/operation-specific/a
   - The code for the asset.
 - authorize
   - int
-  - Flag indicating whether the trustline is authorized.  1 if the account is authorized to transact with the asset. 2 if the account is authorized to maintain orders, but not to perform other transactions. 0 if the account is not authorized to transact with the asset in any way.
+  - Flag indicating whether the trustline is authorized.  0 if the account is not authorized to transact with the asset in any way. 1 if the account is authorized to transact with the asset. 2 if the account is authorized to maintain orders, but not to perform other transactions. 
 - trustee
   - string
   - The issuing account, or source account in this instance.

--- a/content/api/resources/operations/object/allow-trust.mdx
+++ b/content/api/resources/operations/object/allow-trust.mdx
@@ -25,7 +25,7 @@ See the [`Allow Trust` errors](../../../errors/result-codes/operation-specific/a
   - string
   - The code for the asset.
 - authorize
-  - boolean
+  - int
   - Flag indicating whether the trustline is authorized.  1 if the account is authorized to transact with the asset. 2 if the account is authorized to maintain orders, but not to perform other transactions. 0 if the account is not authorized to transact with the asset in any way.
 - trustee
   - string

--- a/content/api/resources/operations/object/allow-trust.mdx
+++ b/content/api/resources/operations/object/allow-trust.mdx
@@ -26,7 +26,7 @@ See the [`Allow Trust` errors](../../../errors/result-codes/operation-specific/a
   - The code for the asset.
 - authorize
   - boolean
-  - Allows or disallows trust.
+  - Flag indicating whether the trustline is authorized.  1 if the account is authorized to transact with the asset. 2 if the account is authorized to maintain orders, but not to perform other transactions. 0 if the account is not authorized to transact with the asset in any way.
 - trustee
   - string
   - The issuing account, or source account in this instance.


### PR DESCRIPTION
Change trust is now an int, not a boolean.  That's because of the Protocol 13 "fine-grained asset auth" adddition.