### PR TITLE
Rice2000 fix links to streaming

### DIFF
--- a/content/api/resources/operations/list-payments.mdx
+++ b/content/api/resources/operations/list-payments.mdx
@@ -8,7 +8,7 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all successful payment-related operations and can be used in [streaming](../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new payments as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known payment unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream payments created since your request time.
+This endpoint lists all successful payment-related operations and can be used in [streaming](../../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new payments as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known payment unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream payments created since your request time.
 
 Operations that can be returned by this endpoint include:
 

--- a/content/api/resources/operations/list.mdx
+++ b/content/api/resources/operations/list.mdx
@@ -8,7 +8,7 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all successful operations and can be used in [streaming](../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new operations as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream operations created since your request time.
+This endpoint lists all successful operations and can be used in [streaming](../../introduction/streaming.mdx) mode. Streaming mode allows you to listen for new operations as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream operations created since your request time.
 
 <Endpoint>
 

--- a/content/api/resources/trades/list.mdx
+++ b/content/api/resources/trades/list.mdx
@@ -8,7 +8,7 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint lists all trades and can be used in [streaming](../introduction/streaming.mdx) mode.
+This endpoint lists all trades and can be used in [streaming](../../introduction/streaming.mdx) mode.
 
 Streaming mode allows you to listen for new trades as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known trade unless a `cursor` is set, in which case it will start from that `cursor`. By setting the cursor value to `now`, you can stream trades created since your request time.
 


### PR DESCRIPTION
A few of the relative paths to the streaming doc were broken.  This fixes them.