### PR TITLE
Fix right side navigation after clicked anchor

### DIFF
--- a/src/components/SideNav/TrackedContent.js
+++ b/src/components/SideNav/TrackedContent.js
@@ -17,7 +17,7 @@ export const TrackedContent = ({ children, identifier }) => {
     return () => {
       stopTrackingElement(toTrack);
     };
-  }, [children, identifier, trackElement, stopTrackingElement]);
+  }, [identifier, trackElement, stopTrackingElement]);
 
   return <El ref={ref}>{children}</El>;
 };


### PR DESCRIPTION
`children` is not used in that effect and was causing too many state updates that it couldn't keep up with re-mounting (tracked items were removed and added again too quickly).