### PR TITLE
Clarify asset format for the claimable balance APIs

### DIFF
--- a/content/api/resources/claimablebalances/object.mdx
+++ b/content/api/resources/claimablebalances/object.mdx
@@ -22,7 +22,7 @@ When Horizon returns information about a claimable balance, it uses the followin
   - A cursor value for use in [pagination](../../introduction/pagination/index.mdx).
 - asset
   - string
-  - The asset available to be claimed.
+  - The asset available to be claimed in the [SEP-11 form](https://github.com/stellar/stellar-protocol/blob/0c675fb3a482183dcf0f5db79c12685acf82a95c/ecosystem/sep-0011.md#values) `asset_code:issuing_address` or `native` (for XLM)
 - amount
   - string
   - The amount of `asset` that can be claimed.

--- a/content/api/resources/operations/object/create-claimable-balance.mdx
+++ b/content/api/resources/operations/object/create-claimable-balance.mdx
@@ -16,7 +16,7 @@ Creates a new claimable balance.
   - DESCRIPTION
 - asset
   - string
-  - The asset available to be claimed in the form `asset_code:issuing_address` or `native` (for XLM)
+  - The asset available to be claimed in the [SEP-11 form](https://github.com/stellar/stellar-protocol/blob/0c675fb3a482183dcf0f5db79c12685acf82a95c/ecosystem/sep-0011.md#values) `asset_code:issuing_address` or `native` (for XLM)
 - amount
   - string
   - The amount available to be claimed.


### PR DESCRIPTION
This is a small change to unify the way the [CreateClaimableBalance operation](https://developers.stellar.org/api/resources/operations/object/create-claimable-balance/) is presented with the [object itself](https://developers.stellar.org/api/resources/claimablebalances/object/).