### PR TITLE
Specify a string rather than a number for /assets?cursor={paging_token}

### DIFF
--- a/content/api/resources/assets/list.mdx
+++ b/content/api/resources/assets/list.mdx
@@ -31,7 +31,7 @@ This endpoint lists all assets.
   - The Stellar address of the issuer for the asset you would like to filter by.
 - cursor
   - optional
-  - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
+  - A string pointing to a specific location in a collection of responses, pulled from the `paging_token` value of a record.
 - order
   - optional
   - A designation of the order in which records should appear. Options include `asc`(ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.


### PR DESCRIPTION
Coupled with stellar/go#3440.