### PR TITLE
Add minor clarifications & cleanup to the Captive Core deployment docs

### DIFF
--- a/content/docs/run-api-server-dep/configuring.mdx
+++ b/content/docs/run-api-server-dep/configuring.mdx
@@ -32,7 +32,7 @@ Specifying command line flags every time you invoke Horizon can be cumbersome, a
 
 Before running the Horizon server, you must first prepare the Horizon database. This database will be used for all of the information produced by Horizon, notably historical information about successful transactions that have occurred on the stellar network.
 
-To prepare a database for Horizon's use, you must first ensure the database is blank. It's easiest to simply create a new database on your postgres server specifically for Horizon's use. Next you must install the schema by running `horizon db init`. Remember to use the appropriate command line flags or environment variables to configure Horizon as explained in [Configuring ](./configuring.mdx). This command will log any errors that occur.
+To prepare a database for Horizon's use, you must first ensure the database is blank. It's easiest to simply create a new database on your postgres server specifically for Horizon's use. Next you must install the schema by running `horizon db init`. Remember to use the appropriate command line flags or environment variables to configure Horizon as explained in [Configuring](./configuring.mdx). This command will log any errors that occur.
 
 ### Postgres Configuration
 

--- a/content/docs/run-api-server-dep/index.mdx
+++ b/content/docs/run-api-server-dep/index.mdx
@@ -5,7 +5,7 @@ order: 0
 
 import { CodeExample } from "components/CodeExample";
 
-**Note**: This section outlines a **deprecated** way of setting up a new, production Horizon deployment. We're leaving it around for posterity while we improve the docs outliningthe [new, recommended way](../run-api-server/index.mdx) of deploying Horizon 2.0+.
+**Note**: This section outlines a **deprecated** way of setting up a new, production Horizon deployment. We're leaving it around for posterity while we improve the docs outlining the [new, recommended way](../run-api-server/index.mdx) of deploying Horizon 2.0+.
 
 Horizon is responsible for providing an HTTP API to data in the Stellar network. It ingests and re-serves the data produced by the stellar network in a form that is easier to consume than the performance-oriented data representations used by stellar-core.
 

--- a/content/docs/run-api-server/configuring.mdx
+++ b/content/docs/run-api-server/configuring.mdx
@@ -77,7 +77,7 @@ HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{
 
 _(For the remainder of this guide, we'll assume this stub lives at `/etc/default/stellar-captive-core-stub.toml`.)_
 
-The minimum required fields are the `[[HOME_DOMAINS]]` and a set of `[[VALIDATORS]]`, so if you wanted to configure your instance for the public network, you would simply replace the above with their pubnet equivalents. As inspiration, [here](https://github.com/stellar/go/blob/master/services/horizon/docker/stellar-core-pubnet.cfg#L15-L202) is the set of domains and validators that SDF configures on the pubnet.
+You can [install](./installing.mdx#package-manager) the `stellar-captive-core` package to simplify configuration here, but the minimum required fields are the `[[HOME_DOMAINS]]` and a set of `[[VALIDATORS]]`, so if you wanted to configure your instance for the public network, you would simply replace the above with their pubnet equivalents. As inspiration, [here](https://github.com/stellar/go/blob/master/services/horizon/docker/stellar-core-pubnet.cfg#L15-L202) is the set of domains and validators that SDF configures on the pubnet.
 
 
 ## Remote Captive Core

--- a/content/docs/run-api-server/installing.mdx
+++ b/content/docs/run-api-server/installing.mdx
@@ -23,7 +23,7 @@ sudo apt update && sudo apt install stellar-core stellar-horizon
 
 </CodeExample>
 
-If you want to do [ingestion](./running.mdx#ingesting-transactions) on this machine, you should also install the `stellar-captive-core` package.  [This page](https://github.com/stellar/packages/blob/master/docs/installing-individual-packages.md#installing-individual-packages) outlines the various commands that these packages make available.
+[This page](https://github.com/stellar/packages/blob/master/docs/installing-individual-packages.md#installing-individual-packages) outlines the various commands that these packages make available.
 
 ### Building
 Should you decide not to use one of our prebuilt releases, you may instead build Horizon from source. To do so, you need to prepare a developer environment, including:
@@ -90,6 +90,7 @@ sudo cp $(go env GOPATH)/bin/captivecore /usr/bin/stellar-captive-core-api
 
 
 ## Completing and Testing Your Installation
+
 If you [built from source](#building) or downloaded a release [from GitHub](https://github.com/stellar/go/releases), make sure to copy the native binary into a directory that is part of your PATH. Most Unix-like systems have `/usr/local/bin` in PATH by default, so unless you have a preference or know better, we recommend you copy the binary there:
 
 <CodeExample>

--- a/content/docs/run-api-server/installing.mdx
+++ b/content/docs/run-api-server/installing.mdx
@@ -18,7 +18,7 @@ SDF publishes new releases to its custom Ubuntu repositories. Follow [this guide
 <CodeExample>
 
 ```bash
-sudo apt update && sudo apt install stellar-horizon
+sudo apt update && sudo apt install stellar-core stellar-horizon
 ```
 
 </CodeExample>

--- a/content/docs/run-api-server/installing.mdx
+++ b/content/docs/run-api-server/installing.mdx
@@ -5,13 +5,10 @@ order: 20
 
 import { CodeExample } from "components/CodeExample";
 
-
-## Installation Methods
-
 To install Horizon, you have a few choices. You can...
   - install prebuilt binaries [from our repositories](#package-manager) via your package manager if running a Debian-based system,
   - download a [prebuilt release](https://github.com/stellar/go/releases) for your target architecture and operation system, or
-  - [build Horizon yourself](#building) from scratch. 
+  - [build Horizon yourself](#building) from scratch.
 
 The first method is recommended: not only do you ensure OS compatibility and dependency management, you'll also install some convenient wrappers that make running Horizon and Stellar Core much simpler.
 
@@ -21,69 +18,59 @@ SDF publishes new releases to its custom Ubuntu repositories. Follow [this guide
 <CodeExample>
 
 ```bash
-sudo apt update && sudo apt install stellar-captive-core stellar-horizon
+sudo apt update && sudo apt install stellar-horizon
 ```
 
 </CodeExample>
 
-[This page](https://github.com/stellar/packages/blob/master/docs/installing-individual-packages.md#installing-individual-packages) outlines the various commands that these packages make available.
+If you want to do [ingestion](./running.mdx#ingesting-transactions) on this machine, you should also install the `stellar-captive-core` package.  [This page](https://github.com/stellar/packages/blob/master/docs/installing-individual-packages.md#installing-individual-packages) outlines the various commands that these packages make available.
 
 ### Building
-Should you decide not to use one of our prebuilt releases, you may instead build Horizon from source. To do so, you need to install some developer tools:
+Should you decide not to use one of our prebuilt releases, you may instead build Horizon from source. To do so, you need to prepare a developer environment, including:
 
 - A Unix-like operating system with the common core commands (cp, tar, mkdir, bash, etc.)
-- A compatible distribution of Go (Go 1.15 or later)
+- A compatible distribution of [Golang](https://golang.org/dl/) (v1.15 or later)
 - [git](https://git-scm.com/)
 
-**Note**: Though Horizon can run on Windows, *building* directly on Windows is not supported.
+_(Though Horizon can run on Windows, *building* directly on Windows is not supported.)_
 
-First, refer to the details of [README.md](https://github.com/stellar/go/blob/master/README.md#dependencies) for installing dependencies. Then, you can build the Horizon binary pretty easily:
+At this point, you can easily build the Horizon binary:
 
 <CodeExample>
 
 ```bash
 git clone https://github.com/stellar/go monorepo && cd monorepo
 go install -v ./services/horizon
-sudo cp $(go env GOPATH)/bin/horizon /usr/bin/stellar-horizon
 ```
 
 </CodeExample>
 
-_(You should refer to the list of [Horizon releases](https://github.com/stellar/go/releases) and `git checkout` accordingly if you're looking for a stable release rather than the bleeding edge `master` branch.)_
+_(You should refer to the list of [Horizon releases](https://github.com/stellar/go/releases) and `git checkout` accordingly before building if you're looking for a stable release rather than the bleeding edge `master` branch.)_
 
-At this point, you can either add Go binaries to your PATH in your `bashrc` or equivalent:
-
-<CodeExample>
-
-```bash
-export PATH=${GOPATH//://bin:}/bin:$PATH
-```
-
-</CodeExample>
-
-or just copy the binary from the `GOPATH` to the system PATH:
+At this point, you can either add Go binaries to your PATH in your `.bashrc` (or equivalent), or copy the binary from the `GOPATH` to the system PATH (as [we'll do later](#completing-and-testing-your-installation):
 
 <CodeExample>
 
 ```bash
-cp $(go env GOPATH)/bin/horizon /usr/bin/stellar-horizon
+export PATH=$(go env GOPATH)/bin:$PATH
 ```
 
 </CodeExample>
 
 
 ## Installing Remote Captive Core
-If you want to run Captive Core instances separately from other Horizon instances, the architecture supports that. This allows flexibility in your scaling and redundancy. For example, you may want to have your ingesting Horizon instances have dedicated Captive Cores, while request-serving instances all use the same Remote Captive Core. Or perhaps you want a dedicated Remote Captive Core for ingestion living on more-powerful hardware.
+
+If you want to run Captive Core instances (for [transaction ingestion](./running.mdx#ingesting-transactions)) separately from other Horizon instances, the architecture supports that. This allows flexibility in scaling and redundancy. For example, you may want to have your ingesting Horizon instances have dedicated Captive Cores, while request-serving instances all use the same Remote Captive Core for transaction submission. Or, perhaps you want a dedicated Remote Captive Core for ingestion living on more-powerful hardware.
 
 If you are interested in this approach, you'll need some additional binaries on that machine.
 
 ### From Repositories
-After setting up repositories as described [above](#package-manager), you'll need to install the following packages on that machine:
+After setting up repositories as [described above](#package-manager), you'll need to install the following packages on that machine:
 
 <CodeExample>
 
 ```bash
-apt install stellar-captive-core stellar-captive-core-api
+sudo apt install stellar-captive-core stellar-captive-core-api
 ```
 
 </CodeExample>
@@ -103,7 +90,7 @@ sudo cp $(go env GOPATH)/bin/captivecore /usr/bin/stellar-captive-core-api
 
 
 ## Completing and Testing Your Installation
-If you [built from source](#building) or downloaded a release [from GitHub](https://github.com/stellar/go/releases), you simply need to copy the native binary into a directory that is part of your PATH. Most Unix-like systems have `/usr/local/bin` in PATH by default, so unless you have a preference or know better, we recommend you copy the binary there:
+If you [built from source](#building) or downloaded a release [from GitHub](https://github.com/stellar/go/releases), make sure to copy the native binary into a directory that is part of your PATH. Most Unix-like systems have `/usr/local/bin` in PATH by default, so unless you have a preference or know better, we recommend you copy the binary there:
 
 <CodeExample>
 

--- a/content/docs/run-api-server/monitoring.mdx
+++ b/content/docs/run-api-server/monitoring.mdx
@@ -5,11 +5,38 @@ order: 60
 
 import { CodeExample } from "components/CodeExample";
 
-To ensure that your instance of Horizon is performing correctly, we encourage you to monitor it, and provide both logs and metrics to do so.
+To ensure that your instance of Horizon is performing correctly, we encourage you to monitor it and provide both logs and metrics to do so.
 
+
+## Metrics
+
+Metrics are collected while a Horizon process is running and they are exposed *privately* via the `/metrics` path, accessible only through the Horizon admin port. You need to configure this via `--admin-port` or `ADMIN_PORT`, since it's disabled by default. If you're running such an instance locally, you can access this endpoint:
+
+<CodeExample>
+
+```
+$ stellar-horizon --admin-port=4200 &
+$ curl localhost:4200/metrics
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 1.665e-05
+go_gc_duration_seconds{quantile="0.25"} 2.1889e-05
+go_gc_duration_seconds{quantile="0.5"} 2.4062e-05
+go_gc_duration_seconds{quantile="0.75"} 3.4226e-05
+go_gc_duration_seconds{quantile="1"} 0.001294239
+go_gc_duration_seconds_sum 0.002469679
+go_gc_duration_seconds_count 25
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 23
+and so on...
+```
+
+</CodeExample>
+
+
+## Logs
 Horizon will output logs to standard out. Information about what requests are coming in will be reported, but more importantly, warnings or errors will also be emitted by default. A correctly running Horizon instance will not output any warning or error log entries.
-
-Metrics are collected while a Horizon process is running and they are exposed at the `/metrics` path. You can see an example at https://horizon-testnet.stellar.org/metrics.
 
 Below we present a few standard log entries with associated fields. You can use them to build metrics and alerts. Please note that these represent Horizon app metrics only. You should also monitor your hardware metrics like CPU or RAM Utilization.
 
@@ -81,6 +108,7 @@ Below are example alerts with potential causes and solutions. Feel free to add m
 | Large number of rate-limited requests | Rate-limiting threshold too low | Increase rate-limiting threshold |
 | Ingestion is slow | Horizon server spec too low | Increase hardware spec |
 | Spike in average response time of a single route | Possible bug in a code responsible for rendering a route | Report an issue in Horizon repository. |
+
 
 ## I'm Stuck! Help!
 

--- a/content/docs/run-api-server/prerequisites.mdx
+++ b/content/docs/run-api-server/prerequisites.mdx
@@ -7,4 +7,10 @@ import { CodeExample } from "components/CodeExample";
 
 Horizon only has one dependency: a PostgreSQL server that it uses to store data that has been processed and ingested from Stellar Core. Horizon requires PostgreSQL version >= 9.5.
 
-As far as system requirements go, there's one main thing to keep in mind: your machines should have enough extra RAM to hold Captive Core's in-memory database (~3GB). A secondary requirement depends on how much of the network's history you'd like to serve from your Horizon instance; this could be anywhere from a few gigabytes to tens of terabytes for the full ingested ledger history.
+As far as system requirements go, there are a few main things to keep in mind:
+
+- If you plan on [ingesting](./running.mdx#ingesting-transactions) live transaction data from the Stellar network, your machines should have enough extra RAM to hold Captive Core's in-memory database (~3GB).
+
+- In the above case, you should also take care to allocate enough space (on the order of ~20 GBs [**I MADE THIS UP** based vaguely [on this](https://github.com/stellar/stellar-core/issues/2942#issuecomment-790016941)]) to your `/tmp` directory for Captive Core to cache ledger information while it runs. You can also set a `TMPDIR` environmental variable ([or equivalent](https://golang.org/pkg/os/#TempDir) for your OS) to change the directory being used.
+
+- Other disk space requirements depend on how much of the network's history you'd like to serve from your Horizon instance; this could be anywhere from a few GBs to tens of TBs for the full ingested pubnet ledger history.

--- a/content/docs/run-api-server/prerequisites.mdx
+++ b/content/docs/run-api-server/prerequisites.mdx
@@ -11,6 +11,6 @@ As far as system requirements go, there are a few main things to keep in mind:
 
 - If you plan on [ingesting](./running.mdx#ingesting-transactions) live transaction data from the Stellar network, your machines should have enough extra RAM to hold Captive Core's in-memory database (~3GB).
 
-- In the above case, you should also take care to allocate enough space (on the order of ~20 GBs [**I MADE THIS UP** based vaguely [on this](https://github.com/stellar/stellar-core/issues/2942#issuecomment-790016941)]) to your `/tmp` directory for Captive Core to cache ledger information while it runs. You can also set a `TMPDIR` environmental variable ([or equivalent](https://golang.org/pkg/os/#TempDir) for your OS) to change the directory being used.
+- In the above case, you should also take care to allocate enough space (on the order of ~20 GBs to your `/tmp` directory for Captive Core to cache ledger information while it runs. You can also set a `TMPDIR` environmental variable ([or equivalent](https://golang.org/pkg/os/#TempDir) for your OS) to change the directory being used, at least until a flag is [introduced](https://github.com/stellar/go/issues/3437) to customize this through Horizon itself.
 
 - Other disk space requirements depend on how much of the network's history you'd like to serve from your Horizon instance; this could be anywhere from a few GBs to tens of TBs for the full ingested pubnet ledger history.

--- a/content/docs/run-api-server/running.mdx
+++ b/content/docs/run-api-server/running.mdx
@@ -43,6 +43,9 @@ The log line above announces that Horizon is ready to serve client requests. Nex
 ## Ingesting Transactions
 Horizon provides most of its utility through ingested data, and your Horizon server can be configured to listen for and ingest transaction results from the Stellar network. However, this option is disabled by default.
 
+**We highly recommend having more than one ingesting instance**, as this makes it easier to avoid downtime during upgrades and adds resilience to your infrastructure, ensuring you always have the latest network data.
+
+
 ### Ingesting Live Data 
 To **enable** ingestion, you must either pass `--ingest=true` on the command line or set the `INGEST` environment variable to "true". Note that you can have multiple ingesting machines in your cluster.
 

--- a/content/docs/run-api-server/running.mdx
+++ b/content/docs/run-api-server/running.mdx
@@ -41,10 +41,10 @@ The log line above announces that Horizon is ready to serve client requests. Nex
 
 
 ## Ingesting Transactions
+
 Horizon provides most of its utility through ingested data, and your Horizon server can be configured to listen for and ingest transaction results from the Stellar network. However, this option is disabled by default.
 
 **We highly recommend having more than one ingesting instance**, as this makes it easier to avoid downtime during upgrades and adds resilience to your infrastructure, ensuring you always have the latest network data.
-
 
 ### Ingesting Live Data 
 To **enable** ingestion, you must either pass `--ingest=true` on the command line or set the `INGEST` environment variable to "true". Note that you can have multiple ingesting machines in your cluster.
@@ -53,7 +53,6 @@ To **enable** ingestion, you must either pass `--ingest=true` on the command lin
 To ingest *historical* data from Stellar Core, you need to run `horizon db reingest range <start> <end>`. If you're running a [full validator](../run-core-node/index.mdx#full-validator) with published history archive(s), for example, you might want to ingest the network's entire history. You can run this process in the background while your Horizon server is up. This continuously decrements the `history.elder_ledger` in your `/metrics` endpoint until `NUM_LEDGERS` is reached and the backfill is complete.
 
 ### Reingesting Ledgers
-
 To reingest older ledgers—occasionally necessary after a version upgrade—or to ingest ledgers closed by the network before you started Horizon use the `horizon db reingest range <start> <end>` command:
 
 <CodeExample>
@@ -68,7 +67,6 @@ horizon3> horizon db reingest range 20001 30000
 </CodeExample>
 
 This allows reingestion to be split up and done in parallel by multiple Horizon processes.
-
 
 ### Managing Storage for Historical Data
 Over time, the recorded network history will grow unbounded, increasing storage used by the database. Horizon needs sufficient disk space to expand the data ingested from Stellar Core. Unless you need to maintain a [history archive](../run-core-node/publishing-history-archives.mdx), you may configure Horizon to only retain a certain number of ledgers in the database. This is done using the `--history-retention-count` flag or the `HISTORY_RETENTION_COUNT` environment variable. Set the value to the number of recent ledgers you wish to keep around, and every hour the Horizon subsystem will reap expired data. Alternatively, you may execute the command `horizon db reap` to force a collection.


### PR DESCRIPTION
Highlights:
 - simplified commands
 - added system requirements
 - clarified how `/metrics` works (which closes #330).