### PR TITLE
Changed "it's" (it is) to "its" in a few places

### DIFF
--- a/content/docs/start/list-of-operations.mdx
+++ b/content/docs/start/list-of-operations.mdx
@@ -538,7 +538,7 @@ Result: `BeginSponsoringFutureReservesResult`
 
 | Parameters  | Type       | Description                                     |
 | ----------- | ---------- | ----------------------------------------------- |
-| SponsoredID | account ID | Account that will have it's reserves sponsored. |
+| SponsoredID | account ID | Account that will have its reserves sponsored.  |
 
 Possible errors:
 
@@ -574,13 +574,13 @@ This operation is a union with **two** possible types -
 
 | Union Type | Parameters | Type | Description |
 | --- | --- | --- | --- |
-| REVOKE_SPONSORSHIP_LEDGER_ENTRY | LedgerKey | ledgerKey | Ledger key that holds information to identify a specific ledgerEntry that may have it's sponsorship modified. See [LedgerKey](../glossary/miscellaneous-core-objects.mdx#LedgerKey) for more information. |
+| REVOKE_SPONSORSHIP_LEDGER_ENTRY | LedgerKey | ledgerKey | Ledger key that holds information to identify a specific ledgerEntry that may have its sponsorship modified. See [LedgerKey](../glossary/miscellaneous-core-objects.mdx#LedgerKey) for more information. |
 
 Or
 
 | Union Type | Parameters | Type | Description |
 | --- | --- | --- | --- |
-| REVOKE_SPONSORSHIP_SIGNER | Signer | {account ID, Signer Key} | Signer that may have it's sponsorship modified. |
+| REVOKE_SPONSORSHIP_SIGNER | Signer | {account ID, Signer Key} | Signer that may have its sponsorship modified. |
 
 Possible errors:
 


### PR DESCRIPTION
I was scrolling through the docs and I noticed a few things referenced with "it's" that should've been "its". Nothing substantial, I know, but I'd like to help improve Stellar and this seems like a simple enough first step. :P