### PR TITLE
Fix a link and remove a redundant character in testnet.mdx

### DIFF
--- a/content/docs/glossary/testnet.mdx
+++ b/content/docs/glossary/testnet.mdx
@@ -41,9 +41,9 @@ If you are having trouble submitting transactions to the testnet, you may need t
 
 In order to preserve a good experience for developers, the SDF testnet is periodically reset to the genesis (initial) ledger. Resets declutter the network, remove spam, minimize the time required to catch up to the latest ledger, and help maintain the system over time.
 
-A reset clears all ledger entries (such as accounts, trustlines, offers, etc), transactions, and historical data from both Stellar Core and\ Horizon, which is why developers should not rely on the persistence of any accounts or on the state of any balances when using testnet.
+A reset clears all ledger entries (such as accounts, trustlines, offers, etc), transactions, and historical data from both Stellar Core and Horizon, which is why developers should not rely on the persistence of any accounts or on the state of any balances when using testnet.
 
-After a reset, you will need to take a few steps to re-join and re-synch to the testnet. Those steps are outlined [here](https://github.com/stellar/packages#testnet-reset), along with line-by-line instructions for people using core + horizon ubuntu packages. If you need help with other packages, check [Stellar's Stack Exchange](https://stellar.stackexchange.com/) for guidance.
+After a reset, you will need to take a few steps to re-join and re-synch to the testnet. Those steps are outlined [here](https://github.com/stellar/packages/blob/master/docs/testnet-reset.md), along with line-by-line instructions for people using core + horizon ubuntu packages. If you need help with other packages, check [Stellar's Stack Exchange](https://stellar.stackexchange.com/) for guidance.
 
 SDF will try to make testnet resets as painless as possible, and will announce the exact date at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/), and via several of Stellar’s online developer communities.
 


### PR DESCRIPTION
The link to re-join and re-sync the testnet was broken.