### PR TITLE
First pass on dropping Watcher references

### DIFF
--- a/content/docs/run-core-node/configuring.mdx
+++ b/content/docs/run-core-node/configuring.mdx
@@ -21,8 +21,6 @@ This doc works best in conjunction with concrete config examples, so as you read
 
 - If you want to connect to the public network, check out this [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg). It includes a properly crafted quorum set with all the current [Tier 1 validators](./tier-1-orgs.mdx), which is a good place to start for most configurations. This node is set up to both [validate](#validating) and write history to a [public archive](./publishing-history-archives.mdx), but you can disable either feature to adjust this config so it's a little lighter.
 
-- Here's a config for a [pubnet watcher](https://github.com/stellar/packages/blob/master/docs/stellar-core_pubnet_watcher.cfg). It's a little out of date — it still uses the old method for quorum set generation — but we'll fix it soon.
-
 ## Database
 
 Stellar Core stores two copies of the ledger: one in a SQL database and one in XDR files on local disk called [buckets](#buckets). The database is consulted during consensus, and modified atomically when a transaction set is applied to the ledger. It's random access, fine-grained, and fast.
@@ -70,7 +68,7 @@ If you run more than one node, set the `HOME_DOMAIN` common to those nodes using
 
 ## Choosing Your Quorum Set
 
-No matter what kind of node you run — Watcher, Basic Validator, Full Validator, or Archiver — you need to select a quorum set, which consists of validators (grouped by organization) that your node checks with to determine whether to apply a transaction set to a ledger. If you want to know more about how qorum sets work, check this article about [how Stellar approaches quorums](https://www.stellar.org/developers-blog/why-quorums-matter-and-how-stellar-approaches-them). If you want to see what a quorum set consisting of all the Tier 1 validators looks like — at tried and true setup — check out the [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg)
+No matter what kind of node you run — Basic Validator, Full Validator, or Archiver — you need to select a quorum set, which consists of validators (grouped by organization) that your node checks with to determine whether to apply a transaction set to a ledger. If you want to know more about how qorum sets work, check this article about [how Stellar approaches quorums](https://www.stellar.org/developers-blog/why-quorums-matter-and-how-stellar-approaches-them). If you want to see what a quorum set consisting of all the Tier 1 validators looks like — at tried and true setup — check out the [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg)
 
 A good quorum set:
 

--- a/content/docs/run-core-node/index.mdx
+++ b/content/docs/run-core-node/index.mdx
@@ -7,6 +7,8 @@ Stellar is a peer-to-peer network made up of nodes, which are computers that kee
 
 You don’t need to run a node to build on Stellar: you can start developing with your [SDK of choice](../software-and-sdks/index.mdx), and use public instances of Horizon to query the ledger and submit transactions right away. In fact, the Stellar Development Foundation offers two public instances of Horizon — one for the public network and one for the testnet — which you can read more about in our [API reference docs](../.././api/introduction/index.mdx). [Lobstr](https://horizon.stellar.lobstr.co), [Satoshipay](https://stellar-horizon.satoshipay.io), and [Coinqvest](https://horizon.stellar.coinqvest.com) also offer public Horizon instances.
 
+Even if you *do* want to run your [own instance of Horizon](./run-api-server/index.mdx), it bundles its own version of Core and manages its lifetime entirely, so there's no need to run a standalone instance.
+
 If you’re serious about building on Stellar, have a production-level product or service that requires high-availability access network, or want to help increase network health and decentralization, then you probably _do_ want to run a node, or even a trio of nodes (more on that in the [Tier 1 section](./tier-1-orgs.mdx)). At that point, you have a choice: you can pay a service provider like [Blockdaemon](https://app.blockdaemon.com/marketplace/categories/-/stellar-horizon) to set up and run your node for you, or you can do it yourself.
 
 If you’re going the DIY route, this section of the docs is for you. It explains the technical and operational aspects of installing, configuring, and maintaining a Stellar Core node, and should help you figure out the best way to set up your Stellar integration.
@@ -23,39 +25,28 @@ The basic flow, which you can navigate through using the menu on the left, goes 
 
 ## Types of nodes
 
-All nodes perform the same basic functions: they run Stellar Core, connect to peers, submit transactions, store the state of the ledger in a SQL [database](./configuring.mdx#database), and keep a duplicate copy of the ledger in flat XDR files called [buckets](./configuring.mdx#buckets). All nodes also support [Horizon](../run-api-server/index.mdx), the Stellar API.
+All nodes perform the same basic functions: they run Stellar Core, connect to peers, submit transactions, store the state of the ledger in a SQL [database](./configuring.mdx#database), and keep a duplicate copy of the ledger in flat XDR files called [buckets](./configuring.mdx#buckets). Though all nodes also support [Horizon](../run-api-server/index.mdx), the Stellar API, this is a deprecated way of architecting your system and will be discontinued soon. If you want to run Horizon, you don't need a separate Stellar Core node.
 
 In addition to those basic functions, there are two key configuration options that determine how a node behaves. A node can:
 
 - Participate in consensus to [validate transactions](./configuring.mdx#validating)
 - Publish an [archive](./publishing-history-archives.mdx) that other nodes can consult to find the complete history of the network.
 
-To make things easier, we’ll define four types of nodes based on permutations of those two options: **Watcher**, **Basic Validator**, **Full Validator**, and **Archiver**. You’ll notice that they _all_ support Horizon and submit transactions to the network:
+To make things easier, we’ll define four types of nodes based on permutations of those two options: **Basic Validator**, **Full Validator**, and **Archiver**. You’ll notice that they _all_ support Horizon and submit transactions to the network:
 
 | Type of Node | Supports Horizon | Submits Transactions | Validates Transactions | Publishes History |
 | --- | --- | --- | --- | --- |
-| **Watcher** | :heavy_check_mark: | :heavy_check_mark: |  |  |
 | **Basic Validator** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |  |
 | **Full Validator** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | **Archiver** | :heavy_check_mark: | :heavy_check_mark: |  | :heavy_check_mark: |
 
 So why choose one type over another? Let’s break it down a bit and take a look at what each type is good for.
 
-### Watcher
-
-#### Non-validating, no public archive
-
-A Watcher is the lightest node you can run. It keeps track of the ledger and submits transactions for possible inclusion, but it is _not_ configured to participate in validation or to publish a history archive, which means it doesn’t do anything to support the network or increase decentralization.
-
-Watchers pair well with Horizon, and if all you need is a Horizon instance to query the ledger or submit transactions, a Watcher is probably the right choice for you. While there are public instances of Horizon you can use — namely those maintained by [SDF](../.././api/introduction/index.mdx), [Lobstr](https://horizon.stellar.lobstr.co), [Satoshipay](https://stellar-horizon.satoshipay.io), and [Coinqvest](https://horizon.stellar.coinqvest.com) — they’re all rate limited, so they won’t work if you need to scale your project or you want to offer your customers an SLA — 99% uptime, for instance.
-
-**Use a Watcher to run Horizon, and to ensure reliable access to the network.**
-
 ### Basic Validator
 
 #### Validating, no public archive
 
-A Basic Validator is a lot like a Watcher, and has the same advantages and similar operational requirements. The difference between the two is that a Basic Validator requires a secret key, and is [configured to participate in consensus](./configuring.mdx#validating) by voting on — and signing off on — changes to the ledger.
+A Basic Validator keeps track of the ledger and submits transactions for possible inclusion, but it is _not_ configured to participate publish history archives. It does require a secret key, and is [configured to participate in consensus](./configuring.mdx#validating) by voting on — and signing off on — changes to the ledger, meaning it supports the network and increases decentralization.
 
 The advantage: signatures can serve as official endorsements of specific ledgers in real time. That’s important if, for instance, you issue an asset on Stellar that represents a real-world asset: you can let your customers know that you will only honor transactions and redeem assets from ledgers signed by your validator, and in the unlikely scenario that something happens to the network, you can use your node as the final arbiter of truth. Setting up your node as a validator allows you to resolve any questions _up front and in writing_ about how you plan to deal with disasters and disputes.
 
@@ -69,7 +60,7 @@ A Full Validator is the same as a Basic Validator except that it also publishes 
 
 When other nodes join the network — or experience difficulty and temporarily fall out of sync — they can consult archives offered by Full Validators to catch up on the history of the network. Redundant archives prevent a single point of failure, and allow network participants to verify the veracity of a given history.
 
-Full Validators can support Horizon, but generally, organizations that run them don’t use them to query network data or submit transactions. In fact, they often run a Watcher to handle Horizon _in addition_ to Full Validators. Most of those organizations are also part of — or on track to join — [Tier 1](./tier-1-orgs.mdx), which is a core group of network participants who run three Full Validators to contribute maximum redundancy.
+Generally, organizations that run Full Validators don't use them to query network data or submit transactions. Most of those organizations are also part of — or on track to join — [Tier 1](./tier-1-orgs.mdx), which is a core group of network participants who run three Full Validators to contribute maximum redundancy.
 
 **Use a Full Validator to sign off on transactions, and to contribute to the health and decentralization of the network.**
 

--- a/content/docs/run-core-node/prerequisites.mdx
+++ b/content/docs/run-core-node/prerequisites.mdx
@@ -3,7 +3,7 @@ title: Prerequisites
 order: 20
 ---
 
-You can install Stellar Core a [number of different ways](./installation.mdx), and once you do, you can [configure](./configuring.mdx) it to participate in the network on a several [different levels](./index.mdx#types-of-nodes): it can be a Watcher, a Basic Validator, or a Full Validator. No matter how you install Stellar Core or what kind of node you run, however, you need to set up to connect to the peer-to-peer network, store the state of the ledger in a SQL [database](configuring.mdx#database), and most likely connect to [Horizon](../.././api/introduction/index.mdx), the Stellar API.
+You can install Stellar Core a [number of different ways](./installation.mdx), and once you do, you can [configure](./configuring.mdx) it to participate in the network on a several [different levels](./index.mdx#types-of-nodes): it can be either a Basic Validator or a Full Validator. No matter how you install Stellar Core or what kind of node you run, however, you need to set up to connect to the peer-to-peer network and store the state of the ledger in a SQL [database](configuring.mdx#database).
 
 ## Compute Requirements
 

--- a/content/docs/run-core-node/publishing-history-archives.mdx
+++ b/content/docs/run-core-node/publishing-history-archives.mdx
@@ -5,7 +5,7 @@ order: 50
 
 import { CodeExample } from "components/CodeExample";
 
-If you want to run a [Full Validator](./index.mdx#full-validator) or an [Archiver](./index.mdx#archiver), you need to set up your node to publish a history archive. You can host an archive using a blob store such as Amazon's s3 or Digital Ocean's spaces, or you can simply serve a local archive directly via an HTTP server such as Nginx or Apache. If you're setting up a [Watcher](index.mdx#watcher) or a [Basic Validator](index.mdx#basic-validator), you can skip this section. No matter what kind of node you're planning to run, make sure to set it up to `get` history, which is covered in [Configuration](./configuring.mdx).
+If you want to run a [Full Validator](./index.mdx#full-validator) or an [Archiver](./index.mdx#archiver), you need to set up your node to publish a history archive. You can host an archive using a blob store such as Amazon's s3 or Digital Ocean's spaces, or you can simply serve a local archive directly via an HTTP server such as Nginx or Apache. If you're setting up a [Basic Validator](index.mdx#basic-validator), you can skip this section. No matter what kind of node you're planning to run, make sure to set it up to `get` history, which is covered in [Configuration](./configuring.mdx).
 
 ## Caching and History Archives
 


### PR DESCRIPTION
This drops the most obvious references to the now-deprecated Watcher nodes. 

There's still quite a lot to be done to remove all of the additional references that recommend or mention various ways to combine standalone Stellar Core nodes with Horizon (which we no longer want people doing due to Captive Core in Horizon 2.x, of course).