### PR TITLE
Clarify that fee bumps behave like normal TXs

### DIFF
--- a/content/docs/glossary/fee-bumps.mdx
+++ b/content/docs/glossary/fee-bumps.mdx
@@ -2,7 +2,7 @@
 title: Fee-Bump Transactions
 order:
 ---
-A fee-bump transaction enables any account to pay the fee for an existing [transaction](./transactions.mdx) without the need to re-sign the existing transaction or manage sequence numbers.  They're useful if you need to increase the fee on a pre-signed transaction, or if you want to build a service that covers user fees.  Unlike a regular transaction, which contains 1-100 [operations](./operations.mdx), a fee-bump transaction contains a single [transaction envelope](./transactions.mdx/#transaction-envelopes).     
+A fee-bump transaction enables any account to pay the fee for an existing [transaction](./transactions.mdx) without the need to re-sign the existing transaction or manage sequence numbers.  They're useful if you need to increase the fee on a pre-signed transaction, or if you want to build a service that covers user fees.  Like a regular transaction, these are submitted to the [`/transactions` endpoint](../../../api/resources/transactions/index.mdx).  *Unlike* a regular transaction, however, which contains 1-100 [operations](./operations.mdx), a fee-bump transaction contains a single [transaction envelope](./transactions.mdx/#transaction-envelopes). 
 
 ## Fee-Bump Transaction Attributes
 


### PR DESCRIPTION
This should resolve any ambiguity about how fee-bump transactions should be submitted. (In other words, they aren't special and don't need an entry in the [API Reference](https://developers.stellar.org/api/).)