### PR TITLE
Drop references to the old docs on the Welcome page.

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -9,7 +9,7 @@ This is the authoritative guide to all things Stellar. Here, you will find helpf
 
 In addition to the docs here, you'll also see a link at the bottom of the left nav to the API Reference. You should check those out, too: that's a resource most developers consult as they build on Stellar.
 
-As you read through these docs, you may find bugs, errors, typos, or omissions. When you do, please file PRs or issues in [this repo](https://github.com/stellar/new-docs/issues/new) or make a report using [this typeform survey](https://stellarform.typeform.com/to/suEIZI).
+As you read through these docs, you may find bugs, errors, typos, or omissions. When you do, please file PRs or issues in [this repo](https://github.com/stellar/new-docs/issues/new). Like the Stellar codebase, the docs are open source, so we welcome and appreciate your contributions!
 
 A rundown of what's here:
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -5,13 +5,11 @@ order: -100
 
 import { ReadMore } from "components/ReadMore";
 
-Right now, you're looking at the **new Stellar docs**, which are a work in progress. These new docs will live alongside the [existing Stellar docs](https://www.stellar.org/developers/guides/) until we complete the content, do some polish passes, root out and squash any bugs in the interface, and get feedback from the SDF and the Stellar community at large.
+This is the authoritative guide to all things Stellar. Here, you will find helpful tutorials, guides for deploying infrastructure, a glossary of common terms, and more! The documentation is designed to be modular, organized around different learning paths that expand as network use cases evolve. 
 
-The goal is to keep everything good from the existing docs but to streamline the navigation, improve the looks, and update the content to better reflect where things stand now. These new docs are also more modular — they're organized around different learning paths — and the plan is to add new paths as network use cases evolve.
+In addition to the docs here, you'll also see a link at the bottom of the left nav to the API Reference. You should check those out, too: that's a resource most developers consult as they build on Stellar.
 
-As you read through these new docs, you will likely find bugs, errors, typos, or omissions. When you do, please file PRs or issues in this repo or make a report using [this typeform survey](https://stellarform.typeform.com/to/suEIZI).
-
-In addition to the docs here, which are guides to building on Stellar, you'll also see a link at the bottom of the left nav to the API Reference. You should check those out, too: that's a resource most developers consult as they build on Stellar.
+As you read through these docs, you may find bugs, errors, typos, or omissions. When you do, please file PRs or issues in [this repo](https://github.com/stellar/new-docs/issues/new) or make a report using [this typeform survey](https://stellarform.typeform.com/to/suEIZI).
 
 A rundown of what's here:
 


### PR DESCRIPTION
Closes #344.