### PR TITLE
ensure installed packages are capped at anticipated versions

### DIFF
--- a/content/docs/building-apps/basic-wallet.mdx
+++ b/content/docs/building-apps/basic-wallet.mdx
@@ -590,7 +590,7 @@ You’ll notice a new package `@capacitor/core`. Let’s install and set that up
 
 ```bash
 # Install dependencies
-npm i -D @capacitor/core @capacitor/cli
+npm i -D @capacitor/core@2 @capacitor/cli@2
 
 # Initialize Capacitor
 npx cap init

--- a/content/docs/building-apps/project-setup.mdx
+++ b/content/docs/building-apps/project-setup.mdx
@@ -108,7 +108,7 @@ Amazing! Just a few more setup bits and we can get coding. I don’t know about 
 <CodeExample>
 
 ```bash
-npm i -D @stencil/postcss @stencil/sass autoprefixer @types/autoprefixer rollup-plugin-node-polyfills
+npm i -D @stencil/postcss@1 @stencil/sass@1 autoprefixer@9 @types/autoprefixer@9 rollup-plugin-node-polyfills
 ```
 
 </CodeExample>

--- a/content/docs/building-apps/xlm-payments.mdx
+++ b/content/docs/building-apps/xlm-payments.mdx
@@ -35,7 +35,7 @@ We'll call the component `stellar-loader`, and deselect both test files leaving 
 <CodeExample>
 
 ```tsx
-import Combinatorics from "js-combinatorics";
+import { BaseN } from "js-combinatorics";
 import { Component, h, State, Prop } from "@stencil/core";
 import { isEqual as loIsEqual, sample as loSample } from "lodash-es";
 
@@ -61,7 +61,7 @@ export class Loader {
   }
 
   generateChances(int: number) {
-    const baseN = Combinatorics.baseN([0, 1], int);
+    const baseN = new BaseN([0, 1], int);
 
     this.chances = baseN.toArray();
     this.getChance();


### PR DESCRIPTION
Seeing a couple of these issues popping up: https://stellar.stackexchange.com/questions/4549/sass-error-undefined-variable and I'm fairly certain it's due to a version issue so I'm capping the version number on the problematic packages.