### PR TITLE
Fixing typos, issuing vs supporting assets

### DIFF
--- a/content/docs/issuing-assets/publishing-asset-info.mdx
+++ b/content/docs/issuing-assets/publishing-asset-info.mdx
@@ -6,11 +6,11 @@ order: 40
 import { CodeExample } from "components/CodeExample";
 import { Alert } from "components/Alert";
 
-When you issue an asset, it’s crucial to provide clear information about it represents. On Stellar, you do that by linking your issuing account to a home domain, publishing a `stellar.toml` file on that domain, and making sure that file is complete.
+When you issue an asset, it’s crucial to provide clear information about what it represents. On Stellar, you do that by linking your issuing account to a home domain, publishing a `stellar.toml` file on that domain, and making sure that file is complete and accurate.
 
 The most successful asset issuers give exchanges, wallets, and potential buyers lots of information about themselves in order to establish trust. More information in your `stellar.toml` will mean:
 
-- Your asset gets _more_ exposure, and is listed on _more_ exchanges
+- Your asset gets _more_ exposure, and is listed on _more_ exchanges.
 - Your asset holders are _more_ confident in you and the assets you issue.
 - Your project will most likely be _more_ successful!
 
@@ -41,7 +41,7 @@ For each of those sections, we’ll let you know which fields are **required**, 
 
 <Alert>
 
-Note: it's a good idea to keep the sections in the order presented in [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md), which is also the order they're presented here. TOML requires arrays to be at the end, so if you move scramble the order, you may cause errors for TOML parsers
+Note: it's a good idea to keep the sections in the order presented in [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md), which is also the order they're presented here. TOML requires arrays to be at the end, so if you scramble the order, you may cause errors for TOML parsers.
 
 </Alert>
 
@@ -70,7 +70,7 @@ Basic information about your organization goes into a TOML **table** called `[DO
 - `ORG_URL` The HTTPS URL of your organization's official website. In order to prove the website is yours, _you must host your stellar.toml on the same domain you list here._ That way, exchanges and buyers can view the SSL certificate on your website, and feel reasonably confident that you are who you say you are.
 - `ORG_LOGO` A URL to a company logo, which will show up next to your organization on exchanges. This image should be a square aspect ratio transparent PNG, ideally of size 128x128. If you fail to provide a logo, the icon next to your organization will appear blank on many exchanges.
 - `ORG_PHYSICAL_ADDRESS` The physical address of your organization. We understand you might want to keep your work address private. At the very least, you should put the _city_ and _country_ in which you operate. A street address is ideal and provides a higher level of trust and transparency to your potential asset holders.
-- `ORG_OFFICIAL_EMAIL` The best contact email address for you organization. This should be hosted at the same domain as your official website.
+- `ORG_OFFICIAL_EMAIL` The best contact email address for your organization. This should be hosted at the same domain as your official website.
 
 #### Suggested
 
@@ -100,6 +100,8 @@ Information about the primary point(s) of contact for your organization goes int
 
 Information about the asset(s) you issue goes into a TOML [array of tables](https://github.com/toml-lang/toml#array-of-tables) called `[[CURRENCIES]]`. If you issue multiple assets, you can include them all in one stellar.toml. Each asset should have its own `[[CURRENCIES]]` entry.
 
+(These entries are also used for assets you support but don’t issue, but as this section focuses on issuing assets the language will reflect that.) 
+
 #### Required
 
 - `code` The asset code. This is one of two key pieces of information that identify your token. Without it, your token cannot be listed anywhere.
@@ -128,9 +130,11 @@ Enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) so people 
 
 `Access-Control-Allow-Origin: *`
 
-Set a `text/plain` content type so that browsers render the contents, rather than prompting for a download. ‘content-type: text/plain’
+Set a `text/plain` content type so that browsers render the contents, rather than prompting for a download. 
 
-You should also use the `set_options` operation to set the home domain on your issueing account.
+`content-type: text/plain`
+
+You should also use the `set_options` operation to set the home domain on your issuing account.
 
 ## Sample code to set the home domain of your issuing account
 
@@ -303,3 +307,5 @@ fixed_number=10000
 [sep-0020]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md
 [seps]: https://github.com/stellar/stellar-protocol/tree/master/ecosystem
 [twilio-guide]: https://support.twilio.com/hc/en-us/articles/223183008-Formatting-International-Phone-Numbers
+
+


### PR DESCRIPTION
A few typos, and adding a caveat about the language used for assets (we share this doc with anchors who also support assets)