### PR TITLE
Redirect to add trailing slash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If TAG is not provided set default value
 TAG ?= stellar/developers:$(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 docker-build:
 	$(SUDO) docker build --label org.opencontainers.image.created="$(BUILD_DATE)" \

--- a/nginx/includes/server.conf
+++ b/nginx/includes/server.conf
@@ -6,16 +6,21 @@ location = / {
   # listening on. Since we listen on 80 but expose 8000 by default from docker
   # locally, the redirect was going to `localhost/docs` which doesn't have a
   # server listening.
-  return 302 $scheme://$http_host/docs;
+  return 302 $scheme://$http_host/docs/;
 }
 
 location / {
   try_files /public/$uri /public/$uri/index.html /static/$uri =404;
 }
 
+location ~* ^/(.*[^/])$ {
+  # Add trailing slashes
+  rewrite ^([^.]*[^/])$ $scheme://$http_host$1/ permanent;
+}
+
 # .+ (vs .*) is important to avoid a redirect loop when rewriting all
 # non-crawler requests to `/api/`
-location ~* ^/api/(?<path>.+)$ {
+location ~* ^/api/(?<path>.+)/$ {
   set $noJs false;
   set $needsCrawlerRedirect '';
 
@@ -28,6 +33,7 @@ location ~* ^/api/(?<path>.+)$ {
   if ($noJs = false) {
     rewrite ^/api/.*$ /api/;
   }
+
   # SEO optimization for API Reference. This lets crawlers only see the content
   # from each individual section.
   # UA check sourced from https://gist.github.com/thoop/8165802
@@ -39,6 +45,6 @@ location ~* ^/api/(?<path>.+)$ {
   # To avoid a redirect loop, we only redirect if it's not already on the no-js
   # request path.
   if ($needsCrawlerRedirect = 'true false') {
-    return 302 $scheme://$http_host/api/$path?javascript=false;
+    return 302 $scheme://$http_host/api/$path/?javascript=false;
   }
 }


### PR DESCRIPTION
Add trailing slashes on docs urls, to make sure you end up at the right place. I typed the url without a trailing slash and was suprised when it took me to the "wrong place".

For example:.
  https://developers.stellar.org/api/resources/effects/types/
    - takes you to the Effect Types section.
vs
  https://developers.stellar.org/api/resources/effects/types
    - Old behaviour: takes you to the top of the page
    - New behaviour: redirects to the above.

I opted to add slashes as that seems to be the convention we use in links.

I'm not an nginx wizard, so maybe there's a cleaner way to do the same behaviour?

(The other commit gets `yarn prod:build` working on osx, as the `date` util there doesn't have the `--rfc-3339` flag.)