### PR TITLE
Add link to stellar-quickstart docs

### DIFF
--- a/content/docs/run-core-node/installation.mdx
+++ b/content/docs/run-core-node/installation.mdx
@@ -19,7 +19,7 @@ If you are using Ubuntu 16.04 LTS, we provide the latest stable releases of [ste
 
 You may choose to install these packages individually, which offers the greatest flexibility but requires **manual** creation of the relevant configuration files and configuration of a **PostgreSQL** database.
 
-Most people, however, choose to install the **stellar-quickstart** package which configures a **Testnet** `stellar-core` and `stellar-horizon` both backed by a local PostgreSQL database. Once installed you can easily modify either the Stellar Core configuration if you want to connect to the public network.
+Most people, however, choose to install the [stellar-quickstart](https://github.com/stellar/packages/blob/master/docs/quickstart.md) package which configures a **Testnet** `stellar-core` and `stellar-horizon` both backed by a local PostgreSQL database. Once installed you can easily modify either the Stellar Core configuration if you want to connect to the public network.
 
 ## Installing from source
 


### PR DESCRIPTION
## What

Add link to the stellar-quickstart package docs where it's mentioned. Maybe it should point to the repo root, or the releases page instead? 

## Why

Makes it easier to find :)