### PR TITLE
Drops references to the now-deprecated AllowTrust operation

### DIFF
--- a/content/docs/glossary/clawback.mdx
+++ b/content/docs/glossary/clawback.mdx
@@ -71,9 +71,8 @@ function enableClawback(account, keys) {
   return server.submitTransaction(buildTx(
     account, keys, [
       sdk.Operation.setOptions({
-        setFlags: StellarSdk.AuthClawbackEnabledFlag | 
-                  StellarSdk.AuthRevocableFlag,
-      })
+        setFlags: sdk.AuthClawbackEnabledFlag | sdk.AuthRevocableFlag,
+      }),
     ],
   ));
 }
@@ -91,7 +90,7 @@ const establishTrustline = function (recipient, key) {
 };
 
 /// Retrieves latest account info for all accounts.
-async function getAccounts() {
+function getAccounts() {
   return Promise.all([
     server.loadAccount(A.publicKey()),
     server.loadAccount(B.publicKey()),
@@ -102,7 +101,7 @@ async function getAccounts() {
 /// Enables clawback on A, and establishes trustlines from C, B -> A.
 function preamble() {
   return getAccounts().then(function (accounts) {
-    let [ accountA, accountB, accountC] = accounts;
+    let [ accountA, accountB, accountC ] = accounts;
     return enableClawback(accountA, A)
       .then(Promise.all([
         establishTrustline(accountB, B),
@@ -187,24 +186,23 @@ These snippets will help us with the final composition: making some payments to 
 <CodeExample>
 
 ```js
-async function examplePaymentClawback() {
-  await getAccounts().then(function(accounts) {
-    let [ accountA, accountB, accountC] = accounts;
+function examplePaymentClawback() {
+  return getAccounts().then(function(accounts) {
+    let [ accountA, accountB, accountC ] = accounts;
     return  makePayment(accountB, accountA, A, "1000")
       .then(makePayment(accountC, accountB, B, "500"))
       .then(doClawback( accountA, A, accountC, "250"));
-  });
-
-  // Let's check account balances to ensure that everything worked!
-  await getAccounts().then(showBalances);
+  })
+  .then(getAccounts)
+  .then(showBalances);
 }
 
-preamble().then(examplePaymentClawback());
+preamble().then(examplePaymentClawback);
 ```
 
 </CodeExample>
 
-After running our example (e.g. via `preamble().then(examplePaymentClawback());`), we should see the balances reflect the example flow:
+After running our example, we should see the balances reflect the example flow:
 
 <CodeExample Title="Example Output">
 
@@ -216,7 +214,7 @@ GC2BK: 250
 
 </CodeExample>
 
-Notice that GCIHA (this is Account A, the issuer) holds none of the asset, despite clawing back 250 from Account C. This should drive home the fact that clawed-back assets are *burned*, not transferred.
+Notice that `GCIHA` (this is Account A, the issuer) holds none of the asset, despite clawing back 250 from Account C. This should drive home the fact that clawed-back assets are *burned*, not transferred.
 
 _(It may be strange that A never holds any tokens of its custom asset, but that's exactly how issuing works: you create value where there used to be none. Sending an asset to its issuing account is *equivalent* to burning it, and auditing the total amount of an asset in existence is one of the benefits of properly distributing an asset via a [distribution account](../issuing-assets/how-to-issue-an-asset.mdx#why-have-separate-accounts-for-issuing-and-distribution), which we avoid doing here for example brevity.)_
 
@@ -273,10 +271,9 @@ function exampleClaimableBalanceClawback() {
     .then(function(accounts) {
       let [ accountA, accountB, accountC ] = accounts;
 
-      return makePayment(accountB, accountA, A, "1000").catch(txCheck)
-        .then(() => createClaimable(accountB, B, accountC, "500").catch(txCheck))
-        .then((txResp) => clawbackClaimable(accountA, A, getBalanceId(txResp)))
-        .catch(txCheck);
+      return makePayment(accountB, accountA, A, "1000")
+        .then(() => createClaimable(accountB, B, accountC, "500"))
+        .then((txResp) => clawbackClaimable(accountA, A, getBalanceId(txResp)));
     })
     .then(getAccounts)
     .then(showBalances);
@@ -285,7 +282,7 @@ function exampleClaimableBalanceClawback() {
 
 </CodeExample>
 
-After running `examplePaymentClawback()`, we should see the balances reflect our flow:
+After running `preamble().then(examplePaymentClawback)`, we should see the balances reflect our flow:
 
 <CodeExample Title="Example Output">
 
@@ -301,5 +298,105 @@ Note that after a particular claimable balance has been *claimed*, this method n
 
 Further note the divergence from the [earlier example][ex1]: you can't do a *partial* clawback of the claimable balance. It's an all-or-nothing operation. 
 
+### Example: Selectively Enabling Clawback
+When you enable the `AUTH_CLAWBACK_ENABLED_FLAG` on your account, it will make all future trustlines have clawback enabled for any of your issued assets. This may not always be desireable: you may want certain assets to behave as they did before. Though you could work around this by reissuing assets from a "dedicated clawback" account, you can also simply disable clawbacks for certain trustlines by clearing the `TRUST_LINE_CLAWBACK_ENABLED_FLAG` on a trustline.
+
+In the following example, we'll have an account (Account A, as before) issue a new asset and distribute it to a second account (Account B). We won't reintroduce Account C like in the earlier examples in order to keep things simple. Then, we'll demonstrate how A claws back some of the asset from B, then clears the trustline and can no longer claw back the asset.
+
+First, let's prepare the accounts (note that we are relying here on helper functions defined in the earlier examples):
+
+<CodeExample title="Preamble, Redux">
+
+```js
+function getAccounts() {
+  return Promise.all([
+    server.loadAccount(A.publicKey()),
+    server.loadAccount(B.publicKey()),
+  ]);
+}
+
+function preambleRedux() {
+  return getAccounts().then((accounts) => {
+    return enableClawback(accounts[0], A)
+      .then(() => establishTrustline(accounts[1], B));
+  });
+}
+```
+
+</CodeExample>
+
+Now, let's distribute some of our asset to Account B, just to claw it back. Then, we'll clear the flag from the trustline and show that another clawback isn't possible:
+
+<CodeExample title="Selectively Enabling Clawback">
+
+```js
+function disableClawback(issuerAccount, issuerKeys, forTrustor) {
+  return server.submitTransaction(buildTx(
+    issuerAccount, issuerKeys, [
+      sdk.Operation.setTrustLineFlags({
+        trustor: forTrustor.accountId(), 
+        asset: ASSET,   // defined in the (original) preamble
+        flags: {
+          clawbackEnabled: false,
+        },
+      }),
+    ]
+  ));
+}
+
+function exampleSelectiveClawback() {
+  return getAccounts().then((accounts) => {
+    let [ accountA, accountB ] = accounts;
+    return makePayment(accountB, accountA, A, "1000")
+      .then(getAccounts).then(showBalances)
+      .then(() => doClawback(accountA, A, accountB, "500"))
+      .then(getAccounts).then(showBalances)
+      .then(() => disableClawback(accountA, A, accountB))
+      .then(() => doClawback(accountA, A, accountB, "500"))
+      .catch((err) => {
+        if (err.response && err.response.data) {
+          // Note that this is a *very* specific way to check for an error, and
+          // you should probably never do it this way.
+          // We do this here to demonstrate that the clawback error *does*
+          // occur as expected.
+          const opErrors = err.response.data.extras.result_codes.operations;
+          if (opErrors && opErrors.length > 0 &&
+              opErrors[0] === "op_no_clawback_enabled") {
+            console.info("Clawback failed, as expected!");
+          } else {
+            console.error("Uh-oh, some other failure occurred:", err.response.data.extras);
+          }
+        } else {
+          console.error("Uh-oh, unknown failure:", err);
+        }
+      });
+  })
+  .then(getAccounts)
+  .then(showBalances);
+}
+```
+
+</CodeExample>
+
+Run the example (e.g. via `preambleRedux().then(exampleSelectiveClawback)`) and observe its result:
+
+<CodeExample>
+
+```txt
+GCIHA: 0
+GDS5N: 1000
+GCIHA: 0
+GDS5N: 500
+Clawback failed, as expected!
+GCIHA: 0
+GDS5N: 500
+```
+
+</CodeExample>
+
+It's important to note that **clearing the clawback flag on a trustline is irreversible**: you cannot *set* the flag, only clear it. This behavior is intended and aligns with the earlier caveat that only *new* trustlines follow the [account's clawback flag](#setting-account-options): it's done so that you cannot retroactively "change the rules" on your asset's holders after they've established trustlines. If you'd like to enable clawback again, holders need to reissue their trustlines.
+
+
 [ex1]: #example:-payments
 [ex2]: #example:-claimable-balances
+[ex3]: #example:-selectively-enable-clawback

--- a/content/docs/glossary/multisig.mdx
+++ b/content/docs/glossary/multisig.mdx
@@ -28,7 +28,7 @@ Low Security:
 
 - [Transaction processing](./transactions.mdx)
   - Charging a fee or updating the sequence number for the source account
-- [Allow Trust](../start/list-of-operations.mdx#allow-trust) operation
+- [Allow Trust](../start/list-of-operations.mdx#allow-trust) and [Set Trust Line Flags](../start/list-of-operations.mdx#set-trust-line-flags) operations
   - Used to allow people to hold credit from this account without exposing the key that enables sending payments from this account.
 - [Bump Sequence](../start/list-of-operations.mdx#bump-sequence)
   - Modify the account's sequence number directly
@@ -87,9 +87,9 @@ This scheme is very flexible. You can require many signers to authorize payments
 
 ### Example 1: Anchors
 
-> You run an anchor that would like to keep its issuing key offline. That way, it's less likely a bad actor can get ahold of the anchor's key and start issuing credit improperly. However, your anchor needs to authorize people holding credit by running the `Allow Trust` operation. Before you issue credit to an account, you need to verify that account is OK.
+> You run an anchor that would like to keep its issuing key offline. That way, it's less likely a bad actor can get ahold of the anchor's key and start issuing credit improperly. However, your anchor needs to authorize people holding credit by running the [`Set Trust Line Flags` operation](../start/list-of-operations.mdx#set-trust-line-flags). Before you issue credit to an account, you need to verify that account is OK.
 
-Multisig allows you to do all of this without exposing the master key of your anchor. You can add another signing key to your account with the operation `Set Options`. This additional key should have a weight below your anchor account's medium threshold. Since `Allow Trust` is a low-threshold operation, this extra key authorizes users to hold your anchor's credit. But, since `Payment` is a medium-threshold operation, this key does not allow anyone who compromises your anchor to issue credit.
+Multisig allows you to do all of this without exposing the master key of your anchor. You can add another signing key to your account with the operation `Set Options`. This additional key should have a weight below your anchor account's medium threshold. Since `Set Trust Line Flags` is a low-threshold operation, this extra key authorizes users to hold your anchor's credit. But, since `Payment` is a medium-threshold operation, this key does not allow anyone who compromises your anchor to issue credit.
 
 Your account setup:
 

--- a/content/docs/glossary/multisig.mdx
+++ b/content/docs/glossary/multisig.mdx
@@ -28,7 +28,7 @@ Low Security:
 
 - [Transaction processing](./transactions.mdx)
   - Charging a fee or updating the sequence number for the source account
-- [Allow Trust](../start/list-of-operations.mdx#allow-trust) and [Set Trust Line Flags](../start/list-of-operations.mdx#set-trust-line-flags) operations
+- [Allow Trust](../start/list-of-operations.mdx#allow-trust) and [Set Trust Line Flags](../start/list-of-operations.mdx#set-trustline-flags) operations
   - Used to allow people to hold credit from this account without exposing the key that enables sending payments from this account.
 - [Bump Sequence](../start/list-of-operations.mdx#bump-sequence)
   - Modify the account's sequence number directly
@@ -87,7 +87,7 @@ This scheme is very flexible. You can require many signers to authorize payments
 
 ### Example 1: Anchors
 
-> You run an anchor that would like to keep its issuing key offline. That way, it's less likely a bad actor can get ahold of the anchor's key and start issuing credit improperly. However, your anchor needs to authorize people holding credit by running the [`Set Trust Line Flags` operation](../start/list-of-operations.mdx#set-trust-line-flags). Before you issue credit to an account, you need to verify that account is OK.
+> You run an anchor that would like to keep its issuing key offline. That way, it's less likely a bad actor can get ahold of the anchor's key and start issuing credit improperly. However, your anchor needs to authorize people holding credit by running the [`Set Trust Line Flags` operation](../start/list-of-operations.mdx#set-trustline-flags). Before you issue credit to an account, you need to verify that account is OK.
 
 Multisig allows you to do all of this without exposing the master key of your anchor. You can add another signing key to your account with the operation `Set Options`. This additional key should have a weight below your anchor account's medium threshold. Since `Set Trust Line Flags` is a low-threshold operation, this extra key authorizes users to hold your anchor's credit. But, since `Payment` is a medium-threshold operation, this key does not allow anyone who compromises your anchor to issue credit.
 

--- a/content/docs/glossary/operations.mdx
+++ b/content/docs/glossary/operations.mdx
@@ -17,6 +17,7 @@ Each operation falls under a specific threshold category: low, medium, or high. 
 
 - Low Security:
   - `AllowTrust`
+  - `SetTrustLineFlags`
   - `BumpSequence`
   - `ClaimClaimableBalance`
 - Medium Security:

--- a/content/docs/issuing-assets/control-asset-access.mdx
+++ b/content/docs/issuing-assets/control-asset-access.mdx
@@ -44,13 +44,13 @@ If the issuer wants to approve transactions on a case-by-base basis while allowi
 
 To intitiate a new operation, the holding account requests that the issuer approve and sign a transaction. Once the issuer inspects the operation and decides to approve it, they sandwich it between a set of operations, first granting authorization, then reducing it.  
 
-Here's a payment from A to B sandwiched between [`allow_trust`](../start/list-of-operations.mdx#allow-trust) operations:
+Here's a payment from A to B sandwiched between [`set_trust_line_flags`](../start/list-of-operations.mdx#allow-trust) operations:
 
-- Operation 1: Issuer uses `AllowTrust` to fully authorize account A, asset X
-- Operation 2: Issuer uses `AllowTrust` to fully authorize account B, asset X
+- Operation 1: Issuer uses `SetTrustLineFlags` to fully authorize account A, asset X
+- Operation 2: Issuer uses `SetTrustLineFlags` to fully authorize account B, asset X
 - Operation 3: Payment from A to B
-- Operation 4: Issuer uses `AllowTrust` to set account B, asset X to `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` state
-- Operation 5: Issuer uses `AllowTrust` to set account A, asset X to `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` state
+- Operation 4: Issuer uses `SetTrustLineFlags` to set account B, asset X to `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` state
+- Operation 5: Issuer uses `SetTrustLineFlags` to set account A, asset X to `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` state
 
 The authorization sandwich allows the issuer to inspect the specifc payment, and to grant authorization for it and it alone.  Since operations bundled in a transaction are simultaneous, A and B are only authorized for the specific, pre-approved payment operation.  Complete authorization does not extend beyond the specific transaction.
 

--- a/content/docs/issuing-assets/control-asset-access.mdx
+++ b/content/docs/issuing-assets/control-asset-access.mdx
@@ -44,7 +44,7 @@ If the issuer wants to approve transactions on a case-by-base basis while allowi
 
 To intitiate a new operation, the holding account requests that the issuer approve and sign a transaction. Once the issuer inspects the operation and decides to approve it, they sandwich it between a set of operations, first granting authorization, then reducing it.  
 
-Here's a payment from A to B sandwiched between [`set_trust_line_flags`](../start/list-of-operations.mdx#allow-trust) operations:
+Here's a payment from A to B sandwiched between [`set_trust_line_flags`](../start/list-of-operations.mdx#set-trustline-flags) operations:
 
 - Operation 1: Issuer uses `SetTrustLineFlags` to fully authorize account A, asset X
 - Operation 2: Issuer uses `SetTrustLineFlags` to fully authorize account B, asset X
@@ -157,5 +157,4 @@ except BaseHorizonError as e:
 ```
 
 </CodeExample>
-
 

--- a/content/docs/start/list-of-operations.mdx
+++ b/content/docs/start/list-of-operations.mdx
@@ -604,9 +604,7 @@ Possible errors:
 ## Set Trustline Flags
 [JavaScript](http://stellar.github.io/js-stellar-sdk/Operation.html#.setTrustLineFlags) | [Java](http://stellar.github.io/java-stellar-sdk/org/stellar/sdk/SetTrustLineFlags.Builder.html) | [Go](https://godoc.org/github.com/stellar/go/txnbuild#SetTrustLineFlags)
 
-Allows an issuing account to configure various authorization and trustline flags for all trustlines to an asset.
-
-TODO: More operation documentation here, borrow from `AllowTrust` above?
+Allows an issuing account to configure various authorization and trustline flags for all trustlines to an asset. This supercedes the deprecated [`AllowTrust`](#allow-trust), but the documentation there still applies. 
 
 Threshold: Low
 


### PR DESCRIPTION
Additionally, introduce an example on how to use `SetTrustLineFlags`.