### PR TITLE
Fix JSON responses in the API references to be valid JSON

### DIFF
--- a/content/api/resources/claimablebalances/list.mdx
+++ b/content/api/resources/claimablebalances/list.mdx
@@ -103,7 +103,7 @@ server
         "amount": "200.0000000",
         "sponsor": "GBVFLWXYCIGPO3455XVFIKHS66FCT5AI64ZARKS7QJN4NF7K5FOXTJNL",
         "last_modified_ledger": 38888,
-        "last_modified_time": "2020-02-26T19:29:16Z"
+        "last_modified_time": "2020-02-26T19:29:16Z",
         "claimants": [
           {
             "destination": "GBVFLWXYCIGPO3455XVFIKHS66FCT5AI64ZARKS7QJN4NF7K5FOXTJNL",
@@ -125,7 +125,7 @@ server
         "amount": "1.0000000",
         "sponsor": "GD2I2F7SWUHBAD7XBIZTF7MBMWQYWJVEFMWTXK76NSYVOY52OJRYNTIY",
         "last_modified_ledger": 49645,
-        "last_modified_time": "2020-03-26T19:29:16Z"
+        "last_modified_time": "2020-03-26T19:29:16Z",
         "claimants": [
           {
             "destination": "GAEJ2UF46PKAPJYED6SQ45CKEHSXV63UQEYHVUZSVJU6PK5Y4ZVA4ELU",
@@ -149,7 +149,7 @@ server
         "amount": "13.1200000",
         "sponsor": "GAEJ2UF46PKAPJYED6SQ45CKEHSXV63UQEYHVUZSVJU6PK5Y4ZVA4ELU",
         "last_modified_ledger": 64339,
-        "last_modified_time": "2020-04-26T19:29:16Z"
+        "last_modified_time": "2020-04-26T19:29:16Z",
         "claimants": [
           {
             "destination": "GD2I2F7SWUHBAD7XBIZTF7MBMWQYWJVEFMWTXK76NSYVOY52OJRYNTIY",
@@ -171,7 +171,7 @@ server
         "amount": "13.1200000",
         "sponsor": "GB5N4275ETC6A77K4DTDL3EFAQMN66PC7UITDUZUBM7Y6LDJP7EYSGOB",
         "last_modified_ledger": 66835,
-        "last_modified_time": "2020-04-27T19:29:16Z"
+        "last_modified_time": "2020-04-27T19:29:16Z",
         "claimants": [
           {
             "destination": "GD2I2F7SWUHBAD7XBIZTF7MBMWQYWJVEFMWTXK76NSYVOY52OJRYNTIY",

--- a/content/api/resources/claimablebalances/object.mdx
+++ b/content/api/resources/claimablebalances/object.mdx
@@ -84,23 +84,21 @@ When Horizon returns information about a claimable balance, it uses the followin
     {
       "destination": "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
       "predicate": {
-        {
-          "and": [
-            {
-              "or": [
-                {
-                  "relBefore": "12"
-                },
-                {
-                  "absBefore": "2020-08-26T11:15:39Z"
-                }
-              ]
-            },
-            {
-              "not": {"unconditional": true}
-            }
-          ]
-        }
+        "and": [
+          {
+            "or": [
+              {
+                "relBefore": "12"
+              },
+              {
+                "absBefore": "2020-08-26T11:15:39Z"
+              }
+            ]
+          },
+          {
+            "not": {"unconditional": true}
+          }
+        ]
       }
     }
   ],

--- a/content/api/resources/claimablebalances/single.mdx
+++ b/content/api/resources/claimablebalances/single.mdx
@@ -79,23 +79,21 @@ server
     {
       "destination": "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
       "predicate": {
-        {
-          "and": [
-            {
-              "or": [
-                {
-                  "relBefore": "12"
-                },
-                {
-                  "absBefore": "2020-08-26T11:15:39Z"
-                }
-              ]
-            },
-            {
-              "not": {"unconditional": true}
-            }
-          ]
-        }
+        "and": [
+          {
+            "or": [
+              {
+                "relBefore": "12"
+              },
+              {
+                "absBefore": "2020-08-26T11:15:39Z"
+              }
+            ]
+          },
+          {
+            "not": {"unconditional": true}
+          }
+        ]
       }
     }
   ],

--- a/content/api/resources/ledgers/single.mdx
+++ b/content/api/resources/ledgers/single.mdx
@@ -56,6 +56,7 @@ server
 <ExampleResponse title="Example Response">
 
 ```json
+{
   "_links": {
     "self": {
       "href": "https://horizon.stellar.org/ledgers/27146933"

--- a/content/api/resources/operations/object/create-claimable-balance.mdx
+++ b/content/api/resources/operations/object/create-claimable-balance.mdx
@@ -87,23 +87,21 @@ Creates a new claimable balance.
     {
       "destination": "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
       "predicate": {
-        {
-          "and": [
-            {
-              "or": [
-                {
-                  "relBefore": "12"
-                },
-                {
-                  "absBefore": "2020-08-26T11:15:39Z"
-                }
-              ]
-            },
-            {
-              "not": {"unconditional": true}
-            }
-          ]
-        }
+        "and": [
+          {
+            "or": [
+              {
+                "relBefore": "12"
+              },
+              {
+                "absBefore": "2020-08-26T11:15:39Z"
+              }
+            ]
+          },
+          {
+            "not": {"unconditional": true}
+          }
+        ]
       }
     }
   ]

--- a/content/api/resources/transactions/single.mdx
+++ b/content/api/resources/transactions/single.mdx
@@ -12,9 +12,9 @@ The single transaction endpoint provides information on a specific transaction.
 
 <Endpoint>
 
-|     |                               |
-| --- | ----------------------------- |
-| GET | /transactions/:transaction_id |
+|     |                                 |
+| --- | ------------------------------- |
+| GET | /transactions/:transaction_hash |
 
 </Endpoint>
 


### PR DESCRIPTION
I'm currently in the process of writing an automated tool to assist with finding out-dated or invalid API reference documentation, and this is some of the preliminary results: invalid JSON in response examples.