### PR TITLE
Issue #360: Updating examples to use simplified accounts

### DIFF
--- a/content/docs/glossary/claimable-balance.mdx
+++ b/content/docs/glossary/claimable-balance.mdx
@@ -156,7 +156,7 @@ func main() {
 	// Build, sign, and submit the transaction
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        &aAccount,
+			SourceAccount:        aAccount.AccountID,
 			IncrementSequenceNum: true,
 			BaseFee:              txnbuild.MinBaseFee,
 			// Use a real timeout in production!
@@ -269,7 +269,7 @@ await server.submitTransaction(tx).catch(function (err) {
 claimBalance := txnbuild.ClaimClaimableBalance{BalanceID: balanceId}
 tx, err = txnbuild.NewTransaction(
 	txnbuild.TransactionParams{
-		SourceAccount:        &aAccount, // or Account B, depending on the condition!
+		SourceAccount:        aAccount.AccountID, // or Account B, depending on the condition!
 		IncrementSequenceNum: true,
 		BaseFee:              txnbuild.MinBaseFee,
 		Timebounds:           txnbuild.NewInfiniteTimeout(),

--- a/content/docs/glossary/claimable-balance.mdx
+++ b/content/docs/glossary/claimable-balance.mdx
@@ -51,7 +51,6 @@ This operation will load the ClaimableBalanceEntry that corresponds to the Balan
 Once a ClaimableBalanceEntry has been claimed, it will be deleted.
 
 ## Example
-
 The below code demonstrates via both the JavaScript and Go [SDKs](../software-and-sdks/index.mdx) how an account ("Account A") can create a `ClaimableBalanceEntry` with two Claimants: Account A (itself) and "Account B" (another recipient).
 
 Each of these accounts can only claim the balance under certain, individual conditions. Namely, Account B has a full minute to claim the balance, after which Account A can "reclaim" the balance back for itself.
@@ -60,61 +59,51 @@ It's worth emphasizing that there is no "recovery" mechanism for a claimable bal
 
 <CodeExample>
 
-
 ```js
 const sdk = require("stellar-sdk");
 
 async function main() {
   let server = new sdk.Server("https://horizon-testnet.stellar.org");
 
-  let A = sdk.Keypair.fromSecret(
-    "SAQLZCQA6AYUXK6JSKVPJ2MZ5K5IIABJOEQIG4RVBHX4PG2KMRKWXCHJ",
-  );
-  let B = sdk.Keypair.fromPublicKey(
-    "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
-  );
+  let A = sdk.Keypair.fromSecret("SAQLZCQA6AYUXK6JSKVPJ2MZ5K5IIABJOEQIG4RVBHX4PG2KMRKWXCHJ");
+  let B = sdk.Keypair.fromPublicKey("GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP");
 
   // NOTE: Proper error checks are omitted for brevity; always validate things!
 
   let aAccount = await server.loadAccount(A.publicKey()).catch(function (err) {
-    console.error(`Failed to load ${A.publicKey()}: ${err}`);
-  });
-  if (!aAccount) {
-    return;
-  }
+    console.error(`Failed to load ${A.publicKey()}: ${err}`)
+  })
+  if (!aAccount) { return }
 
   // Create a claimable balance with our two above-described conditions.
-  let soon = Math.ceil(Date.now() / 1000 + 60); // .now() is in ms
+  let soon = Math.ceil((Date.now() / 1000) + 60); // .now() is in ms
   let bCanClaim = sdk.Claimant.predicateBeforeRelativeTime("60");
   let aCanReclaim = sdk.Claimant.predicateNot(
-    sdk.Claimant.predicateBeforeAbsoluteTime(soon.toString()),
+    sdk.Claimant.predicateBeforeAbsoluteTime(soon.toString())
   );
 
   // Create the operation and submit it in a transaction.
   let claimableBalanceEntry = sdk.Operation.createClaimableBalance({
     claimants: [
       new sdk.Claimant(B.publicKey(), bCanClaim),
-      new sdk.Claimant(A.publicKey(), aCanReclaim),
+      new sdk.Claimant(A.publicKey(), aCanReclaim)
     ],
     asset: sdk.Asset.native(),
     amount: "420",
   });
 
-  let tx = new sdk.TransactionBuilder(aAccount, { fee: sdk.BASE_FEE })
+  let tx = new sdk.TransactionBuilder(aAccount, {fee: sdk.BASE_FEE})
     .addOperation(claimableBalanceEntry)
     .setNetworkPassphrase(sdk.Networks.TESTNET)
     .setTimeout(180)
     .build();
 
   tx.sign(A);
-  let txResponse = await server
-    .submitTransaction(tx)
-    .then(function () {
-      console.log("Claimable balance created!");
-    })
-    .catch(function (err) {
-      console.error(`Tx submission failed: ${err}`);
-    });
+  let txResponse = await server.submitTransaction(tx).then(function() {
+    console.log("Claimable balance created!");
+  }).catch(function (err) {
+    console.error(`Tx submission failed: ${err}`)
+  });
 }
 ```
 
@@ -167,7 +156,7 @@ func main() {
 	// Build, sign, and submit the transaction
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        aAccount.AccountID,
+			SourceAccount:        &aAccount,
 			IncrementSequenceNum: true,
 			BaseFee:              txnbuild.MinBaseFee,
 			// Use a real timeout in production!
@@ -187,17 +176,15 @@ func main() {
 
 </CodeExample>
 
-
 At this point, the `ClaimableBalanceEntry` exists in the ledger, but we'll need its Balance ID to claim it. This can be acquired in a number of ways:
 
-1.  the submitter of the entry (Account A in this case) can retrieve the balance ID _prior_ to submitting the transaction;
-2.  the submitter parses the XDR of the transaction result's operations; **or**
-3.  someone queries the list of claimable balances (filtered accordingly, if necessary).
+ 1. the submitter of the entry (Account A in this case) can retrieve the balance ID *prior* to submitting the transaction; 
+ 2. the submitter parses the XDR of the transaction result's operations; **or**
+ 3. someone queries the list of claimable balances (filtered accordingly, if necessary).
 
 Either party could also check the `/effects` of the transaction, query `/claimable_balances` with different filters, etc. Note that while (1) may be unavailable in some SDKs as its just a helper, the other methods are universal.
 
 <CodeExample>
-
 
 ```js
 // Method 1: Not available in the JavaScript SDK yet.
@@ -205,9 +192,7 @@ Either party could also check the `/effects` of the transaction, query `/claimab
 // Method 2: Suppose `txResponse` comes from the transaction submission
 // above.
 let txResult = sdk.xdr.TransactionResult.fromXDR(
-  txResponse.result_xdr,
-  "base64",
-);
+  txResponse.result_xdr, "base64");
 let results = txResult.result().results();
 
 // We look at the first result since our first (and only) operation
@@ -218,17 +203,15 @@ console.log("Balance ID (2):", balanceId);
 
 // Method 3: Account B could alternatively do something like:
 let balances = await server
-  .claimableBalances()
-  .claimant(B.publicKey())
-  .limit(1) // there may be many in general
-  .order("desc") // so always get the latest one
-  .call()
-  .catch(function (err) {
-    console.error(`Claimable balance retrieval failed: ${err}`);
-  });
-if (!balances) {
-  return;
-}
+    .claimableBalances()
+    .claimant(B.publicKey())
+    .limit(1)       // there may be many in general
+    .order("desc")  // so always get the latest one
+    .call()
+    .catch(function(err) {
+      console.error(`Claimable balance retrieval failed: ${err}`)
+    });
+if (!balances) { return; }
 
 balanceId = balances.records[0].id;
 console.log("Balance ID (3):", balanceId);
@@ -262,19 +245,15 @@ balanceId := balances.Embedded.Records[0].BalanceID
 
 </CodeExample>
 
-
 With the claimable balance ID acquired, either Account B or A can actually submit a claim, depending on which predicate is fulfilled. We'll assume here that a minute has passed, so Account A just reclaims the balance entry.
 
 <CodeExample>
 
-
 ```js
-let claimBalance = sdk.Operation.claimClaimableBalance({
-  balanceId: balanceId,
-});
+let claimBalance = sdk.Operation.claimClaimableBalance({ balanceId: balanceId });
 console.log(A.publicKey(), "claiming", balanceId);
 
-let tx = new sdk.TransactionBuilder(aAccount, { fee: sdk.BASE_FEE })
+let tx = new sdk.TransactionBuilder(aAccount, {fee: sdk.BASE_FEE})
   .addOperation(claimBalance)
   .setNetworkPassphrase(sdk.Networks.TESTNET)
   .setTimeout(180)
@@ -282,7 +261,7 @@ let tx = new sdk.TransactionBuilder(aAccount, { fee: sdk.BASE_FEE })
 
 tx.sign(A);
 await server.submitTransaction(tx).catch(function (err) {
-  console.error(`Tx submission failed: ${err}`);
+  console.error(`Tx submission failed: ${err}`)
 });
 ```
 
@@ -290,7 +269,7 @@ await server.submitTransaction(tx).catch(function (err) {
 claimBalance := txnbuild.ClaimClaimableBalance{BalanceID: balanceId}
 tx, err = txnbuild.NewTransaction(
 	txnbuild.TransactionParams{
-		SourceAccount:        aAccount.AccountID, // or Account B, depending on the condition!
+		SourceAccount:        &aAccount, // or Account B, depending on the condition!
 		IncrementSequenceNum: true,
 		BaseFee:              txnbuild.MinBaseFee,
 		Timebounds:           txnbuild.NewInfiniteTimeout(),
@@ -305,6 +284,5 @@ check(err)
 ```
 
 </CodeExample>
-
 
 And that's it! At this point, since we opted for the "reclaim" path, Account A should have the same balance as what it started with (sans fees), and Account B should be unchanged.

--- a/content/docs/glossary/claimable-balance.mdx
+++ b/content/docs/glossary/claimable-balance.mdx
@@ -51,6 +51,7 @@ This operation will load the ClaimableBalanceEntry that corresponds to the Balan
 Once a ClaimableBalanceEntry has been claimed, it will be deleted.
 
 ## Example
+
 The below code demonstrates via both the JavaScript and Go [SDKs](../software-and-sdks/index.mdx) how an account ("Account A") can create a `ClaimableBalanceEntry` with two Claimants: Account A (itself) and "Account B" (another recipient).
 
 Each of these accounts can only claim the balance under certain, individual conditions. Namely, Account B has a full minute to claim the balance, after which Account A can "reclaim" the balance back for itself.
@@ -59,51 +60,61 @@ It's worth emphasizing that there is no "recovery" mechanism for a claimable bal
 
 <CodeExample>
 
+
 ```js
 const sdk = require("stellar-sdk");
 
 async function main() {
   let server = new sdk.Server("https://horizon-testnet.stellar.org");
 
-  let A = sdk.Keypair.fromSecret("SAQLZCQA6AYUXK6JSKVPJ2MZ5K5IIABJOEQIG4RVBHX4PG2KMRKWXCHJ");
-  let B = sdk.Keypair.fromPublicKey("GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP");
+  let A = sdk.Keypair.fromSecret(
+    "SAQLZCQA6AYUXK6JSKVPJ2MZ5K5IIABJOEQIG4RVBHX4PG2KMRKWXCHJ",
+  );
+  let B = sdk.Keypair.fromPublicKey(
+    "GAS4V4O2B7DW5T7IQRPEEVCRXMDZESKISR7DVIGKZQYYV3OSQ5SH5LVP",
+  );
 
   // NOTE: Proper error checks are omitted for brevity; always validate things!
 
   let aAccount = await server.loadAccount(A.publicKey()).catch(function (err) {
-    console.error(`Failed to load ${A.publicKey()}: ${err}`)
-  })
-  if (!aAccount) { return }
+    console.error(`Failed to load ${A.publicKey()}: ${err}`);
+  });
+  if (!aAccount) {
+    return;
+  }
 
   // Create a claimable balance with our two above-described conditions.
-  let soon = Math.ceil((Date.now() / 1000) + 60); // .now() is in ms
+  let soon = Math.ceil(Date.now() / 1000 + 60); // .now() is in ms
   let bCanClaim = sdk.Claimant.predicateBeforeRelativeTime("60");
   let aCanReclaim = sdk.Claimant.predicateNot(
-    sdk.Claimant.predicateBeforeAbsoluteTime(soon.toString())
+    sdk.Claimant.predicateBeforeAbsoluteTime(soon.toString()),
   );
 
   // Create the operation and submit it in a transaction.
   let claimableBalanceEntry = sdk.Operation.createClaimableBalance({
     claimants: [
       new sdk.Claimant(B.publicKey(), bCanClaim),
-      new sdk.Claimant(A.publicKey(), aCanReclaim)
+      new sdk.Claimant(A.publicKey(), aCanReclaim),
     ],
     asset: sdk.Asset.native(),
     amount: "420",
   });
 
-  let tx = new sdk.TransactionBuilder(aAccount, {fee: sdk.BASE_FEE})
+  let tx = new sdk.TransactionBuilder(aAccount, { fee: sdk.BASE_FEE })
     .addOperation(claimableBalanceEntry)
     .setNetworkPassphrase(sdk.Networks.TESTNET)
     .setTimeout(180)
     .build();
 
   tx.sign(A);
-  let txResponse = await server.submitTransaction(tx).then(function() {
-    console.log("Claimable balance created!");
-  }).catch(function (err) {
-    console.error(`Tx submission failed: ${err}`)
-  });
+  let txResponse = await server
+    .submitTransaction(tx)
+    .then(function () {
+      console.log("Claimable balance created!");
+    })
+    .catch(function (err) {
+      console.error(`Tx submission failed: ${err}`);
+    });
 }
 ```
 
@@ -156,7 +167,7 @@ func main() {
 	// Build, sign, and submit the transaction
 	tx, err := txnbuild.NewTransaction(
 		txnbuild.TransactionParams{
-			SourceAccount:        &aAccount,
+			SourceAccount:        aAccount.AccountID,
 			IncrementSequenceNum: true,
 			BaseFee:              txnbuild.MinBaseFee,
 			// Use a real timeout in production!
@@ -176,15 +187,17 @@ func main() {
 
 </CodeExample>
 
+
 At this point, the `ClaimableBalanceEntry` exists in the ledger, but we'll need its Balance ID to claim it. This can be acquired in a number of ways:
 
- 1. the submitter of the entry (Account A in this case) can retrieve the balance ID *prior* to submitting the transaction; 
- 2. the submitter parses the XDR of the transaction result's operations; **or**
- 3. someone queries the list of claimable balances (filtered accordingly, if necessary).
+1.  the submitter of the entry (Account A in this case) can retrieve the balance ID _prior_ to submitting the transaction;
+2.  the submitter parses the XDR of the transaction result's operations; **or**
+3.  someone queries the list of claimable balances (filtered accordingly, if necessary).
 
 Either party could also check the `/effects` of the transaction, query `/claimable_balances` with different filters, etc. Note that while (1) may be unavailable in some SDKs as its just a helper, the other methods are universal.
 
 <CodeExample>
+
 
 ```js
 // Method 1: Not available in the JavaScript SDK yet.
@@ -192,7 +205,9 @@ Either party could also check the `/effects` of the transaction, query `/claimab
 // Method 2: Suppose `txResponse` comes from the transaction submission
 // above.
 let txResult = sdk.xdr.TransactionResult.fromXDR(
-  txResponse.result_xdr, "base64");
+  txResponse.result_xdr,
+  "base64",
+);
 let results = txResult.result().results();
 
 // We look at the first result since our first (and only) operation
@@ -203,15 +218,17 @@ console.log("Balance ID (2):", balanceId);
 
 // Method 3: Account B could alternatively do something like:
 let balances = await server
-    .claimableBalances()
-    .claimant(B.publicKey())
-    .limit(1)       // there may be many in general
-    .order("desc")  // so always get the latest one
-    .call()
-    .catch(function(err) {
-      console.error(`Claimable balance retrieval failed: ${err}`)
-    });
-if (!balances) { return; }
+  .claimableBalances()
+  .claimant(B.publicKey())
+  .limit(1) // there may be many in general
+  .order("desc") // so always get the latest one
+  .call()
+  .catch(function (err) {
+    console.error(`Claimable balance retrieval failed: ${err}`);
+  });
+if (!balances) {
+  return;
+}
 
 balanceId = balances.records[0].id;
 console.log("Balance ID (3):", balanceId);
@@ -245,15 +262,19 @@ balanceId := balances.Embedded.Records[0].BalanceID
 
 </CodeExample>
 
+
 With the claimable balance ID acquired, either Account B or A can actually submit a claim, depending on which predicate is fulfilled. We'll assume here that a minute has passed, so Account A just reclaims the balance entry.
 
 <CodeExample>
 
+
 ```js
-let claimBalance = sdk.Operation.claimClaimableBalance({ balanceId: balanceId });
+let claimBalance = sdk.Operation.claimClaimableBalance({
+  balanceId: balanceId,
+});
 console.log(A.publicKey(), "claiming", balanceId);
 
-let tx = new sdk.TransactionBuilder(aAccount, {fee: sdk.BASE_FEE})
+let tx = new sdk.TransactionBuilder(aAccount, { fee: sdk.BASE_FEE })
   .addOperation(claimBalance)
   .setNetworkPassphrase(sdk.Networks.TESTNET)
   .setTimeout(180)
@@ -261,7 +282,7 @@ let tx = new sdk.TransactionBuilder(aAccount, {fee: sdk.BASE_FEE})
 
 tx.sign(A);
 await server.submitTransaction(tx).catch(function (err) {
-  console.error(`Tx submission failed: ${err}`)
+  console.error(`Tx submission failed: ${err}`);
 });
 ```
 
@@ -269,7 +290,7 @@ await server.submitTransaction(tx).catch(function (err) {
 claimBalance := txnbuild.ClaimClaimableBalance{BalanceID: balanceId}
 tx, err = txnbuild.NewTransaction(
 	txnbuild.TransactionParams{
-		SourceAccount:        &aAccount, // or Account B, depending on the condition!
+		SourceAccount:        aAccount.AccountID, // or Account B, depending on the condition!
 		IncrementSequenceNum: true,
 		BaseFee:              txnbuild.MinBaseFee,
 		Timebounds:           txnbuild.NewInfiniteTimeout(),
@@ -284,5 +305,6 @@ check(err)
 ```
 
 </CodeExample>
+
 
 And that's it! At this point, since we opted for the "reclaim" path, Account A should have the same balance as what it started with (sans fees), and Account B should be unchanged.

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -58,23 +58,22 @@ See [Revoke Sponsorship](../start/list-of-operations.mdx#revoke-sponsorship) for
 
 The logic above does not detail any of the error cases, which are specified [here](../start/list-of-operations.mdx#revoke-sponsorship).
 
+
+
 ## Examples
-
 Each example builds on itself, referencing variables from previous snippets. We'll demonstrate a few different things you can do with sponsoring:
-
-- [Sponsor creation](#sponsoring-trustlines) of a trustline for another account.
-- [Sponsor **two** trustlines](#sponsoring-trustlines) for an account via two _different_ sponsors.
-- [Transfer sponsorship](#transferring-sponsorship) responsibility from one account to another.
-- [Revoke sponsorship](#sponsorship-revocation) by an account entirely.
+ - [Sponsor creation](#sponsoring-trustlines) of a trustline for another account.
+ - [Sponsor **two** trustlines](#sponsoring-trustlines) for an account via two *different* sponsors.
+ - [Transfer sponsorship](#transferring-sponsorship) responsibility from one account to another.
+ - [Revoke sponsorship](#sponsorship-revocation) by an account entirely.
 
 (For brevity in the Golang examples, we'll assume the existence of a `SignAndSend(...)` method (defined [below](#footnote)) which creates and submits a transaction with the proper parameters and basic error-checking.
 
-### Preamble
 
+### Preamble
 We'll start by including the boilerplate of account and asset creation.
 
 <CodeExample>
-
 
 ```js
 const sdk = require("stellar-sdk");
@@ -96,7 +95,7 @@ async function main() {
 
     console.log(`Funding:\n ${keypair.secret()}\n ${keypair.publicKey()}`);
 
-    // We use the "got" library here to do the HTTP request synchronously, but
+    // We use the "got" library here to do the HTTP request synchronously, but 
     // you can obviously use any method you'd like for this.
     const response = await http(path).catch(function (error) {
       console.error("  failed:", error.response.body);
@@ -164,93 +163,73 @@ func main() {
 
 
 ### Sponsoring Trustlines
-
 Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` operation is sandwiched between the begin and end sponsoring operations and that all relevant accounts need to sign the transaction.
 
 <CodeExample>
 
-
 ```js
-//
-// 1. S1 will sponsor a trustline for Account A.
-//
-let s1Account = await server.loadAccount(S1.publicKey()).catch(accountFail);
-let tx = new sdk.TransactionBuilder(s1Account, { fee: sdk.BASE_FEE })
-  .addOperation(
-    sdk.Operation.beginSponsoringFutureReserves({
+  //
+  // 1. S1 will sponsor a trustline for Account A.
+  //
+  let s1Account = await server.loadAccount(S1.publicKey()).catch(accountFail);
+  let tx = new sdk.TransactionBuilder(s1Account, {fee: sdk.BASE_FEE})
+    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
       sponsoredId: A.publicKey(),
-    }),
-  )
-  .addOperation(
-    sdk.Operation.changeTrust({
+    }))
+    .addOperation(sdk.Operation.changeTrust({
       source: A.publicKey(),
       asset: assets[0],
       limit: "1000", // This limit can vary according with your application;
-      // if left empty, it defaults to the max limit.
-    }),
-  )
-  .addOperation(
-    sdk.Operation.endSponsoringFutureReserves({
+                     // if left empty, it defaults to the max limit.
+    }))
+    .addOperation(sdk.Operation.endSponsoringFutureReserves({
       source: A.publicKey(),
-    }),
-  )
-  .setNetworkPassphrase(sdk.Networks.TESTNET)
-  .setTimeout(180)
-  .build();
+    }))
+    .setNetworkPassphrase(sdk.Networks.TESTNET)
+    .setTimeout(180)
+    .build();
 
-// Note that while either can submit this transaction, both must sign it.
-tx.sign(S1, A);
-let txResponse = await server.submitTransaction(tx).catch(txCheck);
-if (!txResponse) {
-  return;
-}
+  // Note that while either can submit this transaction, both must sign it.
+  tx.sign(S1, A);
+  let txResponse = await server.submitTransaction(tx).catch(txCheck);
+  if (!txResponse) { return; }
 
-console.log("Sponsored a trustline of", A.publicKey());
+  console.log("Sponsored a trustline of", A.publicKey());
 
-//
-// 2. Both S1 and S2 sponsor trustlines for Account A for different assets.
-//
-let aAccount = await server.loadAccount(A.publicKey()).catch(accountFail);
-let tx = new sdk.TransactionBuilder(aAccount, { fee: sdk.BASE_FEE })
-  .addOperation(
-    sdk.Operation.beginSponsoringFutureReserves({
+  //
+  // 2. Both S1 and S2 sponsor trustlines for Account A for different assets.
+  //
+  let aAccount = await server.loadAccount(A.publicKey()).catch(accountFail);
+  let tx = new sdk.TransactionBuilder(aAccount, {fee: sdk.BASE_FEE})
+    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
       source: S1.publicKey(),
-      sponsoredId: A.publicKey(),
-    }),
-  )
-  .addOperation(
-    sdk.Operation.changeTrust({
+      sponsoredId: A.publicKey()
+    }))
+    .addOperation(sdk.Operation.changeTrust({
       asset: assets[1],
-      limit: "5000",
-    }),
-  )
-  .addOperation(sdk.Operation.endSponsoringFutureReserves())
+      limit: "5000"
+    }))
+    .addOperation(sdk.Operation.endSponsoringFutureReserves())
 
-  .addOperation(
-    sdk.Operation.beginSponsoringFutureReserves({
+    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
       source: S2.publicKey(),
-      sponsoredId: A.publicKey(),
-    }),
-  )
-  .addOperation(
-    sdk.Operation.changeTrust({
+      sponsoredId: A.publicKey()
+    }))
+    .addOperation(sdk.Operation.changeTrust({
       asset: assets[2],
-      limit: "2500",
-    }),
-  )
-  .addOperation(sdk.Operation.endSponsoringFutureReserves())
-  .setNetworkPassphrase(sdk.Networks.TESTNET)
-  .setTimeout(180)
-  .build();
+      limit: "2500"
+    }))
+    .addOperation(sdk.Operation.endSponsoringFutureReserves())
+    .setNetworkPassphrase(sdk.Networks.TESTNET)
+    .setTimeout(180)
+    .build();
 
-// Note that all 3 accounts must approve/sign this transaction.
-tx.sign(S1, S2, A);
-let txResponse = await server.submitTransaction(tx).catch(txCheck);
-if (!txResponse) {
-  return;
-}
+  // Note that all 3 accounts must approve/sign this transaction.
+  tx.sign(S1, S2, A);
+  let txResponse = await server.submitTransaction(tx).catch(txCheck);
+  if (!txResponse) { return; }
 
-console.log("Sponsored two trustlines of", A.publicKey());
+  console.log("Sponsored two trustlines of", A.publicKey());
 ```
 
 ```go
@@ -259,7 +238,7 @@ console.log("Sponsored two trustlines of", A.publicKey());
 	//
 	sponsorTrustline := []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: s1Account.AccountID,
+			SourceAccount: &s1Account,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -270,7 +249,7 @@ console.log("Sponsored two trustlines of", A.publicKey());
 	}
 
 	// Note that while A can submit this transaction, both sign it.
-	SignAndSend(client, aAccount.AccountID, []*keypair.Full{S1, A}, sponsorTrustline...)
+	SignAndSend(client, &aAccount, []*keypair.Full{S1, A}, sponsorTrustline...)
 	fmt.Println("Sponsored a trustline of", A.Address())
 
 	//
@@ -278,7 +257,7 @@ console.log("Sponsored two trustlines of", A.publicKey());
 	//
 	sponsorTrustline = []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: s1Account.AccountID,
+			SourceAccount: &s1Account,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -288,7 +267,7 @@ console.log("Sponsored two trustlines of", A.publicKey());
 		&txnbuild.EndSponsoringFutureReserves{},
 
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: s2Account.AccountID,
+			SourceAccount: &s2Account,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -299,7 +278,7 @@ console.log("Sponsored two trustlines of", A.publicKey());
 	}
 
 	// Note that all 3 accounts must approve/sign this transaction.
-	SignAndSend(client, aAccount.AccountID, []*keypair.Full{S1, S2, A}, sponsorTrustline...)
+	SignAndSend(client, &aAccount, []*keypair.Full{S1, S2, A}, sponsorTrustline...)
 	fmt.Println("Sponsored two trustlines of", A.Address())
 ```
 
@@ -307,45 +286,37 @@ console.log("Sponsored two trustlines of", A.publicKey());
 
 
 ### Transferring Sponsorship
-
 Suppose that now Signer 1 wants to transfer responsibility of sponsoring reserves for the trustline to Sponsor 2. This is accomplished by sandwiching the transfer between the `BEGIN`/`END_SPONSORING_FUTURE_RESERVES` operations. Both of the participants must sign the transaction, though either can submit it.
 
 An intuitive way to think of a sponsorship transfer is that the very act of sponsorship is being sponsored by a new account. That is, the new sponsor takes over the responsibilities of the old sponsor by sponsoring a revocation.
 
 <CodeExample>
 
-
-```js
-//
-// 3. Transfer sponsorship of B's second trustline from S1 to S2.
-//
-let tx = new sdk.TransactionBuilder(s1Account, { fee: sdk.BASE_FEE })
-  .addOperation(
-    sdk.Operation.beginSponsoringFutureReserves({
+```js 
+  //
+  // 3. Transfer sponsorship of B's second trustline from S1 to S2.
+  //
+  let tx = new sdk.TransactionBuilder(s1Account, {fee: sdk.BASE_FEE})
+    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
       source: S2.publicKey(),
-      sponsoredId: S1.publicKey(),
-    }),
-  )
-  .addOperation(
-    sdk.Operation.revokeTrustlineSponsorship({
+      sponsoredId: S1.publicKey()
+    }))
+    .addOperation(sdk.Operation.revokeTrustlineSponsorship({
       account: A.publicKey(),
       asset: assets[1],
-    }),
-  )
-  .addOperation(sdk.Operation.endSponsoringFutureReserves())
-  .setNetworkPassphrase(sdk.Networks.TESTNET)
-  .setTimeout(180)
-  .build();
+    }))
+    .addOperation(sdk.Operation.endSponsoringFutureReserves())
+    .setNetworkPassphrase(sdk.Networks.TESTNET)
+    .setTimeout(180)
+    .build();
 
-// Notice that while the old sponsor *sends* the transaction, both sponsors
-// must *approve* the transfer.
-tx.sign(S1, S2);
-let txResponse = await server.submitTransaction(tx).catch(txCheck);
-if (!txResponse) {
-  return;
-}
+  // Notice that while the old sponsor *sends* the transaction, both sponsors
+  // must *approve* the transfer.
+  tx.sign(S1, S2);
+  let txResponse = await server.submitTransaction(tx).catch(txCheck);
+  if (!txResponse) { return; }
 
-console.log("Transferred sponsorship for", A.publicKey());
+  console.log("Transferred sponsorship for", A.publicKey());
 ```
 
 ```go
@@ -354,7 +325,7 @@ console.log("Transferred sponsorship for", A.publicKey());
 	//
 	transferOps := []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: s2Account.AccountID,
+			SourceAccount: &s2Account,
 			SponsoredID:   S1.Address(),
 		},
 		&txnbuild.RevokeSponsorship{
@@ -370,21 +341,19 @@ console.log("Transferred sponsorship for", A.publicKey());
 
 	// Notice that while the old sponsor *sends* the transaction (in this case),
 	// both sponsors must *approve* the transfer.
-	SignAndSend(client, s1Account.AccountID, []*keypair.Full{S1, S2}, transferOps...)
+	SignAndSend(client, &s1Account, []*keypair.Full{S1, S2}, transferOps...)
 	fmt.Println("Transferred sponsorship for", A.Address())
 ```
 
 </CodeExample>
 
-
 At this point, Signer 1 is only sponsoring the first asset (arbitrarily coded as `ABCD`), while Signer 2 is sponsoring the other two assets. (Recall that [initially](#sponsoring-trustlines) Signer 1 was also sponsoring `EFGH`.)
 
-### Sponsorship Revocation
 
+### Sponsorship Revocation
 Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2 removes themselves from all responsibility over the two asset trustlines. Notice that Account A is not involved at all, since revocation should be performable purely at the sponsor's discretion.
 
 <CodeExample>
-
 
 ```js
   //
@@ -435,7 +404,7 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 		},
 	}
 
-	SignAndSend(client, s2Account.AccountID, []*keypair.Full{S2}, revokeOps...)
+	SignAndSend(client, &s2Account, []*keypair.Full{S2}, revokeOps...)
 	fmt.Println("Revoked sponsorship for", A.Address())
 } // ends main()
 ```
@@ -444,17 +413,15 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 
 
 ### Sponsorship Source Accounts
-
 When it comes to the `SourceAccount` fields of the sponsorship sandwich, it's important to refer to the wisdom of [CAP-33](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#abstract):
 
 > This relation is initiated by `BeginSponsoringFutureReservesOp`, where the **sponsoring** account is the source account, and is terminated by `EndSponsoringFutureReserveOp`, where the **sponsored** account is the source account.
 
-Since the source account defaults to the transaction submitter when omitted, this field needs _always_ needs to be set for either the `Begin` or the `End`.
+Since the source account defaults to the transaction submitter when omitted, this field needs *always* needs to be set for either the `Begin` or the `End`.
 
 For example, the following is an identical expression of the [earlier Golang example](#sponsoring-trustlines) of sponsoring a trustline, just submitted by the **sponsor** (Sponsor 1) rather than the **sponsored** account (Account A). Notice the differences in where `SourceAccount` is set:
 
 <CodeExample>
-
 
 ```go
 	sponsorTrustline := []txnbuild.Operation{
@@ -462,35 +429,33 @@ For example, the following is an identical expression of the [earlier Golang exa
 			SponsoredID: addressA,
 		},
 		&txnbuild.ChangeTrust{
-			SourceAccount: aAccount.AccountID,
+			SourceAccount: &aAccount,
 			Line:          &assets[0],
 			Limit:         txnbuild.MaxTrustlineLimit,
 		},
 		&txnbuild.EndSponsoringFutureReserves{
-			SourceAccount: aAccount.AccountID,
+			SourceAccount: &aAccount,
 		},
 	}
 
 	// Again, both participants must still sign the transaction: the sponsored
 	// account must consent to the sponsorship.
-	SignAndSend(client, s1Account.AccountID, []*keypair.Full{S1, A}, sponsorTrustline...)
+	SignAndSend(client, &s1Account, []*keypair.Full{S1, A}, sponsorTrustline...)
 ```
 
 </CodeExample>
 
 
 ### Other Examples
-
 If you'd like other examples, or want to view a more-generic pseudocode breakdown of these sponsorship scenarios, you can refer to [CAP-33](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship) directly.
 
-### Footnote
 
+### Footnote
 For the above examples, an implementation of `SignAndSend` (Golang) and some (very) rudimentary error checking code (all languages) might look something like this:
 
 <CodeExample>
 
-
-```js
+```js 
 function txCheck(err) {
   console.error("Transaction submission failed:", err);
   if (err.response != null && err.response.data != null) {
@@ -551,4 +516,3 @@ func check(err error) {
 ```
 
 </CodeExample>
-

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -238,7 +238,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	//
 	sponsorTrustline := []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s1Account,
+			SourceAccount: s1Account.AccountID,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -249,7 +249,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	}
 
 	// Note that while A can submit this transaction, both sign it.
-	SignAndSend(client, &aAccount, []*keypair.Full{S1, A}, sponsorTrustline...)
+	SignAndSend(client, aAccount.AccountID, []*keypair.Full{S1, A}, sponsorTrustline...)
 	fmt.Println("Sponsored a trustline of", A.Address())
 
 	//
@@ -257,7 +257,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	//
 	sponsorTrustline = []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s1Account,
+			SourceAccount: s1Account.AccountID,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -267,7 +267,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 		&txnbuild.EndSponsoringFutureReserves{},
 
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s2Account,
+			SourceAccount: s2Account.AccountID,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -278,7 +278,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	}
 
 	// Note that all 3 accounts must approve/sign this transaction.
-	SignAndSend(client, &aAccount, []*keypair.Full{S1, S2, A}, sponsorTrustline...)
+	SignAndSend(client, aAccount.AccountID, []*keypair.Full{S1, S2, A}, sponsorTrustline...)
 	fmt.Println("Sponsored two trustlines of", A.Address())
 ```
 
@@ -325,7 +325,7 @@ An intuitive way to think of a sponsorship transfer is that the very act of spon
 	//
 	transferOps := []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s2Account,
+			SourceAccount: s2Account.AccountID,
 			SponsoredID:   S1.Address(),
 		},
 		&txnbuild.RevokeSponsorship{
@@ -341,7 +341,7 @@ An intuitive way to think of a sponsorship transfer is that the very act of spon
 
 	// Notice that while the old sponsor *sends* the transaction (in this case),
 	// both sponsors must *approve* the transfer.
-	SignAndSend(client, &s1Account, []*keypair.Full{S1, S2}, transferOps...)
+	SignAndSend(client, s1Account.AccountID, []*keypair.Full{S1, S2}, transferOps...)
 	fmt.Println("Transferred sponsorship for", A.Address())
 ```
 
@@ -404,7 +404,7 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 		},
 	}
 
-	SignAndSend(client, &s2Account, []*keypair.Full{S2}, revokeOps...)
+	SignAndSend(client, s2Account.AccountID, []*keypair.Full{S2}, revokeOps...)
 	fmt.Println("Revoked sponsorship for", A.Address())
 } // ends main()
 ```
@@ -429,18 +429,18 @@ For example, the following is an identical expression of the [earlier Golang exa
 			SponsoredID: addressA,
 		},
 		&txnbuild.ChangeTrust{
-			SourceAccount: &aAccount,
+			SourceAccount: aAccount.AccountID,
 			Line:          &assets[0],
 			Limit:         txnbuild.MaxTrustlineLimit,
 		},
 		&txnbuild.EndSponsoringFutureReserves{
-			SourceAccount: &aAccount,
+			SourceAccount: aAccount.AccountID,
 		},
 	}
 
 	// Again, both participants must still sign the transaction: the sponsored
 	// account must consent to the sponsorship.
-	SignAndSend(client, &s1Account, []*keypair.Full{S1, A}, sponsorTrustline...)
+	SignAndSend(client, s1Account.AccountID, []*keypair.Full{S1, A}, sponsorTrustline...)
 ```
 
 </CodeExample>

--- a/content/docs/glossary/sponsored-reserves.mdx
+++ b/content/docs/glossary/sponsored-reserves.mdx
@@ -58,22 +58,23 @@ See [Revoke Sponsorship](../start/list-of-operations.mdx#revoke-sponsorship) for
 
 The logic above does not detail any of the error cases, which are specified [here](../start/list-of-operations.mdx#revoke-sponsorship).
 
-
-
 ## Examples
+
 Each example builds on itself, referencing variables from previous snippets. We'll demonstrate a few different things you can do with sponsoring:
- - [Sponsor creation](#sponsoring-trustlines) of a trustline for another account.
- - [Sponsor **two** trustlines](#sponsoring-trustlines) for an account via two *different* sponsors.
- - [Transfer sponsorship](#transferring-sponsorship) responsibility from one account to another.
- - [Revoke sponsorship](#sponsorship-revocation) by an account entirely.
+
+- [Sponsor creation](#sponsoring-trustlines) of a trustline for another account.
+- [Sponsor **two** trustlines](#sponsoring-trustlines) for an account via two _different_ sponsors.
+- [Transfer sponsorship](#transferring-sponsorship) responsibility from one account to another.
+- [Revoke sponsorship](#sponsorship-revocation) by an account entirely.
 
 (For brevity in the Golang examples, we'll assume the existence of a `SignAndSend(...)` method (defined [below](#footnote)) which creates and submits a transaction with the proper parameters and basic error-checking.
 
-
 ### Preamble
+
 We'll start by including the boilerplate of account and asset creation.
 
 <CodeExample>
+
 
 ```js
 const sdk = require("stellar-sdk");
@@ -95,7 +96,7 @@ async function main() {
 
     console.log(`Funding:\n ${keypair.secret()}\n ${keypair.publicKey()}`);
 
-    // We use the "got" library here to do the HTTP request synchronously, but 
+    // We use the "got" library here to do the HTTP request synchronously, but
     // you can obviously use any method you'd like for this.
     const response = await http(path).catch(function (error) {
       console.error("  failed:", error.response.body);
@@ -163,73 +164,93 @@ func main() {
 
 
 ### Sponsoring Trustlines
+
 Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` operation is sandwiched between the begin and end sponsoring operations and that all relevant accounts need to sign the transaction.
 
 <CodeExample>
 
+
 ```js
-  //
-  // 1. S1 will sponsor a trustline for Account A.
-  //
-  let s1Account = await server.loadAccount(S1.publicKey()).catch(accountFail);
-  let tx = new sdk.TransactionBuilder(s1Account, {fee: sdk.BASE_FEE})
-    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
+//
+// 1. S1 will sponsor a trustline for Account A.
+//
+let s1Account = await server.loadAccount(S1.publicKey()).catch(accountFail);
+let tx = new sdk.TransactionBuilder(s1Account, { fee: sdk.BASE_FEE })
+  .addOperation(
+    sdk.Operation.beginSponsoringFutureReserves({
       sponsoredId: A.publicKey(),
-    }))
-    .addOperation(sdk.Operation.changeTrust({
+    }),
+  )
+  .addOperation(
+    sdk.Operation.changeTrust({
       source: A.publicKey(),
       asset: assets[0],
       limit: "1000", // This limit can vary according with your application;
-                     // if left empty, it defaults to the max limit.
-    }))
-    .addOperation(sdk.Operation.endSponsoringFutureReserves({
+      // if left empty, it defaults to the max limit.
+    }),
+  )
+  .addOperation(
+    sdk.Operation.endSponsoringFutureReserves({
       source: A.publicKey(),
-    }))
-    .setNetworkPassphrase(sdk.Networks.TESTNET)
-    .setTimeout(180)
-    .build();
+    }),
+  )
+  .setNetworkPassphrase(sdk.Networks.TESTNET)
+  .setTimeout(180)
+  .build();
 
-  // Note that while either can submit this transaction, both must sign it.
-  tx.sign(S1, A);
-  let txResponse = await server.submitTransaction(tx).catch(txCheck);
-  if (!txResponse) { return; }
+// Note that while either can submit this transaction, both must sign it.
+tx.sign(S1, A);
+let txResponse = await server.submitTransaction(tx).catch(txCheck);
+if (!txResponse) {
+  return;
+}
 
-  console.log("Sponsored a trustline of", A.publicKey());
+console.log("Sponsored a trustline of", A.publicKey());
 
-  //
-  // 2. Both S1 and S2 sponsor trustlines for Account A for different assets.
-  //
-  let aAccount = await server.loadAccount(A.publicKey()).catch(accountFail);
-  let tx = new sdk.TransactionBuilder(aAccount, {fee: sdk.BASE_FEE})
-    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
+//
+// 2. Both S1 and S2 sponsor trustlines for Account A for different assets.
+//
+let aAccount = await server.loadAccount(A.publicKey()).catch(accountFail);
+let tx = new sdk.TransactionBuilder(aAccount, { fee: sdk.BASE_FEE })
+  .addOperation(
+    sdk.Operation.beginSponsoringFutureReserves({
       source: S1.publicKey(),
-      sponsoredId: A.publicKey()
-    }))
-    .addOperation(sdk.Operation.changeTrust({
+      sponsoredId: A.publicKey(),
+    }),
+  )
+  .addOperation(
+    sdk.Operation.changeTrust({
       asset: assets[1],
-      limit: "5000"
-    }))
-    .addOperation(sdk.Operation.endSponsoringFutureReserves())
+      limit: "5000",
+    }),
+  )
+  .addOperation(sdk.Operation.endSponsoringFutureReserves())
 
-    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
+  .addOperation(
+    sdk.Operation.beginSponsoringFutureReserves({
       source: S2.publicKey(),
-      sponsoredId: A.publicKey()
-    }))
-    .addOperation(sdk.Operation.changeTrust({
+      sponsoredId: A.publicKey(),
+    }),
+  )
+  .addOperation(
+    sdk.Operation.changeTrust({
       asset: assets[2],
-      limit: "2500"
-    }))
-    .addOperation(sdk.Operation.endSponsoringFutureReserves())
-    .setNetworkPassphrase(sdk.Networks.TESTNET)
-    .setTimeout(180)
-    .build();
+      limit: "2500",
+    }),
+  )
+  .addOperation(sdk.Operation.endSponsoringFutureReserves())
+  .setNetworkPassphrase(sdk.Networks.TESTNET)
+  .setTimeout(180)
+  .build();
 
-  // Note that all 3 accounts must approve/sign this transaction.
-  tx.sign(S1, S2, A);
-  let txResponse = await server.submitTransaction(tx).catch(txCheck);
-  if (!txResponse) { return; }
+// Note that all 3 accounts must approve/sign this transaction.
+tx.sign(S1, S2, A);
+let txResponse = await server.submitTransaction(tx).catch(txCheck);
+if (!txResponse) {
+  return;
+}
 
-  console.log("Sponsored two trustlines of", A.publicKey());
+console.log("Sponsored two trustlines of", A.publicKey());
 ```
 
 ```go
@@ -238,7 +259,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	//
 	sponsorTrustline := []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s1Account,
+			SourceAccount: s1Account.AccountID,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -249,7 +270,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	}
 
 	// Note that while A can submit this transaction, both sign it.
-	SignAndSend(client, &aAccount, []*keypair.Full{S1, A}, sponsorTrustline...)
+	SignAndSend(client, aAccount.AccountID, []*keypair.Full{S1, A}, sponsorTrustline...)
 	fmt.Println("Sponsored a trustline of", A.Address())
 
 	//
@@ -257,7 +278,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	//
 	sponsorTrustline = []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s1Account,
+			SourceAccount: s1Account.AccountID,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -267,7 +288,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 		&txnbuild.EndSponsoringFutureReserves{},
 
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s2Account,
+			SourceAccount: s2Account.AccountID,
 			SponsoredID:   addressA,
 		},
 		&txnbuild.ChangeTrust{
@@ -278,7 +299,7 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 	}
 
 	// Note that all 3 accounts must approve/sign this transaction.
-	SignAndSend(client, &aAccount, []*keypair.Full{S1, S2, A}, sponsorTrustline...)
+	SignAndSend(client, aAccount.AccountID, []*keypair.Full{S1, S2, A}, sponsorTrustline...)
 	fmt.Println("Sponsored two trustlines of", A.Address())
 ```
 
@@ -286,37 +307,45 @@ Now, let's sponsor trustlines for Account A. Notice how the `CHANGE_TRUST` opera
 
 
 ### Transferring Sponsorship
+
 Suppose that now Signer 1 wants to transfer responsibility of sponsoring reserves for the trustline to Sponsor 2. This is accomplished by sandwiching the transfer between the `BEGIN`/`END_SPONSORING_FUTURE_RESERVES` operations. Both of the participants must sign the transaction, though either can submit it.
 
 An intuitive way to think of a sponsorship transfer is that the very act of sponsorship is being sponsored by a new account. That is, the new sponsor takes over the responsibilities of the old sponsor by sponsoring a revocation.
 
 <CodeExample>
 
-```js 
-  //
-  // 3. Transfer sponsorship of B's second trustline from S1 to S2.
-  //
-  let tx = new sdk.TransactionBuilder(s1Account, {fee: sdk.BASE_FEE})
-    .addOperation(sdk.Operation.beginSponsoringFutureReserves({
+
+```js
+//
+// 3. Transfer sponsorship of B's second trustline from S1 to S2.
+//
+let tx = new sdk.TransactionBuilder(s1Account, { fee: sdk.BASE_FEE })
+  .addOperation(
+    sdk.Operation.beginSponsoringFutureReserves({
       source: S2.publicKey(),
-      sponsoredId: S1.publicKey()
-    }))
-    .addOperation(sdk.Operation.revokeTrustlineSponsorship({
+      sponsoredId: S1.publicKey(),
+    }),
+  )
+  .addOperation(
+    sdk.Operation.revokeTrustlineSponsorship({
       account: A.publicKey(),
       asset: assets[1],
-    }))
-    .addOperation(sdk.Operation.endSponsoringFutureReserves())
-    .setNetworkPassphrase(sdk.Networks.TESTNET)
-    .setTimeout(180)
-    .build();
+    }),
+  )
+  .addOperation(sdk.Operation.endSponsoringFutureReserves())
+  .setNetworkPassphrase(sdk.Networks.TESTNET)
+  .setTimeout(180)
+  .build();
 
-  // Notice that while the old sponsor *sends* the transaction, both sponsors
-  // must *approve* the transfer.
-  tx.sign(S1, S2);
-  let txResponse = await server.submitTransaction(tx).catch(txCheck);
-  if (!txResponse) { return; }
+// Notice that while the old sponsor *sends* the transaction, both sponsors
+// must *approve* the transfer.
+tx.sign(S1, S2);
+let txResponse = await server.submitTransaction(tx).catch(txCheck);
+if (!txResponse) {
+  return;
+}
 
-  console.log("Transferred sponsorship for", A.publicKey());
+console.log("Transferred sponsorship for", A.publicKey());
 ```
 
 ```go
@@ -325,7 +354,7 @@ An intuitive way to think of a sponsorship transfer is that the very act of spon
 	//
 	transferOps := []txnbuild.Operation{
 		&txnbuild.BeginSponsoringFutureReserves{
-			SourceAccount: &s2Account,
+			SourceAccount: s2Account.AccountID,
 			SponsoredID:   S1.Address(),
 		},
 		&txnbuild.RevokeSponsorship{
@@ -341,19 +370,21 @@ An intuitive way to think of a sponsorship transfer is that the very act of spon
 
 	// Notice that while the old sponsor *sends* the transaction (in this case),
 	// both sponsors must *approve* the transfer.
-	SignAndSend(client, &s1Account, []*keypair.Full{S1, S2}, transferOps...)
+	SignAndSend(client, s1Account.AccountID, []*keypair.Full{S1, S2}, transferOps...)
 	fmt.Println("Transferred sponsorship for", A.Address())
 ```
 
 </CodeExample>
 
+
 At this point, Signer 1 is only sponsoring the first asset (arbitrarily coded as `ABCD`), while Signer 2 is sponsoring the other two assets. (Recall that [initially](#sponsoring-trustlines) Signer 1 was also sponsoring `EFGH`.)
 
-
 ### Sponsorship Revocation
+
 Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2 removes themselves from all responsibility over the two asset trustlines. Notice that Account A is not involved at all, since revocation should be performable purely at the sponsor's discretion.
 
 <CodeExample>
+
 
 ```js
   //
@@ -404,7 +435,7 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 		},
 	}
 
-	SignAndSend(client, &s2Account, []*keypair.Full{S2}, revokeOps...)
+	SignAndSend(client, s2Account.AccountID, []*keypair.Full{S2}, revokeOps...)
 	fmt.Println("Revoked sponsorship for", A.Address())
 } // ends main()
 ```
@@ -413,15 +444,17 @@ Finally, we can demonstrate complete revocation of sponsorships. Below, Signer 2
 
 
 ### Sponsorship Source Accounts
+
 When it comes to the `SourceAccount` fields of the sponsorship sandwich, it's important to refer to the wisdom of [CAP-33](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#abstract):
 
 > This relation is initiated by `BeginSponsoringFutureReservesOp`, where the **sponsoring** account is the source account, and is terminated by `EndSponsoringFutureReserveOp`, where the **sponsored** account is the source account.
 
-Since the source account defaults to the transaction submitter when omitted, this field needs *always* needs to be set for either the `Begin` or the `End`.
+Since the source account defaults to the transaction submitter when omitted, this field needs _always_ needs to be set for either the `Begin` or the `End`.
 
 For example, the following is an identical expression of the [earlier Golang example](#sponsoring-trustlines) of sponsoring a trustline, just submitted by the **sponsor** (Sponsor 1) rather than the **sponsored** account (Account A). Notice the differences in where `SourceAccount` is set:
 
 <CodeExample>
+
 
 ```go
 	sponsorTrustline := []txnbuild.Operation{
@@ -429,33 +462,35 @@ For example, the following is an identical expression of the [earlier Golang exa
 			SponsoredID: addressA,
 		},
 		&txnbuild.ChangeTrust{
-			SourceAccount: &aAccount,
+			SourceAccount: aAccount.AccountID,
 			Line:          &assets[0],
 			Limit:         txnbuild.MaxTrustlineLimit,
 		},
 		&txnbuild.EndSponsoringFutureReserves{
-			SourceAccount: &aAccount,
+			SourceAccount: aAccount.AccountID,
 		},
 	}
 
 	// Again, both participants must still sign the transaction: the sponsored
 	// account must consent to the sponsorship.
-	SignAndSend(client, &s1Account, []*keypair.Full{S1, A}, sponsorTrustline...)
+	SignAndSend(client, s1Account.AccountID, []*keypair.Full{S1, A}, sponsorTrustline...)
 ```
 
 </CodeExample>
 
 
 ### Other Examples
+
 If you'd like other examples, or want to view a more-generic pseudocode breakdown of these sponsorship scenarios, you can refer to [CAP-33](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md#example-revoke-sponsorship) directly.
 
-
 ### Footnote
+
 For the above examples, an implementation of `SignAndSend` (Golang) and some (very) rudimentary error checking code (all languages) might look something like this:
 
 <CodeExample>
 
-```js 
+
+```js
 function txCheck(err) {
   console.error("Transaction submission failed:", err);
   if (err.response != null && err.response.data != null) {
@@ -516,3 +551,4 @@ func check(err error) {
 ```
 
 </CodeExample>
+

--- a/content/docs/issuing-assets/how-to-issue-an-asset.mdx
+++ b/content/docs/issuing-assets/how-to-issue-an-asset.mdx
@@ -224,7 +224,7 @@ func main() {
   // issuer.
   tx, err := txnbuild.NewTransaction(
     txnbuild.TransactionParams{
-      SourceAccount:        distributorAccount.AccountID,
+      SourceAccount:        &distributorAccount,
       IncrementSequenceNum: true,
       BaseFee:              txnbuild.MinBaseFee,
       Timebounds:           txnbuild.NewInfiniteTimeout(),
@@ -248,7 +248,7 @@ func main() {
   // Second, the issuing account actually sends a payment using the asset
   tx, err = txnbuild.NewTransaction(
     txnbuild.TransactionParams{
-      SourceAccount:        issuerAccount.AccountID,
+      SourceAccount:        &issuerAccount,
       IncrementSequenceNum: true,
       BaseFee:              txnbuild.MinBaseFee,
       Timebounds:           txnbuild.NewInfiniteTimeout(),

--- a/content/docs/issuing-assets/how-to-issue-an-asset.mdx
+++ b/content/docs/issuing-assets/how-to-issue-an-asset.mdx
@@ -224,7 +224,7 @@ func main() {
   // issuer.
   tx, err := txnbuild.NewTransaction(
     txnbuild.TransactionParams{
-      SourceAccount:        &distributorAccount,
+      SourceAccount:        distributorAccount.AccountID,
       IncrementSequenceNum: true,
       BaseFee:              txnbuild.MinBaseFee,
       Timebounds:           txnbuild.NewInfiniteTimeout(),
@@ -248,7 +248,7 @@ func main() {
   // Second, the issuing account actually sends a payment using the asset
   tx, err = txnbuild.NewTransaction(
     txnbuild.TransactionParams{
-      SourceAccount:        &issuerAccount,
+      SourceAccount:        issuerAccount.AccountID,
       IncrementSequenceNum: true,
       BaseFee:              txnbuild.MinBaseFee,
       Timebounds:           txnbuild.NewInfiniteTimeout(),

--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -21,6 +21,7 @@ Stellar stores and communicates transaction data in a binary format called [XDR]
 
 <CodeExample>
 
+
 ```js
 var StellarSdk = require("stellar-sdk");
 var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
@@ -158,7 +159,7 @@ func main () {
     // Build transaction
     tx, err := txnbuild.NewTransaction(
       txnbuild.TransactionParams{
-        SourceAccount:        &sourceAccount,
+        SourceAccount:        sourceAccount.AccountID,
         IncrementSequenceNum: true,
         BaseFee:              txnbuild.MinBaseFee,
         Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
@@ -251,11 +252,13 @@ except (BadRequestError, BadResponseError) as err:
 
 </CodeExample>
 
+
 What exactly happened there? Let’s break it down.
 
 1. Confirm that the account ID (aka the _public key_) you are sending to actually exists by loading the associated account data from the Stellar network. It's okay to skip this step, but it gives you an opportunity to avoid making a transaction that will inevitably fail.
 
 <CodeExample>
+
 
 ```js
 server.loadAccount(destinationId).then(function (account) {
@@ -281,9 +284,11 @@ server.load_account(destination_id)
 
 </CodeExample>
 
+
 2. Load data for the account you are sending from. An account can only perform one transaction at a time and has something called a [sequence number](../glossary/accounts.mdx#sequence-number), which helps Stellar verify the order of transactions. A transaction’s sequence number needs to match the account’s sequence number, so you need to get the account’s current sequence number from the network.
 
 <CodeExample>
+
 
 ```js
 .then(function() {
@@ -310,11 +315,13 @@ source_account = server.load_account(source_key.public_key)
 
 </CodeExample>
 
+
 The SDK will automatically increment the account’s sequence number when you build a transaction, so you won’t need to retrieve this information again if you want to perform a second transaction.
 
 3. Start building a transaction. This requires an account object, not just an account ID, because it will increment the account’s sequence number.
 
 <CodeExample>
+
 
 ```js
 var transaction = new StellarSdk.TransactionBuilder(sourceAccount);
@@ -327,7 +334,7 @@ Transaction transaction = new Transaction.Builder(sourceAccount, Network.TESTNET
 ```go
 tx, err := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        &sourceAccount,
+    SourceAccount:        sourceAccount.AccountID,
     IncrementSequenceNum: true,
     BaseFee:              MinBaseFee,
     Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
@@ -350,9 +357,11 @@ transaction = TransactionBuilder(
 
 </CodeExample>
 
+
 4. Add the payment operation to the account. Note that you need to specify the type of asset you are sending: Stellar’s network currency is the [lumen](https://www.stellar.org/lumens), but you can send any asset issued on the network. We'll cover sending non-lumen assets [below](#transacting-in-other-currencies). For now, though, we’ll stick to lumens, which are called “native” assets in the SDK:
 
 <CodeExample>
+
 
 ```js
 .addOperation(StellarSdk.Operation.payment({
@@ -382,11 +391,13 @@ Operations: []txnbuild.Operation{
 
 </CodeExample>
 
+
 You should also note that the amount is a string rather than a number. When working with extremely small fractions or large values, [floating point math can introduce small inaccuracies](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems). Since not all systems have a native way to accurately represent extremely small or large decimals, Stellar uses strings as a reliable way to represent the exact amount across any system.
 
 5. Optionally, you can add your own metadata, called a [memo](../glossary/transactions.mdx#memo), to a transaction. Stellar doesn’t do anything with this data, but you can use it for any purpose you’d like. Many exchanges require memos for incoming transactions because they use a single Stellar account for all their users and rely on the memo to differentiate between internal user accounts.
 
 <CodeExample title="Add a Memo">
+
 
 ```js
 .addMemo(StellarSdk.Memo.text('Test Transaction'))
@@ -406,9 +417,11 @@ Memo: txnbuild.MemoText("Test Transaction")
 
 </CodeExample>
 
+
 6. Now that the transaction has all the data it needs, you have to cryptographically sign it using your secret key. This proves that the data actually came from you and not someone impersonating you.
 
 <CodeExample>
+
 
 ```js
 transaction.sign(sourceKeys);
@@ -431,9 +444,11 @@ transaction.sign(source_key)
 
 </CodeExample>
 
+
 7. And finally, submit it to the Stellar network!
 
 <CodeExample>
+
 
 ```js
 server.submitTransaction(transaction);
@@ -456,6 +471,7 @@ server.submit_transaction(transaction)
 
 </CodeExample>
 
+
 In this example, we're submitting the transaction to the SDF-maintained public testnet instance of Horizon, the Stellar API. When submitting transactions to a Horizon server — which is what most people do — it's possible that you will not receive a response from the server due to a bug, network conditions, etc. In such a situation it's impossible to determine the status of your transaction. That's why you should always save a built transaction (or transaction encoded in XDR format) in a variable or a database and resubmit it if you don't know its status. If the transaction has already been successfully applied to the ledger, Horizon will simply return the saved result and not attempt to submit the transaction again. Only in cases where a transaction’s status is unknown (and thus will have a chance of being included into a ledger) will a resubmission to the network occur.
 
 ## Receive a Payment
@@ -465,6 +481,7 @@ You don’t actually need to do anything to receive payments into a Stellar acco
 However, you may want to keep an eye out for incoming payments. A simple program that watches the network for payments and prints each one might look like:
 
 <CodeExample title="Receive Payments">
+
 
 ```js
 var StellarSdk = require("stellar-sdk");
@@ -574,10 +591,10 @@ paymentsRequest.stream(new EventListener<OperationResponse>() {
       System.out.println(output.toString());
     }
   }
-  
+
   @Override
   public void onFailure(Optional<Throwable> optional, Optional<Integer> optional1) {
-  
+
   }
 });
 ```
@@ -663,9 +680,11 @@ for payment in payments.stream():
 
 </CodeExample>
 
+
 There are two main parts to this program. First, you create a query for payments involving a given account. Like most queries in Stellar, this could return a huge number of items, so the API returns paging tokens, which you can use later to start your query from the same point where you previously left off. In the example above, the functions to save and load paging tokens are left blank, but in a real application, you’d want to save the paging tokens to a file or database so you can pick up where you left off in case the program crashes or the user closes it.
 
 <CodeExample>
+
 
 ```js
 var payments = server.payments().forAccount(accountId);
@@ -697,11 +716,13 @@ if last_token:
 
 </CodeExample>
 
+
 Second, the results of the query are streamed. This is the easiest way to watch for payments or other transactions. Each existing payment is sent through the stream, one by one. Once all existing payments have been sent, the stream stays open and new payments are sent as they are made.
 
 Try it out: Run this program, and then, in another window, create and submit a payment. You should see this program log the payment.
 
 <CodeExample>
+
 
 ```js
 payments.stream({
@@ -744,9 +765,11 @@ for payment in payments.stream():
 
 </CodeExample>
 
+
 You can also request payments in groups or pages. Once you’ve processed each page of payments, you’ll need to request the next one until there are none left.
 
 <CodeExample>
+
 
 ```js
 payments.call().then(function handlePage(paymentsPage) {
@@ -773,6 +796,7 @@ payments_next = payments.next()
 ```
 
 </CodeExample>
+
 
 ## Transacting in Other Currencies
 

--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -158,7 +158,7 @@ func main () {
     // Build transaction
     tx, err := txnbuild.NewTransaction(
       txnbuild.TransactionParams{
-        SourceAccount:        &sourceAccount,
+        SourceAccount:        sourceAccount.AccountID,
         IncrementSequenceNum: true,
         BaseFee:              txnbuild.MinBaseFee,
         Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
@@ -327,7 +327,7 @@ Transaction transaction = new Transaction.Builder(sourceAccount, Network.TESTNET
 ```go
 tx, err := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        &sourceAccount,
+    SourceAccount:        sourceAccount.AccountID,
     IncrementSequenceNum: true,
     BaseFee:              MinBaseFee,
     Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!

--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -21,7 +21,6 @@ Stellar stores and communicates transaction data in a binary format called [XDR]
 
 <CodeExample>
 
-
 ```js
 var StellarSdk = require("stellar-sdk");
 var server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
@@ -159,7 +158,7 @@ func main () {
     // Build transaction
     tx, err := txnbuild.NewTransaction(
       txnbuild.TransactionParams{
-        SourceAccount:        sourceAccount.AccountID,
+        SourceAccount:        &sourceAccount,
         IncrementSequenceNum: true,
         BaseFee:              txnbuild.MinBaseFee,
         Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
@@ -252,13 +251,11 @@ except (BadRequestError, BadResponseError) as err:
 
 </CodeExample>
 
-
 What exactly happened there? Let’s break it down.
 
 1. Confirm that the account ID (aka the _public key_) you are sending to actually exists by loading the associated account data from the Stellar network. It's okay to skip this step, but it gives you an opportunity to avoid making a transaction that will inevitably fail.
 
 <CodeExample>
-
 
 ```js
 server.loadAccount(destinationId).then(function (account) {
@@ -284,11 +281,9 @@ server.load_account(destination_id)
 
 </CodeExample>
 
-
 2. Load data for the account you are sending from. An account can only perform one transaction at a time and has something called a [sequence number](../glossary/accounts.mdx#sequence-number), which helps Stellar verify the order of transactions. A transaction’s sequence number needs to match the account’s sequence number, so you need to get the account’s current sequence number from the network.
 
 <CodeExample>
-
 
 ```js
 .then(function() {
@@ -315,13 +310,11 @@ source_account = server.load_account(source_key.public_key)
 
 </CodeExample>
 
-
 The SDK will automatically increment the account’s sequence number when you build a transaction, so you won’t need to retrieve this information again if you want to perform a second transaction.
 
 3. Start building a transaction. This requires an account object, not just an account ID, because it will increment the account’s sequence number.
 
 <CodeExample>
-
 
 ```js
 var transaction = new StellarSdk.TransactionBuilder(sourceAccount);
@@ -334,7 +327,7 @@ Transaction transaction = new Transaction.Builder(sourceAccount, Network.TESTNET
 ```go
 tx, err := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        sourceAccount.AccountID,
+    SourceAccount:        &sourceAccount,
     IncrementSequenceNum: true,
     BaseFee:              MinBaseFee,
     Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
@@ -357,11 +350,9 @@ transaction = TransactionBuilder(
 
 </CodeExample>
 
-
 4. Add the payment operation to the account. Note that you need to specify the type of asset you are sending: Stellar’s network currency is the [lumen](https://www.stellar.org/lumens), but you can send any asset issued on the network. We'll cover sending non-lumen assets [below](#transacting-in-other-currencies). For now, though, we’ll stick to lumens, which are called “native” assets in the SDK:
 
 <CodeExample>
-
 
 ```js
 .addOperation(StellarSdk.Operation.payment({
@@ -391,13 +382,11 @@ Operations: []txnbuild.Operation{
 
 </CodeExample>
 
-
 You should also note that the amount is a string rather than a number. When working with extremely small fractions or large values, [floating point math can introduce small inaccuracies](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems). Since not all systems have a native way to accurately represent extremely small or large decimals, Stellar uses strings as a reliable way to represent the exact amount across any system.
 
 5. Optionally, you can add your own metadata, called a [memo](../glossary/transactions.mdx#memo), to a transaction. Stellar doesn’t do anything with this data, but you can use it for any purpose you’d like. Many exchanges require memos for incoming transactions because they use a single Stellar account for all their users and rely on the memo to differentiate between internal user accounts.
 
 <CodeExample title="Add a Memo">
-
 
 ```js
 .addMemo(StellarSdk.Memo.text('Test Transaction'))
@@ -417,11 +406,9 @@ Memo: txnbuild.MemoText("Test Transaction")
 
 </CodeExample>
 
-
 6. Now that the transaction has all the data it needs, you have to cryptographically sign it using your secret key. This proves that the data actually came from you and not someone impersonating you.
 
 <CodeExample>
-
 
 ```js
 transaction.sign(sourceKeys);
@@ -444,11 +431,9 @@ transaction.sign(source_key)
 
 </CodeExample>
 
-
 7. And finally, submit it to the Stellar network!
 
 <CodeExample>
-
 
 ```js
 server.submitTransaction(transaction);
@@ -471,7 +456,6 @@ server.submit_transaction(transaction)
 
 </CodeExample>
 
-
 In this example, we're submitting the transaction to the SDF-maintained public testnet instance of Horizon, the Stellar API. When submitting transactions to a Horizon server — which is what most people do — it's possible that you will not receive a response from the server due to a bug, network conditions, etc. In such a situation it's impossible to determine the status of your transaction. That's why you should always save a built transaction (or transaction encoded in XDR format) in a variable or a database and resubmit it if you don't know its status. If the transaction has already been successfully applied to the ledger, Horizon will simply return the saved result and not attempt to submit the transaction again. Only in cases where a transaction’s status is unknown (and thus will have a chance of being included into a ledger) will a resubmission to the network occur.
 
 ## Receive a Payment
@@ -481,7 +465,6 @@ You don’t actually need to do anything to receive payments into a Stellar acco
 However, you may want to keep an eye out for incoming payments. A simple program that watches the network for payments and prints each one might look like:
 
 <CodeExample title="Receive Payments">
-
 
 ```js
 var StellarSdk = require("stellar-sdk");
@@ -591,10 +574,10 @@ paymentsRequest.stream(new EventListener<OperationResponse>() {
       System.out.println(output.toString());
     }
   }
-
+  
   @Override
   public void onFailure(Optional<Throwable> optional, Optional<Integer> optional1) {
-
+  
   }
 });
 ```
@@ -680,11 +663,9 @@ for payment in payments.stream():
 
 </CodeExample>
 
-
 There are two main parts to this program. First, you create a query for payments involving a given account. Like most queries in Stellar, this could return a huge number of items, so the API returns paging tokens, which you can use later to start your query from the same point where you previously left off. In the example above, the functions to save and load paging tokens are left blank, but in a real application, you’d want to save the paging tokens to a file or database so you can pick up where you left off in case the program crashes or the user closes it.
 
 <CodeExample>
-
 
 ```js
 var payments = server.payments().forAccount(accountId);
@@ -716,13 +697,11 @@ if last_token:
 
 </CodeExample>
 
-
 Second, the results of the query are streamed. This is the easiest way to watch for payments or other transactions. Each existing payment is sent through the stream, one by one. Once all existing payments have been sent, the stream stays open and new payments are sent as they are made.
 
 Try it out: Run this program, and then, in another window, create and submit a payment. You should see this program log the payment.
 
 <CodeExample>
-
 
 ```js
 payments.stream({
@@ -765,11 +744,9 @@ for payment in payments.stream():
 
 </CodeExample>
 
-
 You can also request payments in groups or pages. Once you’ve processed each page of payments, you’ll need to request the next one until there are none left.
 
 <CodeExample>
-
 
 ```js
 payments.call().then(function handlePage(paymentsPage) {
@@ -796,7 +773,6 @@ payments_next = payments.next()
 ```
 
 </CodeExample>
-
 
 ## Transacting in Other Currencies
 


### PR DESCRIPTION
I've used `sed` to go through all the mdx files in the `content/`
directory and changed the Go code samples to use the new, simplified syntax.

I'd love some feedback, as I've never used Go. I'm not sure if there are
other places to look for these code samples in the repo, as well.

Signed-off-by: Elliot J. Voris <elliot@voris.me>