### PR TITLE
Update command to install postcss 2

### DIFF
--- a/content/docs/building-apps/project-setup.mdx
+++ b/content/docs/building-apps/project-setup.mdx
@@ -108,7 +108,7 @@ Amazing! Just a few more setup bits and we can get coding. I don’t know about 
 <CodeExample>
 
 ```bash
-npm i -D @stencil/postcss@1 @stencil/sass@1 autoprefixer@9 @types/autoprefixer@9 rollup-plugin-node-polyfills
+npm i -D @stencil/postcss@2 @stencil/sass@1 autoprefixer@9 @types/autoprefixer@9 rollup-plugin-node-polyfills
 ```
 
 </CodeExample>


### PR DESCRIPTION
At the time of this commit, Stencil 2 is the default version when `npm init stencil` is executed. By following the tutorial, the installation of the SCSS tools will fail when installing postcss v1.

This change adapts the installation command to lock on version 2 as major for the postcss library, avoiding dependency tree problems like the one below:

````bash
npm i -D @stencil/postcss@1 @stencil/sass@1 autoprefixer@9 @types/autoprefixer@9 rollup-plugin-node-polyfills
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: stellar-wallet@0.0.1
npm ERR! Found: @stencil/core@2.5.2
npm ERR! node_modules/@stencil/core
npm ERR!   @stencil/core@"^2.0.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @stencil/core@"^1.0.2" from @stencil/postcss@1.0.1
npm ERR! node_modules/@stencil/postcss
npm ERR!   dev @stencil/postcss@"1" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/my-user/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/my-user/.npm/_logs/2021-05-12T22_36_31_436Z-debug.log
````