### PR TITLE
Complete "Run a Core Node" transition to the new Captive Core model.

### DIFF
--- a/content/docs/run-core-node/configuring.mdx
+++ b/content/docs/run-core-node/configuring.mdx
@@ -5,7 +5,7 @@ order: 40
 
 import { CodeExample } from "components/CodeExample";
 
-After you've [installed](./installation.mdx) Stellar Core, your next step is to complete a configuration file that specifies crucial things about your node — like whether it connects to the testnet or the public network, what database it writes to, and which other nodes are in its [quorum set](#choosing-your-quorum-set). You do that using a [TOML](https://github.com/toml-lang/toml), and by default Stellar Core loads that file from `./stellar-core.cfg`. You can specify a different file to load using the command line:
+After you've [installed](./installation.mdx) Stellar Core, your next step is to complete a configuration file that specifies crucial things about your node — like whether it connects to the testnet or the public network, what database it writes to, and which other nodes are in its [quorum set](#choosing-your-quorum-set). You do that using [TOML](https://github.com/toml-lang/toml), and by default Stellar Core loads that file from `./stellar-core.cfg`. You can specify a different file to load using the command line:
 
 `$ stellar-core --conf betterfile.cfg <COMMAND>`
 
@@ -19,15 +19,15 @@ This doc works best in conjunction with concrete config examples, so as you read
 
 - If you want to connect to the testnet, check out the [example test network config](https://github.com/stellar/docker-stellar-core-horizon/blob/master/testnet/core/etc/stellar-core.cfg). As you can see, most of the fields from the [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg) are omitted since the default settings work fine. You can easily tailor this config to meet your testnet needs.
 
-- If you want to connect to the public network, check out this [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg). It includes a properly crafted quorum set with all the current [Tier 1 validators](./tier-1-orgs.mdx), which is a good place to start for most configurations. This node is set up to both [validate](#validating) and write history to a [public archive](./publishing-history-archives.mdx), but you can disable either feature to adjust this config so it's a little lighter.
+- If you want to connect to the public network, check out this [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg). It includes a properly crafted quorum set with all the current [Tier 1 validators](./tier-1-orgs.mdx), which is a good place to start for most configurations. This node is set up to both [validate](#validating) and write history to a [public archive](./publishing-history-archives.mdx), but you can disable either feature by adjusting this config so it's a little lighter.
 
 ## Database
 
 Stellar Core stores two copies of the ledger: one in a SQL database and one in XDR files on local disk called [buckets](#buckets). The database is consulted during consensus, and modified atomically when a transaction set is applied to the ledger. It's random access, fine-grained, and fast.
 
-While a SQLite database works with Stellar Core, we generally recommend using a separate PostgreSQL server. Horizon, for instance, requires PostgreSQL. A Postgres database is the bread and butter of Stellar Core.
+While a SQLite database works with Stellar Core, we generally recommend using a separate PostgreSQL server. A Postgres database is the bread and butter of Stellar Core.
 
-You specify your node's database in the aptly named `DATABASE` field of your config file, which you can can read more about in the [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg#L23). It defaults to an in-memory database, but you can specify a path as per the example config.
+You specify your node's database in the aptly named `DATABASE` field of your config file, which you can can read more about in the [complete example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg#L23). It defaults to an in-memory database, but you can specify a path as per the example.
 
 ## Buckets
 
@@ -68,7 +68,7 @@ If you run more than one node, set the `HOME_DOMAIN` common to those nodes using
 
 ## Choosing Your Quorum Set
 
-No matter what kind of node you run — Basic Validator, Full Validator, or Archiver — you need to select a quorum set, which consists of validators (grouped by organization) that your node checks with to determine whether to apply a transaction set to a ledger. If you want to know more about how qorum sets work, check this article about [how Stellar approaches quorums](https://www.stellar.org/developers-blog/why-quorums-matter-and-how-stellar-approaches-them). If you want to see what a quorum set consisting of all the Tier 1 validators looks like — at tried and true setup — check out the [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg)
+No matter what kind of node you run — Basic Validator, Full Validator, or Archiver — you need to select a quorum set, which consists of validators (grouped by organization) that your node checks with to determine whether to apply a transaction set to a ledger. If you want to know more about how quorum sets work, check this article about [how Stellar approaches quorums](https://www.stellar.org/developers-blog/why-quorums-matter-and-how-stellar-approaches-them). If you want to see what a quorum set consisting of all the Tier 1 validators looks like — a tried and true setup — check out the [public network config for a Full Validator](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg)
 
 A good quorum set:
 
@@ -84,13 +84,13 @@ To generate a quorum set, stellar core:
 - Sets the threshold for each of those subquorums
 - Gives weights to those subquorums based on quality
 
-While this does not absolve you of all responsibility — you still need to pick trustworthy validators and keep an eye on them to ensure that they’re consistent and reliable — it does make your life easier, and reduces the chances for human error.
+While this does not absolve you of all responsibility — you still need to pick trustworthy validators and keep an eye on them to ensure that they’re consistent and reliable — it does make your life easier and reduces the chances for human error.
 
 ### Validator discovery
 
 When you add a validating node to your quorum set, it’s generally because you trust the _organization_ running the node: you trust SDF, not some anonymous Stellar public key.
 
-In order to create a self-verified link between a node and the organization that runs it, a validator declares a home domain on-chain using a `set_options` operation, and publishes organizational information in a stellar.toml file hosted on that domain. To find out how that works, take a look at [SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md).
+In order to create a self-verified link between a node and the organization that runs it, a validator declares a home domain on-chain using a [`set_options` operation](../start/list-of-operations.mdx#set-options), and publishes organizational information in a stellar.toml file hosted on that domain. To find out how that works, take a look at [SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md).
 
 As a result of that link, you can look up a node by its Stellar public key and check the stellar.toml to find out who runs it. It’s possible to do that manually, but you can also just consult the list of nodes on [Stellarbeat.io](https://stellarbeat.io/nodes). If you decide to trust an organization, you can use that list to collect the information necessary to add their nodes to your configuration.
 
@@ -177,14 +177,14 @@ ADDRESS="core.rando.com"
 
 **HIGH** quality validators are given the most weight in automatic quorum set configuration. Before assigning a high quality rating to a node, make sure it has low latency and good uptime, and that the organization running the node is reliable and trustworthy.
 
-A high quality a validator:
+A high quality validator:
 
 - publishes an archive
 - belongs to a suite of nodes that provide redundancy
 
 Choosing redundant nodes is good practice. The archive requirement is programmatically enforced.
 
-**MEDIUM** quality validators are nested below high quality validators, and their combined weight is equivalent to a _single high quality entity_. If a node doesn't publish an archive, but you deem it reliable, or have an organizational interest in including in your quorum set, give it a medium quality rating.
+**MEDIUM** quality validators are nested below high quality validators, and their combined weight is equivalent to a _single high quality entity_. If a node doesn't publish an archive, but you deem it reliable or have an organizational interest in including in your quorum set, give it a medium quality rating.
 
 **LOW** quality validators are nested below medium quality validators, and their combined weight is equivalent to a _single medium quality entity_. Should they prove reliable over time, you can upgrade their rating to medium to give them a bigger role in your quorum set configuration.
 
@@ -247,7 +247,7 @@ If you need to regenerate the metadata, the simplest way is to replay ledgers fo
 
 Some deployments of Stellar Core and Horizon will want to retain metadata for the _entire history_ of the network. This metadata can be quite large and computationally expensive to regenerate anew by replaying ledgers in stellar-core from an empty initial database state, as described in the previous section.
 
-This can be especially costly if run more than once. For instance, when bringing a new node online. Or even if running a single node with Horizon, having already ingested the meta data _once_: a subsequent version of Horizon may have a schema change that entails re-ingesting it _again_.
+This can be especially costly if run more than once. For instance, when bringing a new node online. Or even if running a single node with Horizon, having already ingested the metadata _once_: a subsequent version of Horizon may have a schema change that entails re-ingesting it _again_.
 
 Some operators therefore prefer to shut down their stellar-core (and/or Horizon) processes and _take filesystem-level snapshots_ or _database-level dumps_ of the contents of Stellar Core's database and bucket directory, and/or Horizon's database, after metadata generation has occurred the first time. Such snapshots can then be restored, putting stellar-core and/or Horizon in a state containing metadata without performing full replay.
 

--- a/content/docs/run-core-node/index.mdx
+++ b/content/docs/run-core-node/index.mdx
@@ -40,6 +40,15 @@ To make things easier, we’ll define three types of nodes based on permutations
 | **Full Validator** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | **Archiver** | :heavy_check_mark: | :heavy_check_mark: |  | :heavy_check_mark: |
 
+<Alert>
+
+  In the past, there was also a **Watcher** node, which was designed to run alongside Horizon for transaction submission and observing ledger changes, but not participate in validation or history publication.
+
+  This architecture was **deprecated** as of [Horizon 2.0](https://www.stellar.org/developers-blog/a-new-sun-on-the-horizon), which bundles an optimized "Captive" Core for its operational needs.
+
+</Alert>
+
+
 So why choose one type over another? Let’s break it down a bit and take a look at what each type is good for.
 
 ### Basic Validator
@@ -50,7 +59,7 @@ A Basic Validator keeps track of the ledger and submits transactions for possibl
 
 The advantage: signatures can serve as official endorsements of specific ledgers in real time. That’s important if, for instance, you issue an asset on Stellar that represents a real-world asset: you can let your customers know that you will only honor transactions and redeem assets from ledgers signed by your validator, and in the unlikely scenario that something happens to the network, you can use your node as the final arbiter of truth. Setting up your node as a validator allows you to resolve any questions _up front and in writing_ about how you plan to deal with disasters and disputes.
 
-**Use a Basic Validator to run Horizon, ensure reliable access to the network, and sign off on transactions.**
+**Use a Basic Validator to ensure reliable access to the network and sign off on transactions.**
 
 ### Full Validator
 

--- a/content/docs/run-core-node/index.mdx
+++ b/content/docs/run-core-node/index.mdx
@@ -3,6 +3,8 @@ title: "Overview"
 order: 10
 ---
 
+import { Alert } from "components/Alert";
+
 Stellar is a peer-to-peer network made up of nodes, which are computers that keep a common distributed [ledger](../glossary/ledger.mdx), and that communicate to validate and add [transactions](../glossary/transactions.mdx) to it. Nodes use a program called Stellar Core — an implementation of the [Stellar Consensus Protocol](../glossary/scp.mdx) — to stay in sync as they work to agree on the validity of transaction sets and to apply them to the ledger. Generally, nodes reach consensus, apply a transaction set, and update the ledger every 3-5 seconds.
 
 You don’t need to run a node to build on Stellar: you can start developing with your [SDK of choice](../software-and-sdks/index.mdx), and use public instances of Horizon to query the ledger and submit transactions right away. In fact, the Stellar Development Foundation offers two public instances of Horizon — one for the public network and one for the testnet — which you can read more about in our [API reference docs](../.././api/introduction/index.mdx). [Lobstr](https://horizon.stellar.lobstr.co), [Satoshipay](https://stellar-horizon.satoshipay.io), and [Coinqvest](https://horizon.stellar.coinqvest.com) also offer public Horizon instances.
@@ -71,7 +73,7 @@ When other nodes join the network — or experience difficulty and temporarily f
 
 Generally, organizations that run Full Validators don't use them to query network data or submit transactions. Most of those organizations are also part of — or on track to join — [Tier 1](./tier-1-orgs.mdx), which is a core group of network participants who run three Full Validators to contribute maximum redundancy.
 
-**Use a Full Validator to sign off on transactions, and to contribute to the health and decentralization of the network.**
+**Use a Full Validator to sign off on transactions and to contribute to the health and decentralization of the network.**
 
 ### Archiver
 

--- a/content/docs/run-core-node/installation.mdx
+++ b/content/docs/run-core-node/installation.mdx
@@ -7,11 +7,11 @@ There are three ways to install Stellar Core: you can use a Docker image, use pr
 
 ## Docker-based installation
 
-The SDF maintains a [quickstart image](https://github.com/stellar/docker-stellar-core-horizon) that bundles Stellar Core with Horizon and postgreSQL databases. It's a quick way to set up a default, non-validating, ephemeral configuration that should work for most developers.
+SDF maintains a [quickstart image](https://github.com/stellar/docker-stellar-core-horizon) that bundles Stellar Core with Horizon and postgreSQL databases. It's a quick way to set up a default, non-validating, ephemeral configuration that should work for most developers.
 
 The SDF also maintains a Stellar-Core-only [standalone image](https://github.com/stellar/docker-stellar-core) that starts a 3 node local stellar-core network, all on the same docker host
 
-In addition to the SDF images, Satoshipay maintains Docker separate images for [Stellar Core](https://github.com/satoshipay/docker-stellar-core) and [Horizon](https://github.com/satoshipay/docker-stellar-horizon). The Satoshipay Stellar Core Docker image comes in a few flavors, including one with the AWS CLI installed and one with the Google Cloud SDK installed. The Horizon image supports all Horizon environment varilables.
+In addition to SDF images, Satoshipay maintains separate Docker images for [Stellar Core](https://github.com/satoshipay/docker-stellar-core) and [Horizon](https://github.com/satoshipay/docker-stellar-horizon). The Satoshipay Stellar Core Docker image comes in a few flavors, including one with the AWS CLI installed and one with the Google Cloud SDK installed. The Horizon image supports all Horizon environment variables.
 
 ## Package-based Installation
 

--- a/content/docs/run-core-node/prerequisites.mdx
+++ b/content/docs/run-core-node/prerequisites.mdx
@@ -33,4 +33,4 @@ Stellar Core also needs to connect to certain internal systems, though exactly h
   - And to perform administrative commands such as [scheduling upgrades](./network-upgrades.mdx) and changing log levels
   - For more on that, see [commands](./commands.mdx)
 
-Note: if you need to expose your HTTP endpoint to other hosts in your local network,we recommended using an intermediate reverse proxy server to implement authentication. Don't expose the HTTP endpoint to the raw and cruel open internet.
+Note: if you need to expose your HTTP endpoint to other hosts in your local network, we recommended using an intermediate reverse proxy server to implement authentication. Don't expose the HTTP endpoint to the raw and cruel open internet.

--- a/content/docs/run-core-node/prerequisites.mdx
+++ b/content/docs/run-core-node/prerequisites.mdx
@@ -9,7 +9,7 @@ You can install Stellar Core a [number of different ways](./installation.mdx), a
 
 We recently asked Stellar Core operators about their setups, and should have some updated information soon based on their responses. So stay tuned. In early 2018, Stellar Core with PostgreSQL running on the same machine worked well on a [m5.large](https://aws.amazon.com/ec2/instance-types/m5/) in AWS (dual core 2.5 GHz Intel Xeon, 8 GB RAM). Storage-wise, 20 GB was enough in 2018, but the ledger has grown a lot since then, and most people seem to have at least 1TB on hand.
 
-If you are running Stellar Core in conjunction with Horizon, you will need to ensure that your setup is also equipped to handle Horizon's [compute requirements](../run-api-server/prerequisites.mdx) as well.
+If you decide to run Stellar Core on the same machine as Horizon (though note that this is a deprecated architecture, since Horizon now bundles Core for its needs), you will additionally need to ensure that your setup is also equipped to handle Horizon's [compute requirements](../run-api-server/prerequisites.mdx) as well.
 
 Stellar Core is designed to run on relatively modest hardware so that a whole range of individuals and organizations can participate in the network, and basic nodes should be able to function pretty well without tremendous overhead. That said, the more you ask of your node, the greater the requirements.
 
@@ -17,18 +17,18 @@ Stellar Core is designed to run on relatively modest hardware so that a whole ra
 
 Stellar Core interacts with the peer-to-peer network to keep a distributed ledger in sync, which means that your node needs to make certain [TCP ports](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#TCP_ports) available for inbound and outbound communication.
 
-- **Inbound**: a Stellar Core node needs to allow all ips to connect to its `PEER_PORT` over TCP. You can specify a port when you [configure Stellar Core](./configuring.mdx), but most people use the default, which is **11625**.
-- **Outbound**: a Stellar Core needs to connect to other nodes via thier `PEER_PORT`s TCP. You can find information about other nodes' `PEER_PORT`s on a network explorer like [Stellarbeat](https://stellarbeat.io/), but most use the default port, which is, again, **11625**.
+- **Inbound**: a Stellar Core node needs to allow all IPs to connect to its `PEER_PORT` over TCP. You can specify a port when you [configure Stellar Core](./configuring.mdx), but most people use the default, which is **11625**.
+- **Outbound**: a Stellar Core needs to connect to other nodes via their `PEER_PORT`s TCP. You can find information about other nodes' `PEER_PORT`s on a network explorer like [Stellarbeat](https://stellarbeat.io/), but most use the default port, which is, again, **11625**.
 
 ## Internal System Access
 
 Stellar Core also needs to connect to certain internal systems, though exactly how varies based on your setup.
 
 - **Outbound**:
-  - Stellar Core requires access to a postgreSQL database. If that databse resides on a different machine on your network, you'll need to allow that connection. You specify the databse when you configure Stellar Core.
+  - Stellar Core requires access to a PostgreSQL database. If that databse resides on a different machine on your network, you'll need to allow that connection. You specify the database when you configure Stellar Core.
   - You can block all other connections.
 - **Inbound**: Stellar Core exposes an _unauthenticated_ HTTP endpoint on its `HTTP_PORT`. You can specify a port when you [configure Stellar Core](./configuring.mdx), but most people use the default, which is **11626**.
-  - The `HTTP_PORT` is used by Horizon to submit transactions, so may have to be exposed to the rest of your internal ips
+  - The `HTTP_PORT` is used by Horizon to submit transactions, so may have to be exposed to the rest of your internal IPs
   - It's also used to query Stellar Core [info](./commands.mdx) and provide [metrics](./monitoring.mdx)
   - And to perform administrative commands such as [scheduling upgrades](./network-upgrades.mdx) and changing log levels
   - For more on that, see [commands](./commands.mdx)

--- a/content/docs/run-core-node/publishing-history-archives.mdx
+++ b/content/docs/run-core-node/publishing-history-archives.mdx
@@ -5,7 +5,7 @@ order: 50
 
 import { CodeExample } from "components/CodeExample";
 
-If you want to run a [Full Validator](./index.mdx#full-validator) or an [Archiver](./index.mdx#archiver), you need to set up your node to publish a history archive. You can host an archive using a blob store such as Amazon's s3 or Digital Ocean's spaces, or you can simply serve a local archive directly via an HTTP server such as Nginx or Apache. If you're setting up a [Basic Validator](index.mdx#basic-validator), you can skip this section. No matter what kind of node you're planning to run, make sure to set it up to `get` history, which is covered in [Configuration](./configuring.mdx).
+If you want to run a [Full Validator](./index.mdx#full-validator) or an [Archiver](./index.mdx#archiver), you need to set up your node to publish a history archive. You can host an archive using a blob store such as Amazon's S3 or Digital Ocean's spaces, or you can simply serve a local archive directly via an HTTP server such as Nginx or Apache. If you're setting up a [Basic Validator](index.mdx#basic-validator), you can skip this section. No matter what kind of node you're planning to run, make sure to set it up to `get` history, which is covered in [Configuration](./configuring.mdx).
 
 ## Caching and History Archives
 
@@ -103,7 +103,7 @@ To publish a history archive using Amazon S3:
 
 <CodeExample>
 
-```
+```toml
 [HISTORY.s3]
 get='curl -sf http://history.example.com/{0} -o {1}' # Cached HTTP endpoint
 put='aws s3 cp --region us-east-1 {0} s3://bucket.name/{1}' # Direct S3 access
@@ -190,7 +190,7 @@ The steps required to create a History archive for an existing validator — in 
 
 <CodeExample>
 
-```
+```toml
 [HISTORY.local]
 get="cp /mnt/xvdf/stellar-core-archive/node_001/{0} {1}"
 put="cp {0} /mnt/xvdf/stellar-core-archive/node_001/{1}"


### PR DESCRIPTION
Improves language surrounding Watcher nodes (elaborating on their deprecation) and ensures there are no extraneous references to the old architecture in this section.

Closes #376.