### PR TITLE
Repair broken relative links to other Markdown files.

### DIFF
--- a/content/api/errors/http-status-codes/index.mdx
+++ b/content/api/errors/http-status-codes/index.mdx
@@ -13,13 +13,13 @@ Stellar uses conventional HTTP response codes to indicate the success or failure
 - Codes in the 4xx range indicate an error that failed given the information provided
 - Codes in the 5xx range indicate an error with the Horizon server.
 
-There are two types of Status Codes: [Standard Status Codes](./standard.mdx) and [Horizon-Specific Status Codes](./horizon-specific.mdx).
+There are two types of Status Codes: [Standard Status Codes](./standard.mdx) and [Horizon-Specific Status Codes](./horizon-specific/index.mdx).
 
 <MethodTable title="HTTP Status Code Types">
 
 |  |  |
 | --- | --- |
 | [Standard Status Codes](./standard.mdx) | Generic HTTP responses. |
-| [Horizon-Specific Status Codes](./horizon-specific.mdx) | Errors that are unique to Horizon. |
+| [Horizon-Specific Status Codes](./horizon-specific/index.mdx) | Errors that are unique to Horizon. |
 
 </MethodTable>

--- a/content/api/resources/accounts/object.mdx
+++ b/content/api/resources/accounts/object.mdx
@@ -67,7 +67,7 @@ When Horizon returns information about an account, it uses the following format:
       - If set to `true`, this account can freeze the balance of a holder of an asset issued by this account.
     - auth_clawback_enabled
       - boolean
-      - If set to `true`, trustlines created for assets issued by this account have [clawbacks](../../../../docs/glossary/clawback.mdx) enabled.
+      - If set to `true`, trustlines created for assets issued by this account have [clawbacks](../../../docs/glossary/clawback.mdx) enabled.
 - balances
   - object
   - The assets this account holds.

--- a/content/api/resources/transactions/post.mdx
+++ b/content/api/resources/transactions/post.mdx
@@ -8,7 +8,7 @@ import { ExampleResponse } from "components/ExampleResponse";
 import { CodeExample } from "components/CodeExample";
 import { AttributeTable } from "components/AttributeTable";
 
-This endpoint actually submits a transaction to the Stellar network. It only takes a single, required parameter: the signed transaction. Refer to the [Transactions](../docs/glossary/transactions.mdx) page for details on how to craft a proper one.
+This endpoint actually submits a transaction to the Stellar network. It only takes a single, required parameter: the signed transaction. Refer to the [Transactions](../../../docs/glossary/transactions.mdx) page for details on how to craft a proper one.
 
 <Endpoint>
 

--- a/content/docs/glossary/clawback.mdx
+++ b/content/docs/glossary/clawback.mdx
@@ -46,7 +46,7 @@ Finally, A will perform a clawback on the asset from C. In one scenario, Account
 
 <Alert>
 
-In the following code samples, proper error checking is omitted for brevity. However, you should always validate your results, as there are many ways that requests can fail. You can refer to the guide on [Handling Errors Gracefully](../tutorials/handling-errors/index.mdx) for tips on error management strategies.
+In the following code samples, proper error checking is omitted for brevity. However, you should always validate your results, as there are many ways that requests can fail. You can refer to the guide on [Handling Errors Gracefully](../tutorials/handling-errors.mdx) for tips on error management strategies.
 
 </Alert>
 

--- a/content/docs/run-core-node/index.mdx
+++ b/content/docs/run-core-node/index.mdx
@@ -7,7 +7,7 @@ Stellar is a peer-to-peer network made up of nodes, which are computers that kee
 
 You don’t need to run a node to build on Stellar: you can start developing with your [SDK of choice](../software-and-sdks/index.mdx), and use public instances of Horizon to query the ledger and submit transactions right away. In fact, the Stellar Development Foundation offers two public instances of Horizon — one for the public network and one for the testnet — which you can read more about in our [API reference docs](../.././api/introduction/index.mdx). [Lobstr](https://horizon.stellar.lobstr.co), [Satoshipay](https://stellar-horizon.satoshipay.io), and [Coinqvest](https://horizon.stellar.coinqvest.com) also offer public Horizon instances.
 
-Even if you *do* want to run your [own instance of Horizon](./run-api-server/index.mdx), it bundles its own version of Core and manages its lifetime entirely, so there's no need to run a standalone instance.
+Even if you *do* want to run your [own instance of Horizon](../run-api-server/index.mdx), it bundles its own version of Core and manages its lifetime entirely, so there's no need to run a standalone instance.
 
 If you’re serious about building on Stellar, have a production-level product or service that requires high-availability access network, or want to help increase network health and decentralization, then you probably _do_ want to run a node, or even a trio of nodes (more on that in the [Tier 1 section](./tier-1-orgs.mdx)). At that point, you have a choice: you can pay a service provider like [Blockdaemon](https://app.blockdaemon.com/marketplace/categories/-/stellar-horizon) to set up and run your node for you, or you can do it yourself.
 


### PR DESCRIPTION
I used a script to find & resolve relative paths in the repo, this is the result after fixing all of the ones that didn't resolve to a valid file.