### PR TITLE
Clarify how Horizon handles transaction resubmission.

### DIFF
--- a/content/api/resources/transactions/post.mdx
+++ b/content/api/resources/transactions/post.mdx
@@ -10,6 +10,8 @@ import { AttributeTable } from "components/AttributeTable";
 
 This endpoint actually submits a transaction to the Stellar network. It only takes a single, required parameter: the signed transaction. Refer to the [Transactions](../docs/glossary/transactions.mdx) page for details on how to craft a proper one.
 
+If you submit a transaction that has already been included in a ledger, this endpoint will return the same response as would've been returned for the original transaction submission. This allows for safe resubmission of transactions in error scenarios, as highlighted in the [error-handling guide](../../../docs/tutorials/handling-errors.mdx).
+
 <Endpoint>
 
 |  |  |


### PR DESCRIPTION
`POST /transactions` behaves differently on tx resub, and the API reference should reflect that.