### PR TITLE
Fixing Some Broken Links

### DIFF
--- a/content/docs/building-apps/connect-to-anchors/setup-for-anchored-assets.mdx
+++ b/content/docs/building-apps/connect-to-anchors/setup-for-anchored-assets.mdx
@@ -284,19 +284,19 @@ Let's look at some concrete examples: here’s [StellarX.com’s stellar.toml fi
 <CodeExample>
 
 ```toml
+# StellarX <stellarx.com>
+VERSION="2.2.0"
 FEDERATION_SERVER="https://federation.stellarx.com/federation"
-
 ACCOUNTS=[
 "GDM4UWTGHCWSTM7Z46PNF4BLH35GS6IUZYBWNNI4VU5KVIHYSIVQ55Y6"
 ]
-
 [DOCUMENTATION]
-ORG_NAME="Diamond Ltd."
+ORG_NAME="Ultra Stellar LLC"
 ORG_DBA="StellarX"
 ORG_URL="https://www.stellarx.com"
 ORG_LOGO="https://www.stellarx.com/emailAssets/stellarx.png"
 ORG_DESCRIPTION="The first full-featured trading app for Stellar's universal marketplace"
-ORG_PHYSICAL_ADDRESS="Hamilton, Bermuda"
+ORG_PHYSICAL_ADDRESS="Tallinn, Estonia"
 ORG_OFFICIAL_EMAIL="support@stellarx.com"
 ```
 
@@ -313,13 +313,15 @@ NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 
 ACCOUNTS=["GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX", "GASWJWFRYE55KC7MGANZMMRBK5NPXT3HMPDQ6SEXZN6ZPWYXVVYBFRTE"]
 TRANSFER_SERVER="https://api.anchorusd.com/transfer/"
+TRANSFER_SERVER_SEP0024="https://api.anchorusd.com/transfer/"
 WEB_AUTH_ENDPOINT="https://api.anchorusd.com/api/webauth"
+SIGNING_KEY="GASWJWFRYE55KC7MGANZMMRBK5NPXT3HMPDQ6SEXZN6ZPWYXVVYBFRTE"
 
 [DOCUMENTATION]
 ORG_NAME="AnchorCoin LLC"
 ORG_DBA="AnchorUSD"
 ORG_URL="https://www.anchorusd.com"
-ORG_LOGO="https://www.anchorusd.com/assets/images/logo/logo.png"
+ORG_LOGO="https://stablecoin.anchorusd.com/img/anchorusd.png"
 ORG_DESCRIPTION="AnchorUSD develops a stable cryptocurrency backed one-for-one to the US dollar."
 ORG_TWITTER="AnchorUSD"
 ORG_OFFICIAL_EMAIL="support@anchorusd.com"
@@ -327,18 +329,18 @@ ORG_OFFICIAL_EMAIL="support@anchorusd.com"
 [[PRINCIPALS]]
 name="Jim Berkley-Danz"
 email="j@anchorusd.com"
-twitter="jimdanz"
-github="jimdanz"
 
 [[CURRENCIES]]
 code="USD"
 issuer="GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
 display_decimals=2
+status="live"
+is_asset_anchored=true
 anchor_asset_type="fiat"
 anchor_asset="USD"
 name="US Dollar"
 desc="Cryptocurrency backed one-for-one to the US dollar.  All dollar deposits are held in an audited, US-domiciled escrow account for the exclusive benefit of AnchorUSD token holders."
-image="https://www.anchorusd.com/img/usdx.png"
+image="https://stablecoin.anchorusd.com/img/usdx.png"
 ```
 
 </CodeExample>

--- a/content/docs/building-apps/connect-to-anchors/setup-for-anchored-assets.mdx
+++ b/content/docs/building-apps/connect-to-anchors/setup-for-anchored-assets.mdx
@@ -349,7 +349,7 @@ Once we’ve found an Anchor that supports deposit and withdrawal, we can begin 
 
 [1]: https://github.com/stellar/docs-wallet/tree/trustline
 [2]: https://www.stellarx.com/.well-known/stellar.toml
-[3]: https://www.anchorusd.com/.well-known/stellar.toml
+[3]: https://stablecoin.anchorusd.com/.well-known/stellar.toml
 [4]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
 [5]: https://stellar-anchor-server.herokuapp.com/.well-known/stellar.toml
 [6]: /4%20SEP-0024%20%E2%80%93%20Make%20Use%20of%20Anchors/1%20SEP-0024%20Explained.md

--- a/content/docs/run-api-server/configuring.mdx
+++ b/content/docs/run-api-server/configuring.mdx
@@ -108,7 +108,7 @@ export CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/default/stellar-captive-core-stub.to
 (We suppose, of course, that the above PostgreSQL URI is a [correctly-configured](#preparing-the-database) database.)
 
 ### Configuring Horizon
-On the *local* Horizon instance (i.e. the one htat will connect to the above-configured remote Captive Core), rather than passing the `--captive-core-config-append-path`, `--stellar-core-url`, and `--stellar-core-binary-path` parameters described [above](#parameters), we only need a single parameter:
+On the *local* Horizon instance (i.e. the one that will connect to the above-configured remote Captive Core), rather than passing the `--captive-core-config-append-path`, `--stellar-core-url`, and `--stellar-core-binary-path` parameters described [above](#parameters), we only need a single parameter:
 
 | flag | envvar | example |
 | ---- | ------ | ------- |

--- a/content/docs/run-api-server/installing.mdx
+++ b/content/docs/run-api-server/installing.mdx
@@ -76,7 +76,7 @@ sudo apt install stellar-captive-core stellar-captive-core-api
 </CodeExample>
 
 ### From Source
-Alternatively, you can install the bleeding edge [from source](https://github.com/stellar/go/exp/services/captivecore):
+Alternatively, you can install the bleeding edge [from source](https://github.com/stellar/go/tree/master/exp/services/captivecore):
 
 <CodeExample>
 

--- a/content/docs/start/list-of-operations.mdx
+++ b/content/docs/start/list-of-operations.mdx
@@ -602,7 +602,7 @@ Possible errors:
 | REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE | -4 | Sponsorship cannot be removed from this ledgerEntry. This error will happen if the user tries to remove the sponsorship from a ClaimableBalanceEntry. |
 
 ## Set Trustline Flags
-[JavaScript](http://stellar.github.io/js-stellar-sdk/Operation.html#.setTrustLineFlags) | [Java](http://stellar.github.io/java-stellar-sdk/org/stellar/sdk/SetTrustLineFlags.Builder.html) | [Go](https://godoc.org/github.com/stellar/go/txnbuild#SetTrustLineFlags)
+[JavaScript](http://stellar.github.io/js-stellar-sdk/Operation.html#.setTrustLineFlags) | [Java](http://stellar.github.io/java-stellar-sdk/org/stellar/sdk/SetTrustLineFlagsOperation.Builder.html) | [Go](https://godoc.org/github.com/stellar/go/txnbuild#SetTrustLineFlags)
 
 Allows an issuing account to configure various authorization and trustline flags for all trustlines to an asset. This supercedes the deprecated [`AllowTrust`](#allow-trust), but the documentation there still applies. 
 

--- a/content/docs/start/list-of-operations.mdx
+++ b/content/docs/start/list-of-operations.mdx
@@ -602,9 +602,9 @@ Possible errors:
 | REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE | -4 | Sponsorship cannot be removed from this ledgerEntry. This error will happen if the user tries to remove the sponsorship from a ClaimableBalanceEntry. |
 
 ## Set Trustline Flags
-[JavaScript](http://stellar.github.io/js-stellar-sdk/Operation.html#.setTrustLineFlags) | [Java](http://stellar.github.io/java-stellar-sdk/org/stellar/sdk/SetTrustLineFlagsOperation.Builder.html) | [Go](https://godoc.org/github.com/stellar/go/txnbuild#SetTrustLineFlags)
+[JavaScript](http://stellar.github.io/js-stellar-sdk/Operation.html#.setTrustLineFlags) | [Java](http://stellar.github.io/java-stellar-sdk/org/stellar/sdk/SetTrustlineFlagsOperation.Builder.html) | [Go](https://godoc.org/github.com/stellar/go/txnbuild#SetTrustLineFlags)
 
-Allows an issuing account to configure various authorization and trustline flags for all trustlines to an asset. This supercedes the deprecated [`AllowTrust`](#allow-trust), but the documentation there still applies. 
+Allows an issuing account to configure various authorization and trustline flags for all trustlines to an asset. This supercedes the deprecated [`AllowTrust`](#allow-trust), but the documentation there still applies.
 
 Threshold: Low
 
@@ -666,7 +666,7 @@ Result: `ClaimClaimableBalanceResult`
 | --- | --- | --- |
 | BalanceID | claimableBalanceID | The BalanceID on the ClaimableBalanceEntry that the source account is claiming, which can be retrieved from a succesful `CreateClaimableBalanceResult`. |
 
-Refer to the [ClaimableBalanceID](../glossary/miscellaneous-core-objects.mdx#ClaimableBalanceID) or the [Claimable Balance](../glossary/claimable-balance.mdx) glossary entries for more information on acquiring a claimable balance ID. 
+Refer to the [ClaimableBalanceID](../glossary/miscellaneous-core-objects.mdx#ClaimableBalanceID) or the [Claimable Balance](../glossary/claimable-balance.mdx) glossary entries for more information on acquiring a claimable balance ID.
 
 Possible errors:
 


### PR DESCRIPTION
In the `docs` dir, found and fixed some broken links using [markdown-link-check](https://github.com/tcort/markdown-link-check).

I ran the tool against the `api` directory, as well. Everything looks good there.

Signed-off-by: Elliot J. Voris <elliot@voris.me>