### PR TITLE
Removing Extra JSON Response Data from Payments API Example

### DIFF
--- a/content/api/resources/accounts/payments.mdx
+++ b/content/api/resources/accounts/payments.mdx
@@ -181,65 +181,6 @@ server
         "from": "GDV4KECLSZLKRVH4ZTWVAS4I3W2LPAPV66ADFFUZKGIVOTK6GMKGJT53",
         "to": "GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE",
         "amount": "688.4065454"
-      },
-      {
-        "_links": {
-          "self": {
-            "href": "https://horizon.stellar.org/operations/110694007436259330"
-          },
-          "transaction": {
-            "href": "https://horizon.stellar.org/transactions/26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7"
-          },
-          "effects": {
-            "href": "https://horizon.stellar.org/operations/110694007436259330/effects"
-          },
-          "succeeds": {
-            "href": "https://horizon.stellar.org/effects?order=desc\u0026cursor=110694007436259330"
-          },
-          "precedes": {
-            "href": "https://horizon.stellar.org/effects?order=asc\u0026cursor=110694007436259330"
-          }
-        },
-        "id": "110694007436259330",
-        "paging_token": "110694007436259330",
-        "transaction_successful": true,
-        "source_account": "GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI",
-        "type": "account_merge",
-        "type_i": 8,
-        "created_at": "2019-09-11T13:16:44Z",
-        "transaction_hash": "26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7",
-        "account": "GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI",
-        "into": "GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE"
-      },
-      {
-        "_links": {
-          "self": {
-            "href": "https://horizon.stellar.org/operations/110694007436259329"
-          },
-          "transaction": {
-            "href": "https://horizon.stellar.org/transactions/26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7"
-          },
-          "effects": {
-            "href": "https://horizon.stellar.org/operations/110694007436259329/effects"
-          },
-          "succeeds": {
-            "href": "https://horizon.stellar.org/effects?order=desc\u0026cursor=110694007436259329"
-          },
-          "precedes": {
-            "href": "https://horizon.stellar.org/effects?order=asc\u0026cursor=110694007436259329"
-          }
-        },
-        "id": "110694007436259329",
-        "paging_token": "110694007436259329",
-        "transaction_successful": true,
-        "source_account": "GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI",
-        "type": "create_account",
-        "type_i": 0,
-        "created_at": "2019-09-11T13:16:44Z",
-        "transaction_hash": "26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7",
-        "starting_balance": "1.0000000",
-        "funder": "GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI",
-        "account": "GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE"
       }
     ]
   }


### PR DESCRIPTION
In the example response for the [Payments page](https://developers.stellar.org/api/resources/accounts/payments/), the JSON included `account_merge` and `create_account` operations. I've removed the JSON in question from the example.

Signed-off-by: Elliot J. Voris <elliot@voris.me>