### PR TITLE
Update auth_revoke semantics

### DIFF
--- a/content/docs/issuing-assets/control-asset-access.mdx
+++ b/content/docs/issuing-assets/control-asset-access.mdx
@@ -31,8 +31,6 @@ When `AUTHORIZATION_REVOCABLE` is enabled, an issuer can revoke an existing trus
 
 All changes to asset authorization are performed with the [`allow_trust`](../start/list-of-operations.mdx#allow-trust) operation.
 
-To use this setting, `AUTHORIZATION REQUIRED` must also be enabled.
-
 ## Authorization Immutable
 
 With this setting, neither of the other authorization flags can be set, and the issuing account can’t be merged. You set this flag to signal to potential token holders that your issuing account and its assets will persist on ledger in an open and accessible state. 


### PR DESCRIPTION
[CAP 29](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0029.md) (deployed in protocol V16) was implemented: auth_required is no longer required to revoke.