### PR TITLE
Stop (mis)informing people that the docs are still in beta.

### DIFF
--- a/src/components/BetaNotice.js
+++ b/src/components/BetaNotice.js
@@ -25,7 +25,7 @@ const LinkEl = styled(Link)`
 export const BetaNotice = () => (
   <>
     <BetaNoticeEl>
-      These new docs are in beta. Please submit bugs to{" "}
+      Please submit any typos you come across to{" "}
       <LinkEl href="https://github.com/stellar/new-docs/issues">
         GitHub issues
       </LinkEl>


### PR DESCRIPTION
Since these are the official docs now, there's no reason to refer to them as being "in beta". However, it's still nice to encourage people to report typos and issues on GitHub.