### PR TITLE
Nitpick: Consistency in Tier 1 vs Tier One

### DIFF
--- a/content/docs/run-core-node/tier-1-orgs.mdx
+++ b/content/docs/run-core-node/tier-1-orgs.mdx
@@ -5,7 +5,7 @@ order: 120
 
 To help with Stellar’s decentralization, the most reliable and advanced Stellar teams join the ranks of “Tier 1 Organizations.” These organizations run three validators, coordinate any changes to their quorumsets, and hold themselves to a higher standard of uptime and responsiveness.
 
-SDF works closely with Tier One Orgs to ensure the health of the network, maintain good quorum intersection, and build in redundancy to minimize network disruptions. This guide outlines what it takes to be a Tier 1 Org.
+SDF works closely with Tier 1 Orgs to ensure the health of the network, maintain good quorum intersection, and build in redundancy to minimize network disruptions. This guide outlines what it takes to be a Tier 1 Org.
 
 ## Why Three Validators
 


### PR DESCRIPTION
Avoid mixing "Tier One" and "Tier 1".

_Hating myself just a little bit for nitpicking this, but.. yeah. Writing an article myself and was unsure which way Stellar prefers it to be written, maybe this avoids confusion._