### PR TITLE
Fix a couple of spelling mistakes

### DIFF
--- a/content/docs/run-core-node/installation.mdx
+++ b/content/docs/run-core-node/installation.mdx
@@ -3,7 +3,7 @@ title: Installing
 order: 30
 ---
 
-There are three ways to install Stellar Core: you can use a Docker image, use pre-built packages, or build from source. Using a Docker image is the quickest and easiest method, so it's a good choice for a lot of developers, but if you're running Stellar Core in production you may need to use packages or, if you want to sacrficie convenience for maximum control, build from source. Whichever method you use, you should make sure to install the latest [release](https://github.com/stellar/stellar-core/releases) since releases are cumulative and backwards compatible.
+There are three ways to install Stellar Core: you can use a Docker image, use pre-built packages, or build from source. Using a Docker image is the quickest and easiest method, so it's a good choice for a lot of developers, but if you're running Stellar Core in production you may need to use packages or, if you want to sacrifice convenience for maximum control, build from source. Whichever method you use, you should make sure to install the latest [release](https://github.com/stellar/stellar-core/releases) since releases are cumulative and backwards compatible.
 
 ## Docker-based installation
 

--- a/content/docs/run-core-node/prerequisites.mdx
+++ b/content/docs/run-core-node/prerequisites.mdx
@@ -25,7 +25,7 @@ Stellar Core interacts with the peer-to-peer network to keep a distributed ledge
 Stellar Core also needs to connect to certain internal systems, though exactly how varies based on your setup.
 
 - **Outbound**:
-  - Stellar Core requires access to a PostgreSQL database. If that databse resides on a different machine on your network, you'll need to allow that connection. You specify the database when you configure Stellar Core.
+  - Stellar Core requires access to a PostgreSQL database. If that database resides on a different machine on your network, you'll need to allow that connection. You specify the database when you configure Stellar Core.
   - You can block all other connections.
 - **Inbound**: Stellar Core exposes an _unauthenticated_ HTTP endpoint on its `HTTP_PORT`. You can specify a port when you [configure Stellar Core](./configuring.mdx), but most people use the default, which is **11626**.
   - The `HTTP_PORT` is used by Horizon to submit transactions, so may have to be exposed to the rest of your internal IPs


### PR DESCRIPTION
Spotted two spelling errors whilst reading the documentation over the weekend!

`databse` ➡️ `database`
`sacrficie` ➡️ `sacrifice`