### PR TITLE
Fixing bug in the tutorial sample code

### DIFF
--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -158,7 +158,7 @@ func main () {
     // Build transaction
     tx, err := txnbuild.NewTransaction(
       txnbuild.TransactionParams{
-        SourceAccount:        sourceAccount.AccountID,
+        SourceAccount:        &sourceAccount,
         IncrementSequenceNum: true,
         BaseFee:              txnbuild.MinBaseFee,
         Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
@@ -327,7 +327,7 @@ Transaction transaction = new Transaction.Builder(sourceAccount, Network.TESTNET
 ```go
 tx, err := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        sourceAccount.AccountID,
+    SourceAccount:        &sourceAccount,
     IncrementSequenceNum: true,
     BaseFee:              MinBaseFee,
     Timebounds:           txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!


### PR DESCRIPTION
In `txnbuild`, SourceAccount should take `txnbuild.Account` type instead of a `string`.