### PR TITLE
Add details about AUTH_CLAWBACK_ENABLED where other flags are discussed.

### DIFF
--- a/content/docs/issuing-assets/control-asset-access.mdx
+++ b/content/docs/issuing-assets/control-asset-access.mdx
@@ -9,10 +9,12 @@ When you issue an asset on Stellar, anyone can hold it by default. In general, t
 
 However, if you need to control access to an asset to comply with regulations (or for any other reason), you can easily do so by enabling flags on your issuing account.
 
+
+## Flags
+
 Flags are created on the _account level_ using a [`set_options`](../start/list-of-operations.mdx#set-options) operation. They can be set at any time in the life cycle of an asset, not just when you issue it:
 
-## Authorization Required
-
+### Authorization Required
 When `AUTHORIZATION REQUIRED` is enabled, an issuer must approve an account before that account can hold its asset. This setting allows issuers to vet potential token holders using whatever means they see fit, and to approve trustlines if and only if the holders pass muster. 
 
 To allow access, the user creates a trustline, and the issuer approves it by changing the `AUTHORIZE` flag with the [`allow_trust`](../start/list-of-operations.mdx#allow-trust) operation.
@@ -23,17 +25,21 @@ There are two levels of authorization an asset issuer can grant using the `allow
 * `AUTHORIZED_TO_MAINTAIN_LIABILITIES`: This flag denotes limited authorization that allows an account to maintain current orders, but not to otherwise transact with the asset.   
 
 
-## Authorization Revocable
-
+### Authorization Revocable
 When `AUTHORIZATION_REVOCABLE` is enabled, an issuer can revoke an existing trustline's authorization, thereby freezing the asset held by an account. Doing so prevents that account from transfering or trading the asset, and cancels the account’s open orders for the asset. 
 
 `AUTHORIZATION_REVOCABLE` also allows an issuer to reduce authorization from complete to limited, which prevents the account from transferring or trading the asset, but does not cancel the account's open orders for the asset.  This setting is useful for issuers of regulated assets who need to authorize transactions on a case-by-case basis to ensure each conforms to certain requirements.   
 
 All changes to asset authorization are performed with the [`allow_trust`](../start/list-of-operations.mdx#allow-trust) operation.
 
-## Authorization Immutable
+### Authorization Immutable
+With this setting, neither of the other authorization flags can be set, and the issuing account can’t be merged. You set this flag to signal to potential token holders that your issuing account and its assets will persist on ledger in an open and accessible state.
 
-With this setting, neither of the other authorization flags can be set, and the issuing account can’t be merged. You set this flag to signal to potential token holders that your issuing account and its assets will persist on ledger in an open and accessible state. 
+### Clawback Enabled
+With the `AUTHORIZATION_CLAWBACK_ENABLED` flag set, any *subsequent* trustlines established with this account will have clawbacks enabled. You can read more about clawbacks (and selectively controlling them on a per-trustline basis) [here](../glossary/clawback.mdx).
+
+Note that this flag requires that [revocable](#authorization-revocable) is also set.
+
 
 ## Example flow
 To get a sense of how authorization flags work, let's look at how an issuer of a regulated asset might use the `AUTHORIZED_TO_MAINTAIN_LIABILITIES` flag. 


### PR DESCRIPTION
The [Control Access to an Asset](https://developers.stellar.org/docs/issuing-assets/control-asset-access/) page is missing a description of `AUTH_CLAWBACK_ENABLED`.