### PR TITLE
Drop example since /trade_aggregations isn't a streaming endpoint.

### DIFF
--- a/content/api/aggregations/trade-aggregations/list.mdx
+++ b/content/api/aggregations/trade-aggregations/list.mdx
@@ -178,31 +178,3 @@ server
 ```
 
 </ExampleResponse>
-
-<CodeExample title="JavaScript Streaming Example">
-
-```js
-var StellarSdk = require("stellar-sdk");
-var server = new StellarSdk.Server("https://horizon.stellar.org");
-
-var callback = function (resp) {
-  console.log(resp);
-};
-
-var base = new StellarSdk.Asset.native();
-var counter = new StellarSdk.Asset(
-  "EURT",
-  "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
-);
-var startTime = 1582156800000;
-var endTime = 1582178400000;
-var resolution = 3600000;
-var offset = 0;
-
-var es = server
-  .tradeAggregation(base, counter, startTime, endTime, resolution, offset)
-  .cursor("now")
-  .stream({ onmessage: callback });
-```
-
-</CodeExample>


### PR DESCRIPTION
The `/trade_aggregations` endpoint isn't streamable, so there shouldn't be a corresponding example. Closes #425.