### PR TITLE
Remove performance tracking

### DIFF
--- a/src/components/layout/LayoutBase.js
+++ b/src/components/layout/LayoutBase.js
@@ -3,13 +3,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import Helmet from "react-helmet";
 
-import { PERFORMANCE_MARKS } from "constants/performanceMarks";
-
-import { emitMetric } from "helpers/metrics";
-import { mark, measure } from "helpers/performance";
-
 import { BasicLink } from "basics/Links";
-
 import { Seo } from "./Seo";
 
 const contentId = "content";
@@ -42,47 +36,37 @@ export const LayoutBase = ({
   viewport = "width=device-width, initial-scale=1",
   omitSeoHeadersPredicate,
   seo = {},
-}) => {
-  mark(PERFORMANCE_MARKS.renderLayout);
-  React.useEffect(() => {
-    const timing = measure(PERFORMANCE_MARKS.renderLayout);
-    emitMetric("page rendered", {
-      ...timing,
-      page: window.location.pathname,
-    });
-  });
-  return (
-    <>
-      <Helmet
-        link={[
-          { rel: "stylesheet", type: "text/css", href: "/fonts.css" },
-          {
-            rel: "stylesheet",
-            type: "text/css",
-            href: "/docsearch-stellar.css",
-          },
-        ]}
-        meta={[
-          {
-            name: "viewport",
-            content: viewport,
-          },
-        ]}
-      />
-      <Seo
-        title={title}
-        description={description}
-        previewImage={previewImage}
-        path={path}
-        omitPredicate={omitSeoHeadersPredicate}
-        link={seo.link}
-        meta={seo.meta}
-      />
-      <SkipToContentEl />
-      <ContentEl>{children}</ContentEl>
-    </>
-  );
-};
+}) => (
+  <>
+    <Helmet
+      link={[
+        { rel: "stylesheet", type: "text/css", href: "/fonts.css" },
+        {
+          rel: "stylesheet",
+          type: "text/css",
+          href: "/docsearch-stellar.css",
+        },
+      ]}
+      meta={[
+        {
+          name: "viewport",
+          content: viewport,
+        },
+      ]}
+    />
+    <Seo
+      title={title}
+      description={description}
+      previewImage={previewImage}
+      path={path}
+      omitPredicate={omitSeoHeadersPredicate}
+      link={seo.link}
+      meta={seo.meta}
+    />
+    <SkipToContentEl />
+    <ContentEl>{children}</ContentEl>
+  </>
+);
 
 LayoutBase.propTypes = {
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
Removing performance tracking, which we no longer need. It was breaking the website in Firefox when `resistFingerprinting` flag was enabled.
Keeping the performance methods in case we'll need them again in the future.