### PR TITLE
Add captive core storage path config

### DIFF
--- a/content/docs/run-api-server/ingestion.mdx
+++ b/content/docs/run-api-server/ingestion.mdx
@@ -145,6 +145,7 @@ export HISTORY_ARCHIVE_URLS=https://s3-eu-west-1.amazonaws.com/history.stellar.o
 export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export STELLAR_CORE_BINARY_PATH=$(which stellar-core)
 export ENABLE_CAPTIVE_CORE_INGESTION=true
+export CAPTIVE_CORE_STORAGE_PATH="/var/lib/stellar"
 # Number of ledgers per job sent to the workers.
 # The larger the job, the better performance from Captive Core's perspective,
 # but, you want to choose a job size which maximizes the time all workers are

--- a/content/docs/run-api-server/ingestion.mdx
+++ b/content/docs/run-api-server/ingestion.mdx
@@ -145,7 +145,6 @@ export HISTORY_ARCHIVE_URLS=https://s3-eu-west-1.amazonaws.com/history.stellar.o
 export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export STELLAR_CORE_BINARY_PATH=$(which stellar-core)
 export ENABLE_CAPTIVE_CORE_INGESTION=true
-export CAPTIVE_CORE_STORAGE_PATH="/var/lib/stellar"
 # Number of ledgers per job sent to the workers.
 # The larger the job, the better performance from Captive Core's perspective,
 # but, you want to choose a job size which maximizes the time all workers are
@@ -154,6 +153,10 @@ export PARALLEL_JOB_SIZE=100000
 # Retries per job
 export RETRIES=10
 export RETRY_BACKOFF_SECONDS=20
+
+# Enable following config for stellar-horizon to download buckets locally at specific location.
+# If not enabled, stellar-horizon would download data in the current working directory.
+# export CAPTIVE_CORE_STORAGE_PATH="/var/lib/stellar"
 ```
 
 </CodeExample>


### PR DESCRIPTION
This will add a new flag `export CAPTIVE_CORE_STORAGE_PATH="/var/lib/stellar"` to horizon reingestion config. In the absence of this flag stellar-horizon would flood the current working directory with local buckets containing XDR files.