### PR TITLE
Adds a glossary entry describing muxed accounts

### DIFF
--- a/content/docs/anchoring-assets/enabling-deposit-and-withdrawal/setting-up-test-server.mdx
+++ b/content/docs/anchoring-assets/enabling-deposit-and-withdrawal/setting-up-test-server.mdx
@@ -6,7 +6,7 @@ order: 30
 import { CodeExample } from "components/CodeExample";
 import { Alert } from "components/Alert";
 
-Before setting up a server that connects to live banking rails and real money, you should build out a test rig connected to the [Stellar test network](../../glossary/testnet.mdx). The testnet works just like the main Stellar network, but it uses test data and allows you to fund test accounts for free using a tool called [Friendbot](../../glossary/testnet.mdx#friendbot).
+Before setting up a server that connects to live banking rails and real money, you should build out a test rig connected to the [Stellar test network](../../glossary/testnet.mdx). The testnet works just like the main Stellar network, but it uses test data and allows you to fund test accounts for free using a tool called [Friendbot](../../glossary/testnet.mdx#what-is-the-stellar-testnet-good-for).
 
 <Alert>
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -5,15 +5,15 @@ order:
 
 import { Alert } from "components/Alert";
 
+
+A **muxed** (or *multiplexed*) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
+
 <Alert>
 
   **Warning**: *This feature is experimental.*
-  Multiplexed accounts are not widely supported yet. Many wallets may not display a muxed account address and instead display the account ID address, ignoring the 64-bit ID. Adoption efforts are actively in progress.
+  Muxed accounts are not widely supported yet. Many wallets may not display a muxed account address and instead display the account ID address, ignoring the 64-bit ID. Adoption efforts are actively in progress.
 
 </Alert>
-
-
-A **muxed** (or *multiplexed*) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
 
 Muxed accounts were defined in [CAP-27](https://stellar.org/protocol/cap-27), introduced in Protocol 13, and their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). They have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create new muxed accounts with two different IDs:
 
@@ -28,7 +28,7 @@ There are many other benefits to embedding this abstraction into the protocol:
 
   - **"Share-ability"**: Rather than worrying about error-prone things like copy-pasting memo IDs, you can just share your `M...` address.
   - **SDK support**: The various [SDKs](../software-and-sdks) support this abstraction natively, letting you create, manage, and work with muxed accounts easily.
-  - **Extensibility**: 64 bits available in the ID for distinction between accounts should allow any abstraction.
+  - **Efficiency**: By combining related virtual accounts under a single account's umbrella, you can avoid holding reserves and paying fees for all of them to exist in the ledger individually.
 
 <Alert>
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -81,11 +81,25 @@ Even though at the end of the day, only the underlying `G...` account _truly_ ex
 
 ## Examples
 
-In this section, we'll demonstrate how to create muxed accounts and how they interact with some of the supported operations. To drive home the fact that custodial account workarounds based on transaction memos are superfluous now, we'll use that as a skeleton for our example structure.
+In this section, we'll demonstrate how to create muxed accounts and how seamlessly they interface with their supported operations. To drive home the fact that custodial account workarounds based on transaction memos are superfluous now, we'll use that as a skeleton for our example structure.
+
+After preparing some supporting code, we'll demonstrate three scenarios:
+
+  - [normal](#), "full" Stellar account payments (i.e. G to G),
+  - [mixed](#) payments (i.e. M to G), and
+  - [fully muxed](#) payments (i.e. M to M)
+
+but use a shared function for all of them that does the real work, highlighting the ease of implementing muxed account support.
+
+<Alert>
+
+**Warning**: In the following code samples, proper error checking is omitted for brevity. However, you should always validate your results, as there are many ways that requests can fail. You can refer to the guide on [Handling Errors Gracefully](../tutorials/handling-errors.mdx) for tips on error management strategies.
+
+</Alert>
 
 
 ### Preamble
-First, let's create two accounts and then a handful of virtual accounts representing "custodial customers" that the parent account manages.
+First, let's create two accounts and then a handful of virtual accounts representing "custodial customers" that the parent account manages:
 
 <CodeExample title="Preamble">
 
@@ -118,6 +132,8 @@ async function preamble() {
 ```
 
 </CodeExample>
+
+We assume that these accounts exist on the testnet; you can replace them with your own keys and use the [friendbot](../tutorials/create-account.mdx#create-account) if you'd like.
 
 When we run this function, we'll see the similarity in muxed account addresses among the customers, highlighting the fact that they share a public key:
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -83,9 +83,9 @@ In this section, we'll demonstrate how to create muxed accounts and how seamless
 
 After preparing some supporting code, we'll demonstrate three scenarios:
 
-  - [normal](#), "full" Stellar account payments (i.e. G to G),
-  - [mixed](#) payments (i.e. M to G), and
-  - [fully muxed](#) payments (i.e. M to M)
+  - [normal](#payments), "full" Stellar account payments (i.e. G to G),
+  - [mixed](#muxed-to-unmuxed) payments (i.e. M to G), and
+  - [fully muxed](#muxed-to-muxed) payments (i.e. M to M)
 
 but use a shared function for all of them that does the real work, highlighting the ease of implementing muxed account support.
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -15,7 +15,7 @@ import { Alert } from "components/Alert";
 
 A **multiplexed** (or **muxed**) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address alongside a 64-bit integer ID in order to support differentiating multiple "virtual" accounts that share an underlying "real" account.
 
-They were introduced into the protocol in [CAP-21](https://stellar.org/protocol/cap-21) and their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). Muxed accounts have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create two new muxed accounts with different IDs:
+They were defined in [CAP-27](https://stellar.org/protocol/cap-27) and introduced into Stellar protocol in protocol version 13. Their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). Muxed accounts have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create two muxed accounts with different IDs:
 
   - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ` has the ID `0`, while 
   - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAABUTGI4` has the ID `420`.

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -23,7 +23,7 @@ Muxed accounts were defined in [CAP-27](https://stellar.org/protocol/cap-27), in
 
 Both of these addresses, when used with one of the [supported operations][supported-ops], will act on the underlying `GA7Q...` address.
 
-With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where transaction memos were often used to distinguish between users backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous.
+With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where transaction memos were often used to distinguish between users backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous. In other words, virtual accounts are now a first-class citizen on the network.
 
 There are many other benefits to embedding this abstraction into the protocol:
 
@@ -37,7 +37,7 @@ There are many other benefits to embedding this abstraction into the protocol:
 
 </Alert>
 
-It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did not used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (but have different IDs), this is *exactly the same* as that Stellar account sending two payments as far as the ledger is concerned.
+It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. There's no validation on IDs: as far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did not used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (but have different IDs), this is *exactly the same* as that Stellar account sending two payments as far as the ledger is concerned.
 
 It's worth noting that this feature is intended to be a high-level abstraction, embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did *not* use a muxed account. For example, if you make a payment from two "sibling" muxed accounts (i.e. muxed accounts sharing an underlying `G...` account but with different IDs), this is *exactly the same* as that Stellar account sending two payments, as far as the ledger is concerned.
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -114,8 +114,10 @@ const custodian = sdk.Keypair.fromSecret("SAQLZCQA6AYUXK6JSKVPJ2MZ5K5IIABJOEQIG4
 const outsider  = sdk.Keypair.fromSecret("SAAY2H7SANIS3JLFBFPLJRTYNLUYH4UTROIKRVFI4FEYV4LDW5Y7HDZ4");
 
 async function preamble() {
-  custodianAcc = await server.loadAccount(custodian.publicKey());
-  outsiderAcc  = await server.loadAccount(outsider.publicKey());
+  [ custodianAcc, outsiderAcc ] = await Promise.all([
+    server.loadAccount(custodian.publicKey()),
+    server.loadAccount(outsider.publicKey()),
+  ]);
 
   customers = ["1", "22", "333", "4444"].map(
     (id) => custodianAcc.createSubaccount(id)
@@ -151,70 +153,149 @@ Customers:
 
 </CodeExample>
 
-<Alert>
-
-  In the following examples, we'll rely on the existence of some helper functions to keep things brief. You can refer to the examples on the [Clawback page](./clawback.mdx#preamble:-issuing-a-clawback-able-asset) for definitions of these helpers.
-
-</Alert>
+With the accounts out of the way, let's look at how we can manage the difference between "real" Stellar accounts (`G...`) and these "virtual" muxed accounts (`M...`).
 
 
-### External Payments
-TODO.
-
-
-### Internal Payments
-As we've mentioned, muxed account actions aren't represented in the Stellar ledger explicitly. When two muxed accounts sharing an underlying Stellar account communicate, it's as if the underlying account is talking to itself. A payment between two such accounts, then, is essentially a no-op.
+### Muxed Operations Model
+The introduction of muxed addresses as a higher-level abstraction---and their experimental, opt-in nature---means there are mildly diverging branches of code depending on whether the source is a muxed account or not. We still need to, for example, load accounts by their underlying address, because the muxed versions don't actually live on the Stellar ledger:
 
 <CodeExample>
 
 ```js
-function showBalance(account) {
-  console.log(`${acc.accountId().substring(0, 5)}: ${acc.balances[0]}`);
+function loadAccount(account) {
+  if (account.accountId().startsWith("M")) {
+    return loadAccount(account.baseAccount());
+  } else {
+    return server.loadAccount(account.accountId());
+  }
 }
 
-function doInternalPayment(source, dest) {
-  return server
-    .loadAccount(custodian.publicKey())
+function showBalance(acc) {
+  console.log(`${acc.accountId().substring(0, 5)}: ${acc.balances[0].balance}`);
+}
+```
+
+</CodeExample>
+
+For payments---our focus for this set of examples---the divergence only matters because we want to show the balances for the custodian account.
+
+We also need to selectively enable the opt-in flag if we're passing in properties with that require muxing:
+
+<CodeExample>
+
+```js
+/// Returns `true` if *any* passed parameter seems like a muxed account.
+function isAnyAccountMuxed() {
+  return Array.from(arguments)
+    .map((a) => a.accountId().startsWith('M'))
+    .reduce((t, v) => t || v, false);
+}
+```
+
+</CodeExample>
+
+_(Obviously, a string starting with "M" is not a hard-and-fast indicator of a muxed account; however, we rely on the `Account` objects themselves for prior validation.)_
+
+
+### Payments
+The actual code to build payments is almost exactly the same as it would be without the muxed situation:
+
+<CodeExample>
+
+```js
+function doPayment(source, dest) {
+  return loadAccount(source)
     .then((accountBeforePayment) => {
       showBalance(accountBeforePayment);
-
-      console.log(`Sending 10 XLM from Customer ${source.id()} to Customer ${dest.id()}.`)
 
       let payment = sdk.Operation.payment({
         source: source.accountId(),
         destination: dest.accountId(),
         asset: sdk.Asset.native(),
         amount: "10",
-        withMuxing: true,
+        withMuxing: isAnyAccountMuxed(source, dest),
       });
 
-      let tx = buildTx(custodianAcc, custodian, [payment]);
+      let tx = new TransactionBuilder(accountBeforePayment, {
+          networkPassphrase: StellarSdk.Networks.TESTNET,
+          withMuxing: isAnyAccountMuxed(source, dest),
+          fee: 100,
+        })
+        .addOperation(payment)
+        .setTimeout(30)
+        .build();
+
+      tx.sign(custodian);
       return server.submitTransaction(tx);
     })
-    .then(() => {
-      return server.loadAccount(custodian.publicKey()).then(showBalance);
-    });
+    .then(() => loadAccount(source))
+    .then(showBalance);
 }
 ```
 
 </CodeExample>
 
-Notice the `withMuxing: true` line: because muxed account support is still experimental, you need to explicitly opt-in to creating operations with muxed properties when you pass them in. If you do not pass this flag, the operations will use the underlying Stellar accounts for those properties, instead. You'll also need to pass it to your `TransactionBuilder` options.
+We can use this block to make a payment between normal Stellar accounts with ease: `doPayment("GCIHA...", "GDS5N...")`. The main divergence from the [standard payments code](./tutorials/send-and-receive-payments.mdx#send-a-payment)---aside from the stubs to show XLM balances before and after---is the inclusion of code to detect a muxing situation.
+
+#### Muxed to Unmuxed
+The codeblock above covers all payment operations, abstracting away any need for differentiating between muxed (`M...`) and unmuxed (`G...`) addresses. From a high level, then, it's still trivial to make payments between one of our "customers" and someone outside of the "custodian"'s organization:
+
+<CodeExample>
+
+```js
+preamble
+  .then(() => {
+    const src = customers[0];
+    console.log(`Sending 10 XLM from Customer ${src.id()} to ${outsiderAcc.accountId().substring(0, 5)}.`)
+    return doPayment(src, outsiderAcc);
+  });
+```
+
+</CodeExample>
+
+Notice that we still sign the transaction with the `custodian` keys, because muxed accounts have no concept of secret keys. Ultimately, everything still goes through the "parent" account, and so we should see the account's balance decrease by 10 XLM accordingly:
+
+<CodeExample>
+
+```
+Sending 10 XLM from Customer 1 to GDS5N.
+GCIHA: 9519.9997700 XLM
+GCIHA: 9509.9997600 XLM
+```
+
+</CodeExample>
+
+Of course, there's also a fee charged for the transaction itself.
+
+#### Muxed to Muxed
+As we've mentioned, muxed account actions aren't represented in the Stellar ledger explicitly. When two muxed accounts sharing an underlying Stellar account communicate, it's as if the underlying account is talking to itself. A payment between two such accounts, then, is essentially a no-op.
+
+<CodeExample>
+
+```js
+preamble()
+  .then(() => {
+    const [ src, dst ] = customers.slice(0, 2);
+    console.log(`Sending 10 XLM from Customer ${src.id()} to Customer ${dst.id()}.`)
+    return doPayment(src, dst);
+  });
+```
+
+</CodeExample>
 
 The output should be something like the following:
 
 <CodeExample>
 
 ```
-GCIHA: 9579.9999800 XLM
 Sending 10 XLM from Customer 1 to Customer 22.
+GCIHA: 9579.9999800 XLM
 GCIHA: 9579.9999700 XLM
 ```
 
 </CodeExample>
 
-Notice that the account's balance is essentially unchanged. It was, however, charged a fee for essentially doing a no-op. You may want to detect these types of transactions in your application to avoid paying the transaction fee.
-
+Notice that the account's balance is essentially unchanged. It was, however, charged a fee for essentially doing a no-op. You may want to detect these types of transactions in your application to avoid paying the transaction fee. If we were to make a payment between two muxed accounts that had *different* underlying Stellar accounts, this would be equivalent to a payment between those two respective `G...` accounts.
 
 
 ### More Examples

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Multiplexed Accounts
+title: Muxed Accounts
 order:
 ---
 
@@ -13,36 +13,32 @@ import { Alert } from "components/Alert";
 </Alert>
 
 
-A **multiplexed** (or **muxed**) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
+A **muxed** (or *multiplexed*) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
 
-They were defined in [CAP-27](https://stellar.org/protocol/cap-27) and introduced into Stellar protocol in protocol version 13. Their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). Muxed accounts have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create two muxed accounts with different IDs:
+Muxed accounts were defined in [CAP-27](https://stellar.org/protocol/cap-27), introduced in Protocol 13, and their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). They have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create new muxed accounts with two different IDs:
 
   - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ` has the ID `0`, while 
   - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAABUTGI4` has the ID `420`.
 
 Both of these addresses, when used with one of the [supported operations][supported-ops], will act on the underlying `GA7Q...` address.
 
-With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where the memo was often used to distinguish between customers backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous.
+With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where transaction memos were often used to distinguish between users backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous.
 
 There are many other benefits to embedding this abstraction into the protocol:
 
-  - **"Share-ability"**: Rather than worrying about error-prone things like transaction memo IDs, you can just share the `M...` address.
+  - **"Share-ability"**: Rather than worrying about error-prone things like copy-pasting memo IDs, you can just share your `M...` address.
   - **SDK support**: The various [SDKs](../software-and-sdks) support this abstraction natively, letting you create, manage, and work with muxed accounts easily.
-  - **extensibility**: Using 64 bits for the integer ID embedded into each muxed account ensures that most abstractions can be encoded; it can be used to represent almost anything.
-
+  - **Extensibility**: 64 bits available in the ID for distinction between accounts should allow any abstraction.
 
 <Alert>
 
-  **Terminology Tip**: The term *multiplexing* (often contracted to *muxing*) comes from computer networking and telecommunications, where multiple signals are combined into one signal over a shared medium.
-  We are doing the same thing with muxed accounts: combining multiple "virtual" accounts into a single shared account in the Stellar ledger.
+  **Terminology Tip**: The term *muxing* comes from computer networking and telecommunications, where multiple signals are combined into one signal over a shared medium. We are doing the same thing here with muxed accounts: combining multiple "virtual" accounts into a single shared account in the Stellar ledger.
 
 </Alert>
 
-
 It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did not used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (but have different IDs), this is *exactly the same* as that Stellar account sending two payments as far as the ledger is concerned.
 
-At the end of the day, only the underlying `G...` account _truly_ exists on the ledger. 
-However, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
+It's worth noting that this feature is intended to be a high-level abstraction, embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did *not* use a muxed account. For example, if you make a payment from two "sibling" muxed accounts (i.e. muxed accounts sharing an underlying `G...` account but with different IDs), this is *exactly the same* as that Stellar account sending two payments, as far as the ledger is concerned.
 
 
 ## Supported Operations
@@ -54,16 +50,21 @@ Not all operations can be used with muxed accounts. For example, you cannot pass
     * [`Payment`](../start/list-of-operations.mdx#payment),
     * [`PathPaymentStrictSend`](../start/list-of-operations.mdx#path-payment-strict-send), and
     * [`PathPaymentStrictReceive`](../start/list-of-operations.mdx#path-payment-strict-receive)
-  - the destination of an [`AccountMerge`](../start/list-of-operations.mdx#account-merge),
-  - the fee source of a [fee-bump transaction](./fee-bumps.mdx)
+  - the destination of an [`AccountMerge`](../start/list-of-operations.mdx#account-merge), and
+  - the fee source of a [fee-bump transaction](./fee-bumps.mdx).
+
+We'll demonstrate some of these later in [Examples](#examples).
 
 
 ## Horizon Support
-TODO.
+
+Even though at the end of the day, only the underlying `G...` account _truly_ exists on the Stellar network, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
+
+**TODO.**
 
 
 ## Frequently Asked Questions
-TODO.
+**TODO.**
 
 ### How do I support it in my wallet?
 ### Should I support Muxed Accounts in my wallet?
@@ -75,7 +76,7 @@ TODO.
 In this section, we'll demonstrate how to create muxed accounts and how they interact with some of the supported operations.
 
 
-TODO.
+**TODO.**
 
 
 As is the case for most protocol-level features, you can find more usage examples and inspiration in the relevant test suite for your favorite SDK. For example, [here](https://github.com/stellar/js-stellar-base/blob/master/test/unit/muxed_account_test.js) are some of the JavaScript test cases.

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -4,6 +4,7 @@ order:
 ---
 
 import { Alert } from "components/Alert";
+import { CodeExample } from "components/CodeExample";
 
 
 A **muxed** (or *multiplexed*) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
@@ -43,7 +44,7 @@ It's worth noting that this feature is intended to be a high-level abstraction, 
 
 ## Supported Operations
 
-Not all operations can be used with muxed accounts. For example, you cannot pass muxed accounts to [`CreateAccount`](../start/list-of-operations.mdx#create-account), because only their shared, underlying `G...` account exists in the ledger. However, you can use them with:
+Not all operations can be used with muxed accounts. For example, you cannot set the destination of a [`CreateAccount`](../start/list-of-operations.mdx#create-account) operation to be a muxed account, because only their shared, underlying `G...` account exists in the ledger. However, you can use them with:
 
   - the source account of *any* operation or [transaction](./transactions.mdx),
   - the destination of all three types of payments:
@@ -53,12 +54,12 @@ Not all operations can be used with muxed accounts. For example, you cannot pass
   - the destination of an [`AccountMerge`](../start/list-of-operations.mdx#account-merge), and
   - the fee source of a [fee-bump transaction](./fee-bumps.mdx).
 
-We'll demonstrate some of these later in [Examples](#examples).
+We'll demonstrate some of these later in the [Examples](#examples).
 
 
 ## Horizon Support
 
-Even though at the end of the day, only the underlying `G...` account _truly_ exists on the Stellar network, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
+Even though at the end of the day, only the underlying `G...` account _truly_ exists in the Stellar ledger, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
 
 **TODO.**
 
@@ -73,12 +74,127 @@ Even though at the end of the day, only the underlying `G...` account _truly_ ex
 
 ## Examples
 
-In this section, we'll demonstrate how to create muxed accounts and how they interact with some of the supported operations.
+In this section, we'll demonstrate how to create muxed accounts and how they interact with some of the supported operations. To drive home the fact that custodial account workarounds based on transaction memos are superfluous now, we'll use that as a skeleton for our example structure.
 
 
-**TODO.**
+### Preamble
+First, let's create two accounts and then a handful of virtual accounts representing "custodial customers" that the parent account manages.
+
+<CodeExample title="Preamble">
+
+```js
+const sdk = require("stellar-sdk");
+
+const passphrase = "Test SDF Network ; September 2015";
+const url = "https://horizon-testnet.stellar.org";
+let server = new sdk.Server(url);
+
+const custodian = sdk.Keypair.fromSecret("SAQLZCQA6AYUXK6JSKVPJ2MZ5K5IIABJOEQIG4RVBHX4PG2KMRKWXCHJ");
+const outsider  = sdk.Keypair.fromSecret("SAAY2H7SANIS3JLFBFPLJRTYNLUYH4UTROIKRVFI4FEYV4LDW5Y7HDZ4");
+
+async function preamble() {
+  custodianAcc = await server.loadAccount(custodian.publicKey());
+  outsiderAcc  = await server.loadAccount(outsider.publicKey());
+
+  customers = ["1", "22", "333", "4444"].map(
+    (id) => custodianAcc.createSubaccount(id)
+  );
+
+  console.log("Custodian:\n       ", custodian.publicKey());
+  console.log("Customers:")
+  customers.forEach((customer) => {
+    console.log(" " + customer.id().padStart(4, ' ') + ":",
+                customer.accountId());
+  });
+  console.log();
+}
+```
+
+</CodeExample>
+
+When we run this function, we'll see the similarity in muxed account addresses among the customers, highlighting the fact that they share a public key:
+
+<CodeExample>
+
+```
+Custodian:
+       GCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72MJN
+Customers:
+    1: MCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72AAAAAAAAAAAAEDB4
+   22: MCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72AAAAAAAAAAAC3IHY
+  333: MCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72AAAAAAAAAABJV72I
+ 4444: MCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72AAAAAAAAAARLQOKK
+```
+
+</CodeExample>
+
+<Alert>
+
+  In the following examples, we'll rely on the existence of some helper functions to keep things brief. You can refer to the examples on the [Clawback page](./clawback.mdx#preamble:-issuing-a-clawback-able-asset) for definitions of these helpers.
+
+</Alert>
 
 
+### External Payments
+TODO.
+
+
+### Internal Payments
+As we've mentioned, muxed account actions aren't represented in the Stellar ledger explicitly. When two muxed accounts sharing an underlying Stellar account communicate, it's as if the underlying account is talking to itself. A payment between two such accounts, then, is essentially a no-op.
+
+<CodeExample>
+
+```js
+function showBalance(account) {
+  console.log(`${acc.accountId().substring(0, 5)}: ${acc.balances[0]}`);
+}
+
+function doInternalPayment(source, dest) {
+  return server
+    .loadAccount(custodian.publicKey())
+    .then((accountBeforePayment) => {
+      showBalance(accountBeforePayment);
+
+      console.log(`Sending 10 XLM from Customer ${source.id()} to Customer ${dest.id()}.`)
+
+      let payment = sdk.Operation.payment({
+        source: source.accountId(),
+        destination: dest.accountId(),
+        asset: sdk.Asset.native(),
+        amount: "10",
+        withMuxing: true,
+      });
+
+      let tx = buildTx(custodianAcc, custodian, [payment]);
+      return server.submitTransaction(tx);
+    })
+    .then(() => {
+      return server.loadAccount(custodian.publicKey()).then(showBalance);
+    });
+}
+```
+
+</CodeExample>
+
+Notice the `withMuxing: true` line: because muxed account support is still experimental, you need to explicitly opt-in to creating operations with muxed properties when you pass them in. If you do not pass this flag, the operations will use the underlying Stellar accounts for those properties, instead. You'll also need to pass it to your `TransactionBuilder` options.
+
+The output should be something like the following:
+
+<CodeExample>
+
+```
+GCIHA: 9579.9999800 XLM
+Sending 10 XLM from Customer 1 to Customer 22.
+GCIHA: 9579.9999700 XLM
+```
+
+</CodeExample>
+
+Notice that the account's balance is essentially unchanged. It was, however, charged a fee for essentially doing a no-op. You may want to detect these types of transactions in your application to avoid paying the transaction fee.
+
+
+
+### More Examples
 As is the case for most protocol-level features, you can find more usage examples and inspiration in the relevant test suite for your favorite SDK. For example, [here](https://github.com/stellar/js-stellar-base/blob/master/test/unit/muxed_account_test.js) are some of the JavaScript test cases.
 
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -13,7 +13,7 @@ import { Alert } from "components/Alert";
 </Alert>
 
 
-A **multiplexed** (or **muxed**) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address alongside a 64-bit integer ID in order to support differentiating multiple "virtual" accounts that share an underlying "real" account.
+A **multiplexed** (or **muxed**) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
 
 They were defined in [CAP-27](https://stellar.org/protocol/cap-27) and introduced into Stellar protocol in protocol version 13. Their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). Muxed accounts have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create two muxed accounts with different IDs:
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -37,9 +37,7 @@ There are many other benefits to embedding this abstraction into the protocol:
 
 </Alert>
 
-It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. There's no validation on IDs: as far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did not used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (but have different IDs), this is *exactly the same* as that Stellar account sending two payments as far as the ledger is concerned.
-
-It's worth noting that this feature is intended to be a high-level abstraction, embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did *not* use a muxed account. For example, if you make a payment from two "sibling" muxed accounts (i.e. muxed accounts sharing an underlying `G...` account but with different IDs), this is *exactly the same* as that Stellar account sending two payments, as far as the ledger is concerned.
+It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. There's no validation on IDs: as far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did *not* used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (i.e. muxed accounts sharing an underlying `G...` account but with different IDs), this is *exactly the same* as that Stellar account sending two payments, as far as the ledger is concerned.
 
 
 ## Supporting Opt-In

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -41,7 +41,7 @@ There are many other benefits to embedding this abstraction into the protocol:
 
 It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did not used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (but have different IDs), this is *exactly the same* as that Stellar account sending two payments as far as the ledger is concerned.
 
-At the end of the day, only the underlying `G...` account _truly_ exists. 
+At the end of the day, only the underlying `G...` account _truly_ exists on the ledger. 
 However, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
 
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -7,13 +7,13 @@ import { Alert } from "components/Alert";
 
 <Alert>
 
-  **Warning**: This is an experimental feature in the Stellar ecosystem.
-
+  **Warning**: *This feature is experimental.*
   Multiplexed accounts are not widely supported yet. Many wallets may not display a muxed account address and instead display the account ID address, ignoring the 64-bit ID. Adoption efforts are actively in progress.
+
 </Alert>
 
 
-A **multiplexed** (or **muxed**) account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address alongside a 64-bit integer ID in order to support differentiating multiple "virtual" accounts that share an underlying "real" account.
+A **multiplexed** (or **muxed**) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address alongside a 64-bit integer ID in order to support differentiating multiple "virtual" accounts that share an underlying "real" account.
 
 They were introduced into the protocol in [CAP-21](https://stellar.org/protocol/cap-21) and their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). Muxed accounts have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create two new muxed accounts with different IDs:
 
@@ -33,10 +33,7 @@ There are many other benefits to embedding this abstraction into the protocol:
 
 <Alert>
 
-  **Terminology Tip** :lightbulb:
-
-  The term *multiplexing* (sometimes contracted to *muxing*) comes from computer networking and telecommunications, where multiple signals are combined into one signal over a shared medium.
-
+  **Terminology Tip**: The term *multiplexing* (often contracted to *muxing*) comes from computer networking and telecommunications, where multiple signals are combined into one signal over a shared medium.
   We are doing the same thing with muxed accounts: combining multiple "virtual" accounts into a single shared account in the Stellar ledger.
 
 </Alert>
@@ -52,10 +49,17 @@ However, the [Horizon API](../../api/introduction/) will make some effort to int
 
 Not all operations can be used with muxed accounts. For example, you cannot pass muxed accounts to [`CreateAccount`](../start/list-of-operations.mdx#create-account), because only their shared, underlying `G...` account exists in the ledger. However, you can use them with:
 
-  - the `SourceAccount` of *any* operation or [transaction](./transactions.mdx),
-  - the `destination` of all three types of payments ([`Payment`](../start/list-of-operations.mdx#payment), [`PathPaymentStrictSend`](../start/list-of-operations.mdx#path-payment-strict-send), and [`PathPaymentStrictReceive`](../start/list-of-operations.mdx#path-payment-strict-receive)), 
-  - the `destination` of an [`AccountMerge`](../start/list-of-operations.mdx#account-merge),
-  - the `feeSource` of a [fee-bump transaction](./fee-bumps.mdx)
+  - the source account of *any* operation or [transaction](./transactions.mdx),
+  - the destination of all three types of payments:
+    * [`Payment`](../start/list-of-operations.mdx#payment),
+    * [`PathPaymentStrictSend`](../start/list-of-operations.mdx#path-payment-strict-send), and
+    * [`PathPaymentStrictReceive`](../start/list-of-operations.mdx#path-payment-strict-receive)
+  - the destination of an [`AccountMerge`](../start/list-of-operations.mdx#account-merge),
+  - the fee source of a [fee-bump transaction](./fee-bumps.mdx)
+
+
+## Horizon Support
+TODO.
 
 
 ## Frequently Asked Questions

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -20,7 +20,7 @@ They were introduced into the protocol in [CAP-21](https://stellar.org/protocol/
   - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ` has the ID `0`, while 
   - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAABUTGI4` has the ID `420`.
 
-Both of these addresses, when used with one of the [supported operations][supported-ops], will act on behalf of their underlying `GA7Q...` address.
+Both of these addresses, when used with one of the [supported operations][supported-ops], will act on the underlying `GA7Q...` address.
 
 With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where the memo was often used to distinguish between customers backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous.
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -39,6 +39,8 @@ There are many other benefits to embedding this abstraction into the protocol:
 
 It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. There's no validation on IDs: as far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did *not* used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (i.e. muxed accounts sharing an underlying `G...` account but with different IDs), this is *exactly the same* as that Stellar account sending two payments, as far as the ledger is concerned.
 
+Even though only the underlying `G...` account _truly_ exists in the Stellar ledger, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
+
 
 ## Supporting Opt-In
 
@@ -60,21 +62,6 @@ Not all operations can be used with muxed accounts. For example, you cannot set 
   - the fee source of a [fee-bump transaction](./fee-bumps.mdx).
 
 We'll demonstrate some of these later in the [Examples](#examples).
-
-
-## Horizon Support
-
-Even though at the end of the day, only the underlying `G...` account _truly_ exists in the Stellar ledger, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
-
-**TODO.**
-
-
-## Frequently Asked Questions
-**TODO.**
-
-### How do I support it in my wallet?
-### Should I support Muxed Accounts in my wallet?
-### etc.
 
 
 ## Examples

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -42,9 +42,9 @@ It's worth noting that this feature is intended to be a high-level abstraction, 
 
 ## Supporting Opt-In
 
-Because muxed account support is still experimental, you need to **explicitly opt-in** to creating operations with muxed properties. If you do not pass these opt-in flags in the necessary places, SDKs will throw errors. This is done in an effort to ensure that muxed accounts are not "accidentally" working in your application and thus may be misleading to your users.
+Because muxed account support is still experimental, you need to **explicitly opt-in** to creating operations with muxed properties. Eventually, muxed support will be the default, but for now, if you do not pass these opt-in flags in the necessary places, SDKs will throw errors. This is done in an effort to ensure that muxed accounts are not "accidentally" working in your application and thus may be misleading to your users.
 
-Each SDK implements this a little differently, but generally-speaking you need to explicitly call out muxing support when creating operations and/or transactions that use muxed accounts.
+Each SDK implements this a little differently, but generally-speaking you need to explicitly call out muxing support when creating each operation and/or transaction that uses muxed accounts. 
 
 
 ## Supported Operations

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -53,7 +53,7 @@ Each SDK implements this a little differently, but generally-speaking you need t
 
 Not all operations can be used with muxed accounts. For example, you cannot set the destination of a [`CreateAccount`](../start/list-of-operations.mdx#create-account) operation to be a muxed account, because only their shared, underlying `G...` account exists in the ledger. However, you can use them with:
 
-  - the source account of *any* operation or [transaction](./transactions.mdx),
+  - the source account of *any* [operation](../start/list-of-operations.mdx) or [transaction](./transactions.mdx),
   - the destination of all three types of payments:
     * [`Payment`](../start/list-of-operations.mdx#payment),
     * [`PathPaymentStrictSend`](../start/list-of-operations.mdx#path-payment-strict-send), and
@@ -61,7 +61,7 @@ Not all operations can be used with muxed accounts. For example, you cannot set 
   - the destination of an [`AccountMerge`](../start/list-of-operations.mdx#account-merge), and
   - the fee source of a [fee-bump transaction](./fee-bumps.mdx).
 
-We'll demonstrate some of these later in the [Examples](#examples).
+We'll demonstrate some of these in the [Examples](#examples).
 
 
 ## Examples
@@ -142,7 +142,7 @@ With the accounts out of the way, let's look at how we can manage the difference
 
 
 ### Muxed Operations Model
-The introduction of muxed addresses as a higher-level abstraction---and their experimental, opt-in nature---means there are mildly diverging branches of code depending on whether the source is a muxed account or not. We still need to, for example, load accounts by their underlying address, because the muxed versions don't actually live on the Stellar ledger:
+The introduction of muxed addresses as a higher-level abstraction--and their experimental, opt-in nature--means there are mildly diverging branches of code depending on whether the source is a muxed account or not. We still need to, for example, load accounts by their underlying address, because the muxed versions don't actually live on the Stellar ledger:
 
 <CodeExample>
 
@@ -280,7 +280,9 @@ GCIHA: 9579.9999700 XLM
 
 </CodeExample>
 
-Notice that the account's balance is essentially unchanged. It was, however, charged a fee for essentially doing a no-op. You may want to detect these types of transactions in your application to avoid paying the transaction fee. If we were to make a payment between two muxed accounts that had *different* underlying Stellar accounts, this would be equivalent to a payment between those two respective `G...` accounts.
+Notice that the account's balance is essentially unchanged, yet it was charged a fee since this transaction is still recorded in the ledger despite doing next to nothing. You may want to detect these types of transactions in your application to avoid paying the transaction fee.
+
+If we were to make a payment between two muxed accounts that had *different* underlying Stellar accounts, this would be equivalent to a payment between those two respective `G...` accounts.
 
 
 ### More Examples

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -7,7 +7,7 @@ import { Alert } from "components/Alert";
 import { CodeExample } from "components/CodeExample";
 
 
-A **muxed** (or *multiplexed*) **account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
+A **muxed** (or *multiplexed*) **account** is an account that exists "virtually" under a traditional Stellar account address. It combines the familiar `GABC...` address with a 64-bit integer ID and can be used to distinguish multiple "virtual" accounts that share an underlying "real" account.
 
 <Alert>
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -42,6 +42,13 @@ It's worth noting that this feature is intended to be a high-level abstraction, 
 It's worth noting that this feature is intended to be a high-level abstraction, embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did *not* use a muxed account. For example, if you make a payment from two "sibling" muxed accounts (i.e. muxed accounts sharing an underlying `G...` account but with different IDs), this is *exactly the same* as that Stellar account sending two payments, as far as the ledger is concerned.
 
 
+## Supporting Opt-In
+
+Because muxed account support is still experimental, you need to **explicitly opt-in** to creating operations with muxed properties. If you do not pass these opt-in flags in the necessary places, SDKs will throw errors. This is done in an effort to ensure that muxed accounts are not "accidentally" working in your application and thus may be misleading to your users.
+
+Each SDK implements this a little differently, but generally-speaking you need to explicitly call out muxing support when creating operations and/or transactions that use muxed accounts.
+
+
 ## Supported Operations
 
 Not all operations can be used with muxed accounts. For example, you cannot set the destination of a [`CreateAccount`](../start/list-of-operations.mdx#create-account) operation to be a muxed account, because only their shared, underlying `G...` account exists in the ledger. However, you can use them with:

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -22,7 +22,7 @@ They were introduced into the protocol in [CAP-21](https://stellar.org/protocol/
 
 Both of these addresses, when used with one of the [supported operations][supported-ops], will act on behalf of their underlying `GA7Q...` address.
 
-With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where the memo was often used to differentiate between customers backed by a single custodial account. Now, the embedded ID can be used for this distinction.
+With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where the memo was often used to differentiate between customers backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous.
 
 There are many other benefits to embedding this abstraction into the protocol:
 
@@ -59,18 +59,22 @@ Not all operations can be used with muxed accounts. For example, you cannot pass
 
 
 ## Frequently Asked Questions
+TODO.
 
 ### How do I support it in my wallet?
 ### Should I support Muxed Accounts in my wallet?
+### etc.
+
+
+## Examples
+
+In this section, we'll demonstrate how to create muxed accounts and how they interact with some of the supported operations.
 
 
 TODO.
 
 
-## Examples
-
-In [another documentation section](../building-apps/setup-custodial-account.mdx), we recommended some strategies on setting up a "custodial service" -- a service (like a centralized exchange) where one account manages balances for many users behind the scenes. These were based on [SEP-29](https://stellar.org/protocol/sep-29) and using transactions' [`Memo` field](./transactions.mdx#memo) to encode customer IDs.
-
+As is the case for most protocol-level features, you can find more usage examples and inspiration in the relevant test suite for your favorite SDK. For example, [here](https://github.com/stellar/js-stellar-base/blob/master/test/unit/muxed_account_test.js) are some of the JavaScript test cases.
 
 
 [supported-ops]: #supported-operations

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -22,7 +22,7 @@ They were introduced into the protocol in [CAP-21](https://stellar.org/protocol/
 
 Both of these addresses, when used with one of the [supported operations][supported-ops], will act on behalf of their underlying `GA7Q...` address.
 
-With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where the memo was often used to differentiate between customers backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous.
+With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where the memo was often used to distinguish between customers backed by a single custodial account. Now, the embedded ID can be used for this distinction, and guides like [this one](../building-apps/setup-custodial-account.mdx) can be made superfluous.
 
 There are many other benefits to embedding this abstraction into the protocol:
 

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -118,7 +118,7 @@ async function preamble() {
   ]);
 
   customers = ["1", "22", "333", "4444"].map(
-    (id) => custodianAcc.createSubaccount(id)
+    (id) => new MuxedAccount(custodianAcc, id)
   );
 
   console.log("Custodian:\n       ", custodian.publicKey());

--- a/content/docs/glossary/muxed-accounts.mdx
+++ b/content/docs/glossary/muxed-accounts.mdx
@@ -1,0 +1,76 @@
+---
+title: Multiplexed Accounts
+order:
+---
+
+import { Alert } from "components/Alert";
+
+<Alert>
+
+  **Warning**: This is an experimental feature in the Stellar ecosystem.
+
+  Multiplexed accounts are not widely supported yet. Many wallets may not display a muxed account address and instead display the account ID address, ignoring the 64-bit ID. Adoption efforts are actively in progress.
+</Alert>
+
+
+A **multiplexed** (or **muxed**) account** is an account that exists "on top of" a traditional Stellar account address. It combines the familiar `GABC...` address alongside a 64-bit integer ID in order to support differentiating multiple "virtual" accounts that share an underlying "real" account.
+
+They were introduced into the protocol in [CAP-21](https://stellar.org/protocol/cap-21) and their string representation is described in [SEP-23](https://stellar.org/protocol/sep-21). Muxed accounts have their own address format that starts with an `M` prefix. For example, from the account address `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`, we can create two new muxed accounts with different IDs:
+
+  - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ` has the ID `0`, while 
+  - `MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAABUTGI4` has the ID `420`.
+
+Both of these addresses, when used with one of the [supported operations][supported-ops], will act on behalf of their underlying `GA7Q...` address.
+
+With muxed accounts, we can *natively* support the ecosystem-level abstraction of account memo requirements (see [SEP-29](https://stellar.org/protocol/sep-29)), where the memo was often used to differentiate between customers backed by a single custodial account. Now, the embedded ID can be used for this distinction.
+
+There are many other benefits to embedding this abstraction into the protocol:
+
+  - **"Share-ability"**: Rather than worrying about error-prone things like transaction memo IDs, you can just share the `M...` address.
+  - **SDK support**: The various [SDKs](../software-and-sdks) support this abstraction natively, letting you create, manage, and work with muxed accounts easily.
+  - **extensibility**: Using 64 bits for the integer ID embedded into each muxed account ensures that most abstractions can be encoded; it can be used to represent almost anything.
+
+
+<Alert>
+
+  **Terminology Tip** :lightbulb:
+
+  The term *multiplexing* (sometimes contracted to *muxing*) comes from computer networking and telecommunications, where multiple signals are combined into one signal over a shared medium.
+
+  We are doing the same thing with muxed accounts: combining multiple "virtual" accounts into a single shared account in the Stellar ledger.
+
+</Alert>
+
+
+It's worth noting that this feature is intended to be a high-level abstraction, merely embedded into the protocol for convenience and standardization. As far as the Stellar Network is concerned, all of the [supported operations][supported-ops] operate exactly as if you did not used a muxed account. For example, if you make a payment from two muxed accounts that share an underlying Stellar account (but have different IDs), this is *exactly the same* as that Stellar account sending two payments as far as the ledger is concerned.
+
+At the end of the day, only the underlying `G...` account _truly_ exists. 
+However, the [Horizon API](../../api/introduction/) will make some effort to interpret and track the muxed accounts responsible for certain actions.
+
+
+## Supported Operations
+
+Not all operations can be used with muxed accounts. For example, you cannot pass muxed accounts to [`CreateAccount`](../start/list-of-operations.mdx#create-account), because only their shared, underlying `G...` account exists in the ledger. However, you can use them with:
+
+  - the `SourceAccount` of *any* operation or [transaction](./transactions.mdx),
+  - the `destination` of all three types of payments ([`Payment`](../start/list-of-operations.mdx#payment), [`PathPaymentStrictSend`](../start/list-of-operations.mdx#path-payment-strict-send), and [`PathPaymentStrictReceive`](../start/list-of-operations.mdx#path-payment-strict-receive)), 
+  - the `destination` of an [`AccountMerge`](../start/list-of-operations.mdx#account-merge),
+  - the `feeSource` of a [fee-bump transaction](./fee-bumps.mdx)
+
+
+## Frequently Asked Questions
+
+### How do I support it in my wallet?
+### Should I support Muxed Accounts in my wallet?
+
+
+TODO.
+
+
+## Examples
+
+In [another documentation section](../building-apps/setup-custodial-account.mdx), we recommended some strategies on setting up a "custodial service" -- a service (like a centralized exchange) where one account manages balances for many users behind the scenes. These were based on [SEP-29](https://stellar.org/protocol/sep-29) and using transactions' [`Memo` field](./transactions.mdx#memo) to encode customer IDs.
+
+
+
+[supported-ops]: #supported-operations


### PR DESCRIPTION
This glossary entry is intended to be focused on the technical details behind muxed accounts, but may also be expanded to incorporate an ecosystem- and partner-level FAQ that provides adoption guidance rather than implementation and SDK usage examples.

Jump directly to a preview of the new page with [this link here](https://developers-pr510.previews.kube001.services.stellar-ops.com/docs/glossary/muxed-accounts/).

(cc: @tomerweller and @meiyib as additional reviewers)