### PR TITLE
Updated link to use correct Account Viewer repo

### DIFF
--- a/content/docs/software-and-sdks/index.mdx
+++ b/content/docs/software-and-sdks/index.mdx
@@ -94,7 +94,7 @@ The Stellar laboratory is a GUI that allows you to create accounts, construct an
 
 ### [Account Viewer](https://www.stellar.org/account-viewer/)
 
-The account viewer is a stripped-down wallet that you can use to check an account's XLM balance and send simple payments. It works on the testnet as well as the public network. The source is available [here](https://github.com/stellar/account-viewer).
+The account viewer is a stripped-down wallet that you can use to check an account's XLM balance and send simple payments. It works on the testnet as well as the public network. The source is available [here](https://github.com/stellar/account-viewer-v2).
 
 ### [Anchor Validator](https://anchor-tests.stellar.org/)
 


### PR DESCRIPTION
There was a link to the deprecated account viewer repo. I've updated to use the correct repo link.