### PR TITLE
doc - update send-and-receive-payments.mdx

### DIFF
--- a/content/docs/tutorials/send-and-receive-payments.mdx
+++ b/content/docs/tutorials/send-and-receive-payments.mdx
@@ -210,6 +210,7 @@ from stellar_sdk.network import Network
 from stellar_sdk.server import Server
 from stellar_sdk.transaction_builder import TransactionBuilder
 from stellar_sdk.exceptions import NotFoundError, BadResponseError, BadRequestError
+from stellar_sdk import Asset
 
 server = Server("https://horizon-testnet.stellar.org")
 source_key = Keypair.from_secret("SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4")
@@ -239,7 +240,7 @@ transaction = (
     )
         # Because Stellar allows transaction in many currencies, you must specify the asset type.
         # Here we are sending Lumens.
-        .append_payment_op(destination=destination_id, amount="10", asset_code="XLM")
+        .append_payment_op(destination=destination_id, amount="10", asset=Asset("XLM"))
         # A memo allows you to add your own metadata to a transaction. It's
         # optional and does not affect how Stellar treats the transaction.
         .add_text_memo("Test Transaction")


### PR DESCRIPTION
The given Python example in the current version contains a wrong attribute for the .append_payment_op method within the TransactionBuilder. I fixed it by creating an Asset directly from the Asset Model and added the required import.