### PR TITLE
Integrate LP explanations and cross-references deeper into overall docs

### DIFF
--- a/content/docs/glossary/accounts.mdx
+++ b/content/docs/glossary/accounts.mdx
@@ -63,7 +63,7 @@ Asset issuers set flags at the account level (via [Set Options](../start/list-of
 
 ### Balances
 
-Each account has a balance for each token the account holds, including XLM.
+Each account has a balance for each token or pool share the account holds, including XLM.
 
 ### Liabilities
 

--- a/content/docs/glossary/liquidity-pool.mdx
+++ b/content/docs/glossary/liquidity-pool.mdx
@@ -34,9 +34,9 @@ An automated market maker charges a fee on every trade, and that fee is a fixed 
 
 ## Liquidity Pool Participation
 
-Participation in a liquidity pool is represented by pool shares. Pool shares are very similar to other Stellar assets, but there is one important difference: pool shares are not transferable. The only way to increase the number of pool shares held is to deposit into a liquidity pool, and the only way to decrease the number of pool shares held is to withdraw from a liquidity pool. Two specific examples of this are that pool shares cannot be sent in payments and cannot be sold using offers.
+Participation in a liquidity pool is represented by pool shares. Pool shares are very similar to other Stellar assets, but there is one important difference: pool shares are not transferable. The only way to increase the number of pool shares held is to deposit into a liquidity pool (via [`LiquidityPoolDepositOp`](../start/list-of-operations.mdx#liquidity-pool-deposit), and the only way to decrease the number of pool shares held is to withdraw from a liquidity pool [`LiquidityPoolWithdrawOp`](../start/list-of-operations.mdx#liquidity-pool-withdraw). Two specific examples of this are that pool shares cannot be sent in payments and cannot be sold using offers.
 
-A pool share has two representations. The full representation is used with change trust, and the hashed representation is used in all other cases. When constructing the asset representation of a pool share, the assets must be in lexicographical order. For example, A-B is in the correct order but B-A is not. This results in a canonical representation of a pool share.
+A pool share has two representations. The full representation is used with [`ChangeTrustOp`](../start/list-of-operations.mdx#change-trust), and the hashed representation is used in all other cases. When constructing the asset representation of a pool share, the assets must be in lexicographical order. For example, A-B is in the correct order but B-A is not. This results in a canonical representation of a pool share.
 
 ### Trustlines
 

--- a/content/docs/issuing-assets/anatomy-of-an-asset.mdx
+++ b/content/docs/issuing-assets/anatomy-of-an-asset.mdx
@@ -32,7 +32,12 @@ Before an account can hold an asset another account issues, it has to establish 
 
 A trustline is an explicit opt-in to hold a particular token, so it specifies both asset code and issuer. Each trustline increases an account’s minimum lumen balance by one [base reserve](../glossary/minimum-balance.mdx) — currently 0.5 XLM — and tracks the balance of the asset the account holds. Trustlines can also limit the amount of an asset an account can hold, though more often than not, account holders don’t set that limit: they simply turn the trustline on, which by default allows the maximum.
 
+### Liabilities
 A trustline also tracks liabilities. Buying liabilities equal the total amount of the asset offered to buy aggregated over all offers owned by an account, and selling liabilities equal the total amount of the asset offered to sell aggregated over all offers owned by an account. A trustline must always have balance sufficiently large to satisfy its selling liabilities, and a balance sufficiently below its limit to accommodate its buying liabilities.
+
+### Pool Shares
+With the introduction of native support for liquidity pools in [Protocol 18](https://stellar.org/developers-blog/liquidity-liquidity-liquidity), assets can also be *pool shares*, representing ownership of the pool's reserves. Users need to establish trustlines to three different assets to participate in a liquidity pool: both of the reserve assets (unless one of them is native) and the pool share asset itself. The pool share asset is defined by the liquidity pool identifier, which in turn is defined by the two assets its reserves are composed of. You should refer to the [glossary entry](../glossary/liquidity-pool.mdx#liquidity-pool-participation) for details on liquidity pool participation.
+
 
 ## Representation
 

--- a/content/docs/start/list-of-operations.mdx
+++ b/content/docs/start/list-of-operations.mdx
@@ -359,13 +359,15 @@ Creates, updates, or deletes a trustline. For more on trustlines, please refer t
 
 To delete an existing trustline, set Line to the asset of the trustline, and Limit to `0`.
 
+The `Line` parameter is an instance of a `ChangeTrustAsset`. If you are modifying a trustline to a regular asset (i.e. one in a `Code:Issuer` format), this is equivalent to the `Asset` type. If you are modifying a trustline to a *pool share*, however, this is composed of the liquidity pool reserve assets and the pool fee. You can refer to the liquidity pool [glossary entry](../glossary/liquidity-pool.mdx#liquidity-pool-participation) and the examples therein for details. 
+
 Threshold: Medium
 
 Result: `ChangeTrustResult`
 
 | Parameters | Type | Description |
 | --- | --- | --- |
-| Line | asset | The asset of the trustline. For example, if a user extends a trustline of up to 200 USD to an anchor, the `line` is USD:anchor. |
+| Line | ChangeTrustAsset | The asset of the trustline. For example, if a user extends a trustline of up to 200 USD to an anchor, the `line` is USD:anchor. |
 | Limit | integer | The limit of the trustline. In the previous example, the `limit` would be 200. |
 
 Possible errors:
@@ -615,6 +617,8 @@ Possible errors:
 
 Allows an issuing account to configure various authorization and trustline flags for all trustlines to an asset. This supersedes the deprecated [`AllowTrust`](#allow-trust), but the documentation there still applies.
 
+The `Asset` parameter is of the `TrustLineAsset` type. If you are modifying a trustline to a regular asset (i.e. one in a `Code:Issuer` format), this is equivalent to the `Asset` type. If you are modifying a trustline to a *pool share*, however, this is composed of the liquidity pool's unique ID. You can refer to the liquidity pool [glossary entry](../glossary/liquidity-pool.mdx#liquidity-pool-participation) and the examples therein for details.
+
 Threshold: Low
 
 Result: `SetTrustLineFlagsResult`
@@ -622,7 +626,7 @@ Result: `SetTrustLineFlagsResult`
 | Parameters | Type | Description |
 | --- | --- | --- |
 | Trustor | account ID | The account that established this trustline. |
-| Asset | asset | The asset trustline whose flags are being modified. |
+| Asset | TrustLineAsset | The asset trustline whose flags are being modified. |
 | SetFlags | integer | One or more flags (combined via bitwise-OR) indicating which flags to **set**. Possible flags are: `1` if the trustor is authorized to transact with the asset or `2` if the trustor is authorized to maintain offers but not to perform other transactions. |
 | ClearFlags | integer | One or more flags (combined via bitwise `OR`) indicating which flags to **clear**. Possibilities include those for `SetFlags`as well as `4`, which prevents the issuer from clawing back its asset (both from accounts and claimable balances). |
 
@@ -690,9 +694,11 @@ Possible errors:
 
 Deposits assets into a liquidity pool.
 
-Depositing increases the reserves of a liquidity pool in exchange for pool shares. Parameters to this operation depend on the ordering of assets in the liquidity pool (see the liquidity pool glossary entry for information about how to determine the ordering of assets). “A” refers to the first asset in the liquidity pool, and “B” refers to the second asset in the liquidity pool.
+Depositing increases the reserves of a liquidity pool in exchange for pool shares. 
 
-If the pool is empty, then this operation deposits maxAmountA of A and maxAmountB of B into the pool. If the pool is not empty, then this operation deposits at most maxAmountA of A and maxAmountB of B into the pool. The actual amounts deposited are determined using the current reserves of the pool.
+Parameters to this operation depend on the ordering of assets in the liquidity pool: “A” refers to the first asset in the liquidity pool, and “B” refers to the second asset in the liquidity pool. Refer to the liquidity pool [glossary entry](../glossary/liquidity-pool.mdx#liquidity-pool-participation) for information about how to determine the fixed ordering of assets. SDKs often have helpers (like [`Asset.compare`](https://stellar.github.io/js-stellar-base/Asset.html#.compare)) to determine the right order.
+
+If the pool is empty, then this operation deposits `maxAmountA` of A and `maxAmountB` of B into the pool. If the pool is not empty, then this operation deposits **at most** `maxAmountA` of A and `maxAmountB` of B into the pool. The actual amounts deposited are determined using the current reserves of the pool. You can use these parameters to control a percentage of slippage; refer to the [example](../glossary/liquidity-pool.mdx#participation:-deposits) for details.
 
 Threshold: Medium
 
@@ -722,7 +728,11 @@ Possible errors:
 
 Withdraw assets from a liquidity pool.
 
-Withdrawing reduces the number of pool shares in exchange for reserves from a liquidity pool. Parameters to this operation depend on the ordering of assets in the liquidity pool (see the liquidity pool glossary entry for information about how to determine the ordering of assets). “A” refers to the first asset in the liquidity pool, and “B” refers to the second asset in the liquidity pool.
+Withdrawing reduces the number of pool shares in exchange for reserves from a liquidity pool.
+
+Refer to the discussion on asset ordering in [Liquidity Pool Deposit](#liquidity-pool-deposit), above, for details on the “A” and “B” parameters.
+
+The `minAmountA` and `minAmountB` parameters can be used to control a percentage of slippage from the "spot price" on the pool; refer to the [example](../glossary/liquidity-pool.mdx#participation:-deposits) for details.
 
 Threshold: Medium
 


### PR DESCRIPTION
This includes:
 - more explanation of the `min`/`maxAmount` parameters in deposit/withdrawal operations
 - deeper explanation of parameter changes to `ChangeTrust` and `SetTrustLineFlags`
 - more cross-references between the glossary entry and the list of operations
 - mention of pool shares in the documentation about asset issuance