### PR TITLE
Add context for CHANGE_TRUST_INVALID_LIMIT error

### DIFF
--- a/content/docs/start/list-of-operations.mdx
+++ b/content/docs/start/list-of-operations.mdx
@@ -374,7 +374,7 @@ Possible errors:
 | --- | --- | --- |
 | CHANGE_TRUST_MALFORMED | -1 | The input to this operation is invalid. |
 | CHANGE_TRUST_NO_ISSUER | -2 | The issuer of the asset cannot be found. |
-| CHANGE_TRUST_INVALID_LIMIT | -3 | The `limit` is not sufficient to hold the current balance of the trustline and still satisfy its buying liabilities. |
+| CHANGE_TRUST_INVALID_LIMIT | -3 | The `limit` is not sufficient to hold the current balance of the trustline and still satisfy its buying liabilities. This error occurs when attempting to remove a trustline with a non-zero asset balance. |
 | CHANGE_TRUST_LOW_RESERVE | -4 | This account does not have enough XLM to satisfy the minimum XLM reserve increase caused by adding a subentry and still satisfy its XLM selling liabilities. For every new trustline added to an account, the minimum reserve of XLM that account must hold increases. |
 | CHANGE_TRUST_SELF_NOT_ALLOWED | -5 | The source account attempted to create a trustline for itself, which is not allowed. |
 


### PR DESCRIPTION
A partner mentioned how this wasn't clear in the docs. Although its not semantically different, removing a trustline is conceptually different than adjusting it's limit, so having a invalid limit error raised when trying to remove it entirely can be confusing.