### PR TITLE
Add / Update API endpoints and responses for Protocol 18

### DIFF
--- a/content/api/resources/liquiditypools/list.mdx
+++ b/content/api/resources/liquiditypools/list.mdx
@@ -15,7 +15,7 @@ This endpoint lists all available liquidity pools.
 
 |  |  |
 | --- | --- |
-| GET | /liquidity_pools?reserves={:reserves}&cursor={paging_token}&order={asc,desc}&limit={1-200} |
+| GET | /liquidity_pools?reserves={:reserves}&account={:account_id}&cursor={paging_token}&order={asc,desc}&limit={1-200} |
 
 </Endpoint>
 
@@ -28,7 +28,10 @@ This endpoint lists all available liquidity pools.
   - DESCRIPTION
 - reserves
   - string (optional)
-  - Comma-separated list of assets, represented as "Code:IssuerAccountID". Only include liquidity pools which have reserves matching all listed assets.
+  - Comma-separated list of assets in canonical form (`Code:IssuerAccountID`), to only include liquidity pools which have reserves matching _all_ listed assets.
+- account
+  - string (optional)
+  - A Stellar account ID, to only include liquidity pools in which this account is participating in (i.e. holds pool shares to).
 - cursor
   - string (optional)
   - A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
@@ -56,12 +59,8 @@ var server = new StellarSdk.Server("https://horizon.stellar.org");
 server
   .liquidityPools()
   .call()
-  .then(function (resp) {
-    console.log(resp);
-  })
-  .catch(function (err) {
-    console.error(err);
-  });
+  .then(response => console.log(response))
+  .catch(err => console.error(err));
 ```
 
 ```python

--- a/content/api/resources/operations/object/change-trust.mdx
+++ b/content/api/resources/operations/object/change-trust.mdx
@@ -17,22 +17,25 @@ See the [`Change Trust` errors](../../../errors/result-codes/operation-specific/
   - DESCRIPTION
 - asset_type
   - string
-  - The type of asset being trusted. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+  - The type of asset being trusted, one of `native`, `credit_alphanum4`, `credit_alphanum12`, or `liquidity_pool_shares`.
 - asset_code
   - string
-  - The Stellar address of the asset being trusted.
+  - The Stellar address of the asset being trusted. (Only present for credit assets.)
 - asset_issuer
   - string
-  - The code for the asset being trusted.
+  - The code for the asset being trusted. (Only present for credit assets.)
 - limit
   - string
   - Limits the amount of an asset that the source account can hold.
 - trustee
   - string
-  - The issuing account.
+  - The issuing account. (Only present for credit assets.)
 - trustor
   - string
   - The source account.
+- liquidity_pool_id
+  - string
+  - The liquidity pool whose trustline is being modified. (Only present for `asset_type == liquidity_pool_shares`.)
 
 </AttributeTable>
 

--- a/content/api/resources/operations/object/end-sponsoring-future-reserves.mdx
+++ b/content/api/resources/operations/object/end-sponsoring-future-reserves.mdx
@@ -10,7 +10,6 @@ End a sponsorship.
 
 <AttributeTable>
 
-
 - ATTRIBUTE
   - DATA TYPE
   - DESCRIPTION

--- a/content/api/resources/operations/object/liquidity-pool-deposit.mdx
+++ b/content/api/resources/operations/object/liquidity-pool-deposit.mdx
@@ -1,0 +1,117 @@
+---
+title: Liquidity Pool Deposit Object
+order: 200
+---
+
+import { ExampleResponse } from "components/ExampleResponse";
+import { AttributeTable } from "components/AttributeTable";
+
+Deposit asset reserves into a liquidity pool.
+
+See the [`Liquidity Pool Deposit` operation](../../../../docs/start/list-of-operations.mdx#liquidity-pool-deposit) for parameters, errors, etc.
+
+<AttributeTable>
+
+- ATTRIBUTE
+  - DATA TYPE
+  - DESCRIPTION
+- liquidity_pool_id
+  - string
+  - The liquidity pool associated with this deposit
+- reserves_max
+  - array 
+  - An array of objects corresponding to the maximum amount of each reserve that could've been deposited
+    - asset
+      - string
+      - The asset in canonical (`Code:Issuer`) form
+    - amount
+      - string
+      - A floating point value encoded as a string
+- min_price
+  - string
+  - A floating point value encoded as a string indicating the minimum exchange rate for this deposit operation
+- min_price_r
+  - object
+  - A precise (fractional) representation of the buy and sell price of the assets on offer.
+    - n
+      - number
+      - The numerator.
+    - d
+      - number
+      - The denominator.
+- max_price
+  - string
+  - A floating point value encoded as a string indicating the maximum exchange rate for this deposit operation
+- max_price_r
+  - object
+  - A precise (fractional) representation of the buy and sell price of the assets on offer.
+    - n
+      - number
+      - The numerator.
+    - d
+      - number
+      - The denominator.
+- reserves_deposited
+  - array
+  - An array of objects representing how much of each reserve ended up actually deposited into the pool 
+    - asset
+      - string
+      - The asset in canonical (`Code:Issuer`) form
+    - amount
+      - string
+      - A floating point value encoded as a string
+- shares_received
+  - string
+  - A floating point value encoded as a string representing the number of pool shares received for this deposit
+
+</AttributeTable>
+
+
+<ExampleResponse>
+
+```json
+{
+  "id": "3697472920621057",
+  "paging_token": "3697472920621057",
+  "transaction_successful": true,
+  "source_account": "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
+  "type": "liquidity_pool_deposit",
+  "type_i": 22,
+  "created_at": "2021-11-18T03:47:47Z",
+  "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
+  "liquidity_pool_id": "abcdef",
+  "reserves_max": [
+    {
+      "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+      "amount": "1000.0000005"
+    },
+    {
+      "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+      "amount": "3000.0000005"
+    }
+  ],
+  "min_price": "0.2680000",
+  "min_price_r": {
+    "n": 67,
+    "d": 250
+  },
+  "max_price": "0.3680000",
+  "max_price_r": {
+    "n": 73,
+    "d": 250
+  },
+  "reserves_deposited": [
+    {
+      "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+      "amount": "983.0000005"
+    },
+    {
+      "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+      "amount": "2378.0000005"
+    }
+  ],
+  "shares_received": "1000"
+}
+```
+
+</ExampleResponse>

--- a/content/api/resources/operations/object/liquidity-pool-withdraw.mdx
+++ b/content/api/resources/operations/object/liquidity-pool-withdraw.mdx
@@ -1,0 +1,93 @@
+---
+title: Liquidity Pool Deposit Object
+order: 210
+---
+
+import { ExampleResponse } from "components/ExampleResponse";
+import { AttributeTable } from "components/AttributeTable";
+
+Withdraws asset reserves from a liquidity pool by redeeming pool shares.
+
+See the [`Liquidity Pool Withdraw` operation](../../../../docs/start/list-of-operations.mdx#liquidity-pool-withdraw) for parameters, errors, etc.
+
+<AttributeTable>
+
+- ATTRIBUTE
+  - DATA TYPE
+  - DESCRIPTION
+- liquidity_pool_id
+  - string
+  - The liquidity pool associated with this withdrawal
+- reserves_min
+  - array 
+  - An array of objects corresponding to the minimum amount of each reserve that should've been withdrawn
+    - asset
+      - string
+      - The asset in canonical (`Code:Issuer`) form
+    - amount
+      - string
+      - A floating point value encoded as a string
+- shares
+  - string
+  - The number of shares that were redeemed for this withdrawal operation
+- reserves_received
+  - array
+  - An array of objects representing how much of each reserve ended up actually withdrawn from the pool 
+    - asset
+      - string
+      - The asset in canonical (`Code:Issuer`) form
+    - amount
+      - string
+      - A floating point value encoded as a string
+
+</AttributeTable>
+
+
+<ExampleResponse>
+
+```json
+{
+  "id": "3697472920621057",
+  "paging_token": "3697472920621057",
+  "transaction_successful": true,
+  "source_account": "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
+  "type": "liquidity_pool_deposit",
+  "type_i": 22,
+  "created_at": "2021-11-18T03:47:47Z",
+  "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
+  "liquidity_pool_id": "abcdef",
+  "reserves_max": [
+    {
+      "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+      "amount": "1000.0000005"
+    },
+    {
+      "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+      "amount": "3000.0000005"
+    }
+  ],
+  "min_price": "0.2680000",
+  "min_price_r": {
+    "n": 67,
+    "d": 250
+  },
+  "max_price": "0.3680000",
+  "max_price_r": {
+    "n": 73,
+    "d": 250
+  },
+  "reserves_deposited": [
+    {
+      "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+      "amount": "983.0000005"
+    },
+    {
+      "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+      "amount": "2378.0000005"
+    }
+  ],
+  "shares_received": "1000"
+}
+```
+
+</ExampleResponse>

--- a/content/api/resources/operations/object/liquidity-pool-withdraw.mdx
+++ b/content/api/resources/operations/object/liquidity-pool-withdraw.mdx
@@ -1,5 +1,5 @@
 ---
-title: Liquidity Pool Deposit Object
+title: Liquidity Pool Withdraw Object
 order: 210
 ---
 


### PR DESCRIPTION
This adds two new operation response objects:
 - liquidity pool deposit
 - liquidity pool withdraw
updates the response for change trust to reflect the new asset type, and adds the new filter on the liquidity pool list endpoint.

Reference: the [Horizon Protocol 18 API spec](https://docs.google.com/document/d/1pXL8kr1a2vfYSap9T67R-g72B_WWbaE1YsLMa04OgoU).

Should address stellar/go#3884.