### PR TITLE
Change Error values to match with Horizon

### DIFF
--- a/content/api/errors/result-codes/operation-specific/change-trust.mdx
+++ b/content/api/errors/result-codes/operation-specific/change-trust.mdx
@@ -15,10 +15,10 @@ Learn more about the [`Change Trust` operation](../../../../docs/start/list-of-o
 - OpSuccess
   - CHANGE_TRUST_SUCCESS
   - Trust was successfully changed
-- OpMalformed
+- op_malformed
   - CHANGE_TRUST_MALFORMED
   - The input to this operation is invalid.
-- OpNoIssuer
+- op_no_issuer
   - CHANGE_TRUST_NO_ISSUER
   - The issuer of the asset cannot be found.
 - op_invalid_limit


### PR DESCRIPTION
Hey there!

When encountering an Error while submitting to Horizon, the outputs mentioned in the documentation and what horizon outputs aren't the same. You can see here in the following example: `{"transaction":"tx_failed","operations":["op_no_issuer"]}`

In this PR I submit changes to match with Horizon and also matches with the other error values :)