### PR TITLE
Update testnet.mdx

### DIFF
--- a/content/docs/glossary/testnet.mdx
+++ b/content/docs/glossary/testnet.mdx
@@ -56,7 +56,7 @@ SDF will try to make testnet resets as painless as possible, and will announce t
 The testnet resets once per quarter (every three months). The 2022 dates:
 
 - 3/16/22
-- 6/15/22
+- 6/22/22
 - 9/14/22
 - 12/14/22
 


### PR DESCRIPTION
Moving the testnet reset back a week (to 6/22) to give the ecosystem 2 weeks notice.