### PR TITLE
Remove questionnaire link

### DIFF
--- a/content/docs/tutorials/moneygram-access-integration-guide.mdx
+++ b/content/docs/tutorials/moneygram-access-integration-guide.mdx
@@ -8,7 +8,7 @@ import { Alert } from "components/Alert";
 
 This document guides the reader through the technical requirements for integrating [MoneyGram Access] into an existing application. MoneyGram Access is a MoneyGram product that enables users of third-party applications, such as crypto wallets and exchanges, to cash-in (deposit) and cash-out (withdrawal) of Stellar USDC.
 
-MoneyGram requires businesses to go through an onboarding process in order to get access to their testing and production environments. To get started with this process, fill out the [MoneyGram Screening Questionnaire] and reach out to partnerships@stellar.org.
+MoneyGram requires businesses to go through an onboarding process in order to get access to their testing and production environments. To get started with this process, reach out to partnerships@stellar.org.
 
 ## Resources
 


### PR DESCRIPTION
Tom CL wanted to remove the questionnaire link because he's getting submissions without the correct information/context.