### PR TITLE
Fix API service example for minimal captive-core

### DIFF
--- a/content/docs/run-api-server/configuring.mdx
+++ b/content/docs/run-api-server/configuring.mdx
@@ -112,6 +112,8 @@ While a full Stellar Core node requires a complex configuration with [lots of po
 <CodeExample>
 
 ```toml
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
 [[HOME_DOMAINS]]
 HOME_DOMAIN="testnet.stellar.org"
 QUALITY="HIGH"


### PR DESCRIPTION
### What
Add the `NETWORK_PASSPHRASE` parameter to the minimal captive-core config example.

### Why
Running stellar-core in captive core mode without the network passphrase in the config results in an error:
```2022-11-18T16:42:58.430 GBATA [default FATAL] Got an exception: NETWORK_PASSPHRASE not configured```